### PR TITLE
feat: add_github_comment agent capability

### DIFF
--- a/packages/mcp-server/src/tools/git-tools.ts
+++ b/packages/mcp-server/src/tools/git-tools.ts
@@ -223,4 +223,27 @@ export const gitTools: Tool[] = [
       required: ['projectPath', 'threadId'],
     },
   },
+  {
+    name: 'add_github_comment',
+    description:
+      'Post a comment to an existing GitHub issue. Returns the comment id and confirmation.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        issueNumber: {
+          type: 'number',
+          description: 'GitHub issue number to comment on',
+        },
+        body: {
+          type: 'string',
+          description: 'Comment body (supports markdown)',
+        },
+      },
+      required: ['projectPath', 'issueNumber', 'body'],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

Add an agent capability to post a comment to an EXISTING GitHub issue: add_github_comment(repo, issue_number, body) -> returns comment id/confirmation. Mirror the existing create_github_issue tool pattern (find it in packages/mcp-server tools and the server-side GitHub integration service) and register the new tool so Ava and agents can use it. Add a unit test. Closes #3817.

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-ba689af1 team= created=2026-05-26T20:39:41.326Z -->