### PR TITLE
feat(projects): feed request-changes feedback into PRD regeneration

### DIFF
--- a/apps/server/src/routes/projects/lifecycle/generate-prd.ts
+++ b/apps/server/src/routes/projects/lifecycle/generate-prd.ts
@@ -48,16 +48,33 @@ export function createGeneratePrdHandler(
         return;
       }
 
+      // A regeneration after "request changes" carries reviewer feedback and a
+      // prior PRD. Feed both to the model so it REVISES the existing PRD to
+      // address the feedback instead of starting from scratch (the whole point
+      // of the request-changes loop).
+      const reviewFeedback = project.reviewFeedback?.trim();
+      const priorPrd = project.prd;
+      const PRD_SECTIONS = ['situation', 'problem', 'approach', 'results', 'constraints'] as const;
+
       // Build context from project data
       const contextParts = [
         `**Project:** ${project.title}`,
         project.goal ? `**Goal:** ${project.goal}` : '',
         project.description ? `**Description:** ${project.description}` : '',
         project.researchSummary ? `**Research Summary:**\n${project.researchSummary}` : '',
+        priorPrd
+          ? `**Existing PRD (revise this — do not discard what still holds):**\n${PRD_SECTIONS.map(
+              (k) => `### ${k}\n${priorPrd[k] || ''}`
+            ).join('\n\n')}`
+          : '',
+        reviewFeedback ? `**Requested changes to address:**\n${reviewFeedback}` : '',
         additionalContext ? `**Additional Context:**\n${additionalContext}` : '',
       ].filter(Boolean);
 
-      const prompt = `Generate a SPARC PRD for this project. Respond with ONLY a JSON object.\n\n${contextParts.join('\n\n')}`;
+      const instruction = reviewFeedback
+        ? 'Revise the SPARC PRD below to address the requested changes, preserving sections that are still correct.'
+        : 'Generate a SPARC PRD for this project.';
+      const prompt = `${instruction} Respond with ONLY a JSON object.\n\n${contextParts.join('\n\n')}`;
 
       // Update status to drafting
       await projectService.updateProject(projectPath, projectSlug, { status: 'drafting' });
@@ -94,7 +111,8 @@ export function createGeneratePrdHandler(
         return;
       }
 
-      // Save PRD to project
+      // Save PRD to project. Clear reviewFeedback now that it's been folded into
+      // this revision, so it isn't re-applied to a future unrelated regeneration.
       await projectService.updateProject(projectPath, projectSlug, {
         prd: {
           situation: prd.situation || '',
@@ -105,6 +123,7 @@ export function createGeneratePrdHandler(
           generatedAt: new Date().toISOString(),
         },
         status: 'reviewing',
+        ...(reviewFeedback ? { reviewFeedback: '' } : {}),
       });
 
       res.json({ success: true, prd });

--- a/apps/server/tests/unit/routes/projects/generate-prd.test.ts
+++ b/apps/server/tests/unit/routes/projects/generate-prd.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the generate-prd handler's request-changes feedback loop (#85).
+ *
+ * Verifies that a PRD regeneration after "request changes" folds the stored
+ * reviewFeedback (and the prior PRD) into the prompt and clears the feedback
+ * once consumed — and that a fresh generation does neither.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+import { createGeneratePrdHandler } from '@/routes/projects/lifecycle/generate-prd.js';
+
+vi.mock('@protolabsai/model-resolver', () => ({
+  resolveModelString: vi.fn(() => 'claude-sonnet-4-5'),
+}));
+
+vi.mock('@/providers/simple-query-service.js', () => ({
+  streamingQuery: vi.fn(),
+}));
+
+import { streamingQuery } from '@/providers/simple-query-service.js';
+
+const VALID_PRD_JSON = JSON.stringify({
+  situation: 's',
+  problem: 'p',
+  approach: 'a',
+  results: 'r',
+  constraints: 'c',
+});
+
+function makeRes() {
+  const res: Partial<Response> & { statusCode: number; body: unknown } = {
+    statusCode: 200,
+    body: undefined,
+  };
+  res.status = vi.fn((c: number) => {
+    res.statusCode = c;
+    return res as Response;
+  }) as unknown as Response['status'];
+  res.json = vi.fn((b: unknown) => {
+    res.body = b;
+    return res as Response;
+  }) as unknown as Response['json'];
+  return res;
+}
+
+function lastPrompt(): string {
+  return (vi.mocked(streamingQuery).mock.calls[0][0] as { prompt: string }).prompt;
+}
+
+describe('generate-prd handler — request-changes feedback loop (#85)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(streamingQuery).mockResolvedValue({ text: VALID_PRD_JSON } as Awaited<
+      ReturnType<typeof streamingQuery>
+    >);
+  });
+
+  it('folds stored reviewFeedback + prior PRD into the prompt and clears feedback after', async () => {
+    const project = {
+      title: 'T',
+      goal: 'G',
+      reviewFeedback: 'Make the approach simpler and cheaper',
+      prd: {
+        situation: 'old-sit',
+        problem: 'old-prob',
+        approach: 'old-approach-text',
+        results: 'old-res',
+        constraints: 'old-con',
+      },
+    };
+    const updateProject = vi.fn().mockResolvedValue(project);
+    const projectService = {
+      getProject: vi.fn().mockResolvedValue(project),
+      updateProject,
+    } as unknown as Parameters<typeof createGeneratePrdHandler>[1];
+
+    const handler = createGeneratePrdHandler(
+      {} as Parameters<typeof createGeneratePrdHandler>[0],
+      projectService
+    );
+    const res = makeRes();
+    await handler({ body: { projectPath: '/p', projectSlug: 's' } } as Request, res as Response);
+
+    const prompt = lastPrompt();
+    expect(prompt).toContain('Make the approach simpler and cheaper');
+    expect(prompt).toContain('Revise the SPARC PRD');
+    expect(prompt).toContain('old-approach-text'); // prior PRD carried in for revision
+
+    const saveCall = updateProject.mock.calls.find((c) => (c[2] as { prd?: unknown })?.prd);
+    expect(saveCall).toBeDefined();
+    expect((saveCall![2] as { reviewFeedback?: string }).reviewFeedback).toBe('');
+    expect((res.body as { success: boolean }).success).toBe(true);
+  });
+
+  it('does not add a revise instruction or clear feedback on a fresh generation', async () => {
+    const project = { title: 'T', goal: 'G' };
+    const updateProject = vi.fn().mockResolvedValue(project);
+    const projectService = {
+      getProject: vi.fn().mockResolvedValue(project),
+      updateProject,
+    } as unknown as Parameters<typeof createGeneratePrdHandler>[1];
+
+    const handler = createGeneratePrdHandler(
+      {} as Parameters<typeof createGeneratePrdHandler>[0],
+      projectService
+    );
+    const res = makeRes();
+    await handler({ body: { projectPath: '/p', projectSlug: 's' } } as Request, res as Response);
+
+    const prompt = lastPrompt();
+    expect(prompt).toContain('Generate a SPARC PRD');
+    expect(prompt).not.toContain('Revise the SPARC PRD');
+
+    const saveCall = updateProject.mock.calls.find((c) => (c[2] as { prd?: unknown })?.prd);
+    expect(saveCall).toBeDefined();
+    expect(saveCall![2]).not.toHaveProperty('reviewFeedback');
+  });
+});


### PR DESCRIPTION
Project design-flow improvement (#85 from the audit). Closes the "request-changes feedback is dropped" gap.

## Problem

`request-changes` stores `reviewFeedback` on the project and resets status to `reviewing`, but `generate-prd` never read it. So the **request changes → regenerate** loop silently dropped the reviewer's notes unless the user manually retyped them into `additionalContext`.

## Fix

`generate-prd` now:
- Folds the stored `reviewFeedback` **and** the prior PRD into the prompt, with a *revise-in-place* instruction ("preserve sections that are still correct") so regeneration actually addresses the feedback instead of starting from scratch.
- Clears `reviewFeedback` once it's been consumed, so it doesn't bleed into a later unrelated regeneration.
- Leaves fresh generations (no feedback, no prior PRD) unchanged.

## Tests

New unit test for the handler: the feedback path (prompt contains the feedback + revise instruction + prior PRD; feedback cleared on save) and the fresh-generation path (no revise instruction; feedback key absent). `tsc` + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PRD regeneration now supports incorporating reviewer feedback from previous iterations, enabling iterative refinement of product requirements.

* **Improvements**
  * Enhanced feedback lifecycle management to ensure reviewer comments are applied correctly during regeneration and properly cleared afterwards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->