### PR TITLE
fix(git-workflow): enforce lockfile sync on manifest change

### DIFF
--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -274,6 +274,10 @@ export class GitWorkflowService {
         featureOverride.skipGitHooks ??
         global.skipGitHooks ??
         DEFAULT_GIT_WORKFLOW_SETTINGS.skipGitHooks,
+      syncLockfileOnManifestChange:
+        featureOverride.syncLockfileOnManifestChange ??
+        global.syncLockfileOnManifestChange ??
+        DEFAULT_GIT_WORKFLOW_SETTINGS.syncLockfileOnManifestChange,
     };
   }
 
@@ -473,7 +477,8 @@ export class GitWorkflowService {
         feature,
         projectPath,
         gitSettings.excludeFromStaging,
-        skipHooks
+        skipHooks,
+        gitSettings.syncLockfileOnManifestChange
       );
 
       if (!commitHash) {
@@ -1128,7 +1133,8 @@ export class GitWorkflowService {
     feature: Feature,
     projectPath: string,
     excludeFromStaging?: string[],
-    skipGitHooks = true
+    skipGitHooks = true,
+    syncLockfileOnManifestChange = true
   ): Promise<string | null> {
     // Check for changes - include untracked files explicitly
     const { stdout: status } = await execAsync('git status --porcelain --untracked-files=all', {
@@ -1151,6 +1157,20 @@ export class GitWorkflowService {
       cwd: workDir,
       env: execEnv,
     });
+
+    // Sync lockfile if any package.json manifest changed in the staged diff.
+    if (syncLockfileOnManifestChange) {
+      try {
+        const manifestChanged = await this.hasManifestChange(workDir);
+        if (manifestChanged) {
+          await this.syncAndStageLockfile(workDir, projectPath);
+        }
+      } catch (lockfileError) {
+        logger.warn(
+          `Lockfile sync failed (non-fatal): ${lockfileError instanceof Error ? lockfileError.message : String(lockfileError)}`
+        );
+      }
+    }
 
     // Auto-format staged files before committing (matches CI prettier behavior)
     try {
@@ -1292,6 +1312,53 @@ export class GitWorkflowService {
     logger.info(
       `Auto-generated changeset ${id} for ${touchedPackages.size} package(s): ${[...touchedPackages].join(', ')}`
     );
+  }
+
+  /**
+   * Check if any package.json manifest is present in the currently staged files.
+   * Returns true if the staged diff contains at least one `package.json` file
+   * (root or workspace-level).
+   */
+  private async hasManifestChange(workDir: string): Promise<boolean> {
+    try {
+      const { stdout } = await execAsync(
+        "git diff --cached --name-only --diff-filter=ACMR -- 'package.json' '**/package.json'",
+        { cwd: workDir, env: execEnv }
+      );
+      return stdout.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Regenerate the lockfile from the repo root and stage the result.
+   * Runs `npm install --package-lock-only --ignore-scripts` from the project root
+   * (NOT from a temp directory — that corrupts workspace paths).
+   */
+  private async syncAndStageLockfile(workDir: string, projectPath: string): Promise<void> {
+    logger.info(`Regenerating lockfile from repo root (${projectPath})`);
+    await execAsync('npm install --package-lock-only --ignore-scripts', {
+      cwd: projectPath,
+      env: execEnv,
+      timeout: 120_000,
+    });
+
+    // Stage the updated lockfile(s) — run from workDir so git paths are relative to the worktree.
+    // package-lock.json lives at the repo root; workspace locks live at workspace roots.
+    await execAsync(`git add package-lock.json`, { cwd: workDir, env: execEnv }).catch(() => {
+      // package-lock.json may not exist (e.g. yarn/pnpm projects) — non-fatal
+    });
+
+    // Also stage any workspace-level lockfiles that changed
+    await execAsync("git add -- '*.lock' '*.lock.json' 'pnpm-lock.yaml' 'yarn.lock'", {
+      cwd: workDir,
+      env: execEnv,
+    }).catch(() => {
+      // No other lockfiles — non-fatal
+    });
+
+    logger.info(`Lockfile synced and staged`);
   }
 
   /**

--- a/apps/server/tests/unit/services/git-workflow-lockfile-sync.test.ts
+++ b/apps/server/tests/unit/services/git-workflow-lockfile-sync.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for lockfile-sync enforcement in GitWorkflowService.commitChanges().
+ *
+ * Covers:
+ * - No-op when no package.json manifest changed
+ * - Sync + stage when manifest changed
+ * - Gate off when syncLockfileOnManifestChange is false
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ─── Module mocks (hoisted) ──────────────────────────────────────────────────
+
+vi.mock('child_process', () => {
+  const exec = vi.fn();
+  const execFile = vi.fn();
+  return { exec, execFile };
+});
+
+vi.mock('@/lib/worktree-metadata.js', () => ({
+  updateWorktreePRInfo: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/routes/github/utils/pr-ownership.js', () => ({
+  buildPROwnershipWatermark: vi.fn().mockReturnValue('<!-- watermark -->'),
+}));
+
+vi.mock('@/lib/git-staging-utils.js', () => ({
+  buildGitAddCommand: vi.fn().mockReturnValue('git add -A'),
+}));
+
+vi.mock('@/services/github-merge-service.js', () => ({
+  githubMergeService: { checkPRStatus: vi.fn() },
+}));
+
+vi.mock('@/services/coderabbit-resolver-service.js', () => ({
+  codeRabbitResolverService: { resolveThreads: vi.fn() },
+}));
+
+vi.mock('@protolabsai/git-utils', async () => {
+  const actual =
+    await vi.importActual<typeof import('@protolabsai/git-utils')>('@protolabsai/git-utils');
+  return {
+    ...actual,
+    createGitExecEnv: vi.fn().mockReturnValue({}),
+    extractTitleFromDescription: vi.fn().mockReturnValue('Test Feature'),
+  };
+});
+
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual('@protolabsai/utils');
+  const mockLogger = {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  };
+  return { ...actual, createLogger: () => mockLogger };
+});
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+import { exec, execFile } from 'child_process';
+import type { Feature } from '@protolabsai/types';
+
+type ExecResultCallback = (err: Error | null, result?: { stdout: string; stderr: string }) => void;
+
+function makeExecQueue(
+  responses: Array<{ stdout: string } | { error: Error }>
+): ReturnType<typeof vi.fn> {
+  let idx = 0;
+  return vi.fn((_cmd: string, _optsOrCb: unknown, maybeCb?: unknown) => {
+    const cb: ExecResultCallback =
+      typeof _optsOrCb === 'function'
+        ? (_optsOrCb as ExecResultCallback)
+        : (maybeCb as ExecResultCallback);
+    const response = responses[idx++];
+    if (!response) {
+      throw new Error(
+        `makeExecQueue: unexpected exec call #${idx} (only ${responses.length} responses provided). Command: ${_cmd}`
+      );
+    }
+    if ('error' in response) {
+      cb(response.error);
+    } else {
+      cb(null, { stdout: response.stdout, stderr: '' });
+    }
+    return {} as ReturnType<typeof exec>;
+  });
+}
+
+const FAKE_FEATURE: Feature = {
+  id: 'feat-lockfile-sync',
+  title: 'Test Lockfile Sync Feature',
+  description: 'Tests lockfile sync enforcement',
+  status: 'in_progress',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+const WORK_DIR = '/project/.worktrees/feat-lockfile-sync';
+const PROJECT_PATH = '/project';
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('GitWorkflowService – lockfile sync on manifest change', () => {
+  let service: { commitChanges: (...args: unknown[]) => Promise<string | null> };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Bypass retry delays so tests run fast
+    vi.spyOn(global, 'setTimeout').mockImplementation((fn: TimerHandler) => {
+      if (typeof fn === 'function') fn();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+
+    const mod = await import('@/services/git-workflow-service.js');
+    const { GitWorkflowService } = mod as unknown as {
+      GitWorkflowService: new () => typeof service;
+    };
+    service = new GitWorkflowService();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is a no-op when no package.json manifest changed', async () => {
+    // git status (has changes), git add, hasManifestChange (no package.json),
+    // git diff --cached (no formattable files), generateChangeset (no staged libs/),
+    // git commit (execFile), git rev-parse HEAD
+    vi.mocked(exec).mockImplementation(
+      makeExecQueue([
+        { stdout: ' M someFile.ts\n' }, // git status --porcelain
+        { stdout: '' }, // git add -A
+        { stdout: '' }, // hasManifestChange: no package.json in staged
+        { stdout: '' }, // git diff --cached (no formattable files)
+        { stdout: 'someFile.ts\n' }, // generateChangeset: staged files (no libs/ touched)
+        { stdout: 'abc12345\n' }, // git rev-parse HEAD
+      ]) as ReturnType<typeof exec>
+    );
+    vi.mocked(execFile).mockImplementation(
+      vi.fn((_file: string, _args: string[], _optsOrCb: unknown, maybeCb?: unknown) => {
+        const cb: ExecResultCallback =
+          typeof _optsOrCb === 'function' ? _optsOrCb : (maybeCb as ExecResultCallback);
+        cb(null, { stdout: '', stderr: '' });
+        return {} as ReturnType<typeof execFile>;
+      }) as ReturnType<typeof execFile>
+    );
+
+    const result = await service.commitChanges(
+      WORK_DIR,
+      FAKE_FEATURE,
+      PROJECT_PATH,
+      undefined,
+      true,
+      true
+    );
+
+    expect(result).toBe('abc12345');
+
+    // Verify npm install was NOT called
+    const execCalls = vi.mocked(exec).mock.calls;
+    const npmInstallCalled = execCalls.some(
+      (call) => typeof call[0] === 'string' && call[0].includes('npm install')
+    );
+    expect(npmInstallCalled).toBe(false);
+  });
+
+  it('syncs and stages lockfile when package.json changed', async () => {
+    // git status, git add, hasManifestChange (package.json found),
+    // npm install (exec), git add package-lock.json, git add -- '*.lock' ...,
+    // git diff --cached (no formattable files), generateChangeset (no staged libs/),
+    // git rev-parse HEAD
+    vi.mocked(exec).mockImplementation(
+      makeExecQueue([
+        { stdout: ' M package.json\n M src/index.ts\n' }, // git status
+        { stdout: '' }, // git add -A
+        { stdout: 'package.json\n' }, // hasManifestChange: package.json is staged
+        { stdout: '' }, // npm install --package-lock-only --ignore-scripts
+        { stdout: '' }, // git add package-lock.json
+        { error: new Error('nothing to stage') }, // git add -- '*.lock' ... (no other locks)
+        { stdout: '' }, // git diff --cached (no formattable files)
+        { stdout: 'package.json\nsrc/index.ts\n' }, // generateChangeset staged files
+        { stdout: 'def67890\n' }, // git rev-parse HEAD
+      ]) as ReturnType<typeof exec>
+    );
+    vi.mocked(execFile).mockImplementation(
+      vi.fn((_file: string, _args: string[], _optsOrCb: unknown, maybeCb?: unknown) => {
+        const cb: ExecResultCallback =
+          typeof _optsOrCb === 'function' ? _optsOrCb : (maybeCb as ExecResultCallback);
+        cb(null, { stdout: '', stderr: '' });
+        return {} as ReturnType<typeof execFile>;
+      }) as ReturnType<typeof execFile>
+    );
+
+    const result = await service.commitChanges(
+      WORK_DIR,
+      FAKE_FEATURE,
+      PROJECT_PATH,
+      undefined,
+      true,
+      true
+    );
+
+    expect(result).toBe('def67890');
+
+    // Verify npm install WAS called
+    const execCalls = vi.mocked(exec).mock.calls;
+    const npmInstallCalled = execCalls.some(
+      (call) => typeof call[0] === 'string' && call[0].includes('npm install')
+    );
+    expect(npmInstallCalled).toBe(true);
+
+    // Verify it ran from projectPath (repo root), not workDir
+    const npmInstallCall = execCalls.find(
+      (call) => typeof call[0] === 'string' && call[0].includes('npm install')
+    );
+    expect(npmInstallCall).toBeDefined();
+    const npmOpts = npmInstallCall![1] as { cwd?: string };
+    expect(npmOpts.cwd).toBe(PROJECT_PATH);
+  });
+
+  it('skips lockfile sync when syncLockfileOnManifestChange is false', async () => {
+    // git status, git add, git diff --cached, generateChangeset, git rev-parse HEAD
+    vi.mocked(exec).mockImplementation(
+      makeExecQueue([
+        { stdout: ' M package.json\n' }, // git status
+        { stdout: '' }, // git add -A
+        { stdout: '' }, // git diff --cached (no formattable files)
+        { stdout: 'package.json\n' }, // generateChangeset staged files
+        { stdout: 'abc12345\n' }, // git rev-parse HEAD
+      ]) as ReturnType<typeof exec>
+    );
+    vi.mocked(execFile).mockImplementation(
+      vi.fn((_file: string, _args: string[], _optsOrCb: unknown, maybeCb?: unknown) => {
+        const cb: ExecResultCallback =
+          typeof _optsOrCb === 'function' ? _optsOrCb : (maybeCb as ExecResultCallback);
+        cb(null, { stdout: '', stderr: '' });
+        return {} as ReturnType<typeof execFile>;
+      }) as ReturnType<typeof execFile>
+    );
+
+    const result = await service.commitChanges(
+      WORK_DIR,
+      FAKE_FEATURE,
+      PROJECT_PATH,
+      undefined,
+      true,
+      false // syncLockfileOnManifestChange = false
+    );
+
+    expect(result).toBe('abc12345');
+
+    // Verify npm install was NOT called
+    const execCalls = vi.mocked(exec).mock.calls;
+    const npmInstallCalled = execCalls.some(
+      (call) => typeof call[0] === 'string' && call[0].includes('npm install')
+    );
+    expect(npmInstallCalled).toBe(false);
+  });
+});

--- a/libs/types/src/git-settings.ts
+++ b/libs/types/src/git-settings.ts
@@ -72,6 +72,14 @@ export interface GitWorkflowSettings {
    * Default: true
    */
   skipGitHooks?: boolean;
+  /**
+   * Automatically regenerate and stage lockfiles when a package.json manifest
+   * (root or workspace) changes. Runs `npm install --package-lock-only --ignore-scripts`
+   * from the repo root to produce a consistent lockfile, then stages the updated
+   * lockfile alongside the feature changes.
+   * Default: true
+   */
+  syncLockfileOnManifestChange?: boolean;
 }
 
 /**
@@ -90,6 +98,7 @@ export const DEFAULT_GIT_WORKFLOW_SETTINGS: Required<GitWorkflowSettings> = {
   excludeFromStaging: [],
   softChecks: [],
   skipGitHooks: true,
+  syncLockfileOnManifestChange: true,
 };
 
 /**


### PR DESCRIPTION
## Summary

Implement lockfile-sync enforcement in apps/server/src/services/git-workflow-service.ts at the stage where a feature's work is staged/committed. (1) Detect if the diff touches any package.json (root or workspace manifest); if none, no-op (key differentiator). (2) If a manifest changed, run 'npm install --package-lock-only --ignore-scripts' from the repo ROOT (NOT via --prefix tempdir — that corrupts workspace paths, see closed #3808). (3) Stage the updated package-lock.json (and workspace locks)...

Closes #3808

---
*Created automatically by Automaker*

<!-- automaker:owner instance=transient-53095e35 team= created=2026-05-26T20:42:26.707Z -->