### PR TITLE
feat(projects): agent-driven PRD review gate (#86)

### DIFF
--- a/apps/server/src/routes/projects/lifecycle/index.ts
+++ b/apps/server/src/routes/projects/lifecycle/index.ts
@@ -12,6 +12,7 @@ import type { ProjectService } from '../../../services/project-service.js';
 import { createInitiateHandler } from './initiate.js';
 import { createApprovePrdHandler } from './approve-prd.js';
 import { createGeneratePrdHandler } from './generate-prd.js';
+import { createReviewPrdHandler } from './review-prd.js';
 import { createLaunchHandler } from './launch.js';
 import { createStatusHandler } from './status.js';
 import { createRequestChangesHandler } from './request-changes.js';
@@ -71,6 +72,13 @@ export function createLifecycleRoutes(
     validatePathParams('projectPath'),
     validateSlugs('projectSlug'),
     createGeneratePrdHandler(lifecycleService, projectService)
+  );
+
+  router.post(
+    '/review-prd',
+    validatePathParams('projectPath'),
+    validateSlugs('projectSlug'),
+    createReviewPrdHandler(projectService, events)
   );
 
   return router;

--- a/apps/server/src/routes/projects/lifecycle/review-prd.ts
+++ b/apps/server/src/routes/projects/lifecycle/review-prd.ts
@@ -1,0 +1,166 @@
+/**
+ * POST /lifecycle/review-prd - Agent-driven quality review of a project's PRD.
+ *
+ * Closes the "no real review gate" gap: previously `reviewing -> approved` was a
+ * bare UI button with no agent evaluation. This runs a critic agent over the
+ * SPARC PRD and produces a structured verdict.
+ *
+ * Synergy with the rest of the flow:
+ *   - PASS  -> status 'approved' (the reserved state from the lifecycle model),
+ *              reviewFeedback cleared. The project is ready to scaffold.
+ *   - FAIL  -> status stays 'reviewing', the actionable issues are stored as
+ *              reviewFeedback so the next generate-prd revision addresses them.
+ *
+ * This is an available gate, not a hard block on approve-prd — the UI / operator
+ * decides whether to require a passing review before scaffolding.
+ */
+
+import type { Request, Response } from 'express';
+import type { ProjectService } from '../../../services/project-service.js';
+import type { EventEmitter } from '../../../lib/events.js';
+import { resolveModelString } from '@protolabsai/model-resolver';
+import { streamingQuery } from '../../../providers/simple-query-service.js';
+import { getErrorMessage, logError } from '../common.js';
+
+const REVIEW_MODEL = resolveModelString('sonnet');
+
+/** Score at/above which a PRD passes review when the model doesn't say otherwise. */
+const PASS_THRESHOLD = 75;
+
+const REVIEW_SYSTEM_PROMPT = `You are a senior staff engineer doing a critical review of a SPARC PRD before any engineering work begins. Be rigorous and skeptical — your job is to catch weak plans early, not to rubber-stamp.
+
+Evaluate the PRD against these criteria:
+- Situation: grounded in real context, not generic boilerplate
+- Problem: a sharp, specific problem statement (not a solution in disguise)
+- Approach: concrete and feasible; names real components/steps, not hand-waving
+- Results: measurable, verifiable success criteria
+- Constraints: explicit constraints AND non-goals (scope boundaries)
+
+You MUST respond with ONLY a valid JSON object — no markdown, no code fences, no preamble:
+
+{
+  "passed": true,
+  "score": 0,
+  "issues": ["each issue is a specific, actionable fix the author should make"],
+  "summary": "one-paragraph verdict"
+}
+
+Rules:
+- "score" is 0-100 (overall PRD quality).
+- "passed" is true only if the PRD is genuinely ready for implementation. A score below ${PASS_THRESHOLD}, or any critical gap (missing measurable results, infeasible approach, no non-goals), means passed=false.
+- "issues" must be empty when passed=true, and non-empty and actionable when passed=false.`;
+
+export function createReviewPrdHandler(projectService: ProjectService, events?: EventEmitter) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, projectSlug } = req.body as {
+        projectPath: string;
+        projectSlug: string;
+      };
+
+      if (!projectPath || !projectSlug) {
+        res.status(400).json({ success: false, error: 'projectPath and projectSlug are required' });
+        return;
+      }
+
+      const project = await projectService.getProject(projectPath, projectSlug);
+      if (!project) {
+        res.status(404).json({ success: false, error: `Project "${projectSlug}" not found` });
+        return;
+      }
+
+      if (!project.prd) {
+        res
+          .status(400)
+          .json({ success: false, error: 'Project has no PRD. Generate one before reviewing.' });
+        return;
+      }
+
+      const prd = project.prd;
+      const prompt = `Review this SPARC PRD. Respond with ONLY a JSON object.
+
+**Project:** ${project.title}
+${project.goal ? `**Goal:** ${project.goal}` : ''}
+
+### situation
+${prd.situation || ''}
+
+### problem
+${prd.problem || ''}
+
+### approach
+${prd.approach || ''}
+
+### results
+${prd.results || ''}
+
+### constraints
+${prd.constraints || ''}`;
+
+      const result = await streamingQuery({
+        prompt,
+        systemPrompt: REVIEW_SYSTEM_PROMPT,
+        model: REVIEW_MODEL,
+        cwd: projectPath,
+        maxTurns: 1,
+        traceContext: { projectSlug, phase: 'prd-review', agentRole: 'prd-reviewer' },
+      });
+
+      const text = result.text || '';
+      let review: { passed: boolean; score: number; issues: string[]; summary: string };
+      try {
+        const jsonMatch = text.match(/\{[\s\S]*\}/);
+        if (!jsonMatch) throw new Error('No JSON object found in response');
+        const parsed = JSON.parse(jsonMatch[0]) as Partial<typeof review>;
+        review = {
+          passed: Boolean(parsed.passed),
+          score: typeof parsed.score === 'number' ? parsed.score : 0,
+          issues: Array.isArray(parsed.issues)
+            ? parsed.issues.filter((i) => typeof i === 'string')
+            : [],
+          summary: typeof parsed.summary === 'string' ? parsed.summary : '',
+        };
+      } catch {
+        res.status(500).json({
+          success: false,
+          error: 'Failed to parse PRD review from AI response',
+          rawText: text.slice(0, 2000),
+        });
+        return;
+      }
+
+      // Belt-and-suspenders: a sub-threshold score never counts as a pass even
+      // if the model said so.
+      const passed = review.passed && review.score >= PASS_THRESHOLD;
+
+      if (passed) {
+        // Ready to scaffold. Record the verdict and clear any prior feedback.
+        await projectService.updateProject(projectPath, projectSlug, {
+          status: 'approved',
+          reviewFeedback: '',
+        });
+      } else {
+        // Feed the actionable issues back into the regeneration loop.
+        const feedback =
+          review.issues.length > 0 ? review.issues.map((i) => `- ${i}`).join('\n') : review.summary;
+        await projectService.updateProject(projectPath, projectSlug, {
+          status: 'reviewing',
+          reviewFeedback: feedback,
+        });
+      }
+
+      events?.emit('project:prd:reviewed', {
+        projectPath,
+        projectSlug,
+        passed,
+        score: review.score,
+        issueCount: review.issues.length,
+      });
+
+      res.json({ success: true, review: { ...review, passed } });
+    } catch (error) {
+      logError(error, 'Review PRD failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/tests/unit/routes/projects/review-prd.test.ts
+++ b/apps/server/tests/unit/routes/projects/review-prd.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the review-prd handler (#86 — agent-driven PRD review gate).
+ *
+ * Verifies the verdict wiring:
+ *   - PASS -> status 'approved', reviewFeedback cleared
+ *   - FAIL -> status 'reviewing', issues stored as reviewFeedback (feeds the
+ *             generate-prd regeneration loop)
+ *   - a sub-threshold score never counts as a pass even if the model says so
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+import { createReviewPrdHandler } from '@/routes/projects/lifecycle/review-prd.js';
+
+vi.mock('@protolabsai/model-resolver', () => ({
+  resolveModelString: vi.fn(() => 'claude-sonnet-4-5'),
+}));
+
+vi.mock('@/providers/simple-query-service.js', () => ({
+  streamingQuery: vi.fn(),
+}));
+
+import { streamingQuery } from '@/providers/simple-query-service.js';
+
+const PRD = {
+  situation: 's',
+  problem: 'p',
+  approach: 'a',
+  results: 'r',
+  constraints: 'c',
+};
+
+function makeRes() {
+  const res: Partial<Response> & { statusCode: number; body: unknown } = {
+    statusCode: 200,
+    body: undefined,
+  };
+  res.status = vi.fn((c: number) => {
+    res.statusCode = c;
+    return res as Response;
+  }) as unknown as Response['status'];
+  res.json = vi.fn((b: unknown) => {
+    res.body = b;
+    return res as Response;
+  }) as unknown as Response['json'];
+  return res;
+}
+
+function setup(verdict: unknown, project: Record<string, unknown> = { title: 'T', prd: PRD }) {
+  vi.mocked(streamingQuery).mockResolvedValue({ text: JSON.stringify(verdict) } as Awaited<
+    ReturnType<typeof streamingQuery>
+  >);
+  const updateProject = vi.fn().mockResolvedValue(project);
+  const events = { emit: vi.fn() };
+  const projectService = {
+    getProject: vi.fn().mockResolvedValue(project),
+    updateProject,
+  } as unknown as Parameters<typeof createReviewPrdHandler>[0];
+  const handler = createReviewPrdHandler(
+    projectService,
+    events as unknown as Parameters<typeof createReviewPrdHandler>[1]
+  );
+  return { handler, updateProject, events };
+}
+
+describe('review-prd handler (#86)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("PASS -> status 'approved' and clears reviewFeedback", async () => {
+    const { handler, updateProject, events } = setup({
+      passed: true,
+      score: 90,
+      issues: [],
+      summary: 'Solid plan.',
+    });
+    const res = makeRes();
+    await handler({ body: { projectPath: '/p', projectSlug: 's' } } as Request, res as Response);
+
+    expect(updateProject).toHaveBeenCalledWith('/p', 's', {
+      status: 'approved',
+      reviewFeedback: '',
+    });
+    expect((res.body as { review: { passed: boolean } }).review.passed).toBe(true);
+    expect(events.emit).toHaveBeenCalledWith(
+      'project:prd:reviewed',
+      expect.objectContaining({ passed: true, score: 90 })
+    );
+  });
+
+  it("FAIL -> status 'reviewing' and stores issues as reviewFeedback", async () => {
+    const { handler, updateProject } = setup({
+      passed: false,
+      score: 40,
+      issues: ['No measurable results', 'Approach is hand-wavy'],
+      summary: 'Needs work.',
+    });
+    const res = makeRes();
+    await handler({ body: { projectPath: '/p', projectSlug: 's' } } as Request, res as Response);
+
+    const call = updateProject.mock.calls[0];
+    expect(call[2]).toMatchObject({ status: 'reviewing' });
+    expect((call[2] as { reviewFeedback: string }).reviewFeedback).toContain(
+      'No measurable results'
+    );
+    expect((call[2] as { reviewFeedback: string }).reviewFeedback).toContain(
+      'Approach is hand-wavy'
+    );
+  });
+
+  it('treats a sub-threshold score as NOT passed even if the model claims passed', async () => {
+    const { handler, updateProject } = setup({
+      passed: true,
+      score: 60, // below PASS_THRESHOLD
+      issues: ['Thin on constraints'],
+      summary: 'Borderline.',
+    });
+    const res = makeRes();
+    await handler({ body: { projectPath: '/p', projectSlug: 's' } } as Request, res as Response);
+
+    expect(updateProject.mock.calls[0][2]).toMatchObject({ status: 'reviewing' });
+    expect((res.body as { review: { passed: boolean } }).review.passed).toBe(false);
+  });
+
+  it('returns 400 when the project has no PRD', async () => {
+    const { handler } = setup({ passed: true, score: 90, issues: [], summary: '' }, { title: 'T' });
+    const res = makeRes();
+    await handler({ body: { projectPath: '/p', projectSlug: 's' } } as Request, res as Response);
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/docs/internal/server/project-service.md
+++ b/docs/internal/server/project-service.md
@@ -113,16 +113,19 @@ Stats are written to `.automaker/projects/stats.json` and used by the dashboard.
 
 `project.status` (`ProjectStatus`) reflects the stage of the design flow and is set at distinct transitions so the lifecycle is observable from `status` alone — no need to cross-reference other fields:
 
-| Status        | Set by                                                     | Means                                        |
-| ------------- | ---------------------------------------------------------- | -------------------------------------------- |
-| `drafting`    | project creation / after research                          | Idea captured, PRD not yet under review      |
-| `researching` | `ProjectLifecycleService.runResearch()` (early-stage only) | Deep research running; reverts to `drafting` |
-| `reviewing`   | `generate-prd`                                             | PRD drafted, awaiting approval               |
-| `scaffolded`  | `approvePrd()` / `orchestrateProjectFeatures()`            | Features created, **not** yet launched       |
-| `active`      | `ProjectLifecycleService.launch()`                         | Auto-mode launched — execution in progress   |
-| `completed`   | completion detection                                       | All work done                                |
+| Status        | Set by                                                     | Means                                          |
+| ------------- | ---------------------------------------------------------- | ---------------------------------------------- |
+| `drafting`    | project creation / after research                          | Idea captured, PRD not yet under review        |
+| `researching` | `ProjectLifecycleService.runResearch()` (early-stage only) | Deep research running; reverts to `drafting`   |
+| `reviewing`   | `generate-prd`                                             | PRD drafted, awaiting review/approval          |
+| `approved`    | `review-prd` (agent review **passed**)                     | PRD passed the quality gate; ready to scaffold |
+| `scaffolded`  | `approvePrd()` / `orchestrateProjectFeatures()`            | Features created, **not** yet launched         |
+| `active`      | `ProjectLifecycleService.launch()`                         | Auto-mode launched — execution in progress     |
+| `completed`   | completion detection                                       | All work done                                  |
 
-Key invariant: **approval lands in `scaffolded`, and only `launch()` sets `active`** — so `active` unambiguously means "running," distinct from "has features but idle." `researching` is only applied when the project is still early (`ongoing`/`drafting`/`reviewing`); re-running research against a `scaffolded`/`active` project does not clobber its status. `approved` remains reserved for a future explicit human-approval gate (approval and scaffolding are currently a single operation).
+Key invariant: **approval lands in `scaffolded`, and only `launch()` sets `active`** — so `active` unambiguously means "running," distinct from "has features but idle." `researching` is only applied when the project is still early (`ongoing`/`drafting`/`reviewing`); re-running research against a `scaffolded`/`active` project does not clobber its status.
+
+`approved` is set by the agent review gate (`POST /lifecycle/review-prd`): a critic agent scores the PRD and, on a pass, advances to `approved` (a fail keeps `reviewing` and stores the actionable issues as `reviewFeedback`, which the next `generate-prd` revision folds in). The gate is available, not mandatory — `approvePrd()` does not require a prior pass, so operators/UI decide whether to require review before scaffolding.
 
 ## Calendar Integration
 

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -173,6 +173,7 @@ export type EventType =
   | 'project:completed'
   | 'project:reflection:complete'
   | 'project:prd:changes-requested'
+  | 'project:prd:reviewed'
   // CoS intake events
   | 'cos:prd-submitted'
   // PR lifecycle events (consumed by Lead Engineer state machine)
@@ -580,6 +581,13 @@ export interface EventPayloadMap {
     projectSlug: string;
     projectPath: string;
     feedback: string;
+  };
+  'project:prd:reviewed': {
+    projectPath: string;
+    projectSlug: string;
+    passed: boolean;
+    score: number;
+    issueCount: number;
   };
   // Lead Engineer events
   'lead-engineer:started': { projectPath: string; projectSlug: string };


### PR DESCRIPTION
Final project design-flow improvement (#86 from the audit). Closes the "no real review gate" gap.

## Problem

`reviewing → approved` was a bare UI button — no agent evaluated PRD quality before features were scaffolded.

## Change

New **`POST /lifecycle/review-prd`** runs a skeptical critic agent over the SPARC PRD and returns a structured verdict `{ passed, score, issues[], summary }`, then wires it into the lifecycle:

- **PASS** → status **`approved`** (finally exercising the reserved state from #84), `reviewFeedback` cleared — ready to scaffold.
- **FAIL** → status stays `reviewing`, the actionable issues are stored as `reviewFeedback` so the next `generate-prd` revision (#85) folds them in. This closes the loop: **review → feedback → regenerate → review**.
- A sub-threshold score (`< 75`) never counts as a pass even if the model claims `passed: true`.
- Emits `project:prd:reviewed` for observability.

It's an **available gate, not a hard block** on `approve-prd` — the UI/operator decides whether to require a passing review before scaffolding (non-breaking).

## Tests

4 unit tests: pass → approved+cleared, fail → reviewing+feedback, sub-threshold override, no-PRD → 400. Adds the event type to `@protolabsai/types`. `tsc` + prettier clean. Documented in the lifecycle status model (`project-service.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)