### PR TITLE
chore(ci): add zizmor + actionlint workflow security linters

### DIFF
--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -1,0 +1,49 @@
+# SECURITY: This workflow is hardened against fork PR attacks. See docs/security/ci-hardening.md
+name: Workflow Security
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+  schedule:
+    # Run weekly on Mondays at 9 AM UTC (security audit)
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint (workflow syntax)
+    runs-on: namespace-profile-protolabs-linux
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check workflow files with actionlint
+        uses: rhysd/actionlint@f7e528ccf59f9c800e034e63bcae6d07052ee4c1 # v2
+
+  zizmor:
+    name: zizmor (security audit)
+    runs-on: namespace-profile-protolabs-linux
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run zizmor
+        uses: pwschenck/zizmor@b1152517984fca5e6f16e5a9a3405a0230f984a2 # v1
+        with:
+          args: '--fail-informational'

--- a/packages/create-protolab/src/phases/analyze.ts
+++ b/packages/create-protolab/src/phases/analyze.ts
@@ -210,16 +210,30 @@ export function analyzeGaps(
           'Add a security audit step to CI that runs package manager audit to detect vulnerable dependencies.',
       });
     }
+    if (!research.ci.hasWorkflowSecurity) {
+      addGap({
+        id: 'ci-workflow-security',
+        category: 'ci',
+        severity: 'recommended',
+        title: 'CI missing workflow security checks',
+        current: 'No GitHub Actions security linting',
+        target: 'zizmor + actionlint in CI',
+        effort: 'small',
+        featureDescription:
+          'Add zizmor (security linter) and actionlint (workflow syntax checker) to CI. These tools catch untrusted-expression script injection, GITHUB_TOKEN over-privilege, and other Actions misconfigurations in .github/workflows/.',
+      });
+    }
     if (
       research.ci.hasBuildCheck &&
       research.ci.hasTestCheck &&
       research.ci.hasFormatCheck &&
-      research.ci.hasSecurityAudit
+      research.ci.hasSecurityAudit &&
+      research.ci.hasWorkflowSecurity
     ) {
       addCompliant({
         category: 'ci',
         title: 'CI pipeline complete',
-        detail: 'Build, test, format, and audit checks present',
+        detail: 'Build, test, format, audit, and workflow security checks present',
       });
     }
   }

--- a/packages/create-protolab/src/phases/ci.ts
+++ b/packages/create-protolab/src/phases/ci.ts
@@ -34,7 +34,13 @@ export async function setupCI(options: CIOptions): Promise<CIResult> {
     filesCreated.push('.github/workflows/');
 
     // 2. Load workflow templates
-    const templateNames = ['build.yml', 'test.yml', 'format-check.yml', 'security-audit.yml'];
+    const templateNames = [
+      'build.yml',
+      'test.yml',
+      'format-check.yml',
+      'security-audit.yml',
+      'workflow-security.yml',
+    ];
 
     // 3. Get package manager specific variables
     const pmVars = getPackageManagerVars(packageManager);

--- a/packages/create-protolab/src/phases/propose.ts
+++ b/packages/create-protolab/src/phases/propose.ts
@@ -33,6 +33,7 @@ const MILESTONE_DEFS: { title: string; gapIds: string[] }[] = [
       'ci-test-check',
       'ci-format-check',
       'ci-security-audit',
+      'ci-workflow-security',
       'branch-protection',
       'prettier',
       'eslint',

--- a/packages/create-protolab/src/phases/research.ts
+++ b/packages/create-protolab/src/phases/research.ts
@@ -352,6 +352,7 @@ export async function researchRepo(projectPath: string): Promise<RepoResearchRes
   let hasTestCheck = false;
   let hasFormatCheck = false;
   let hasSecurityAudit = false;
+  let hasWorkflowSecurity = false;
   for (const wf of workflows) {
     try {
       const content = await fs.readFile(path.join(ghWorkflowDir, wf), 'utf-8');
@@ -363,6 +364,7 @@ export async function researchRepo(projectPath: string): Promise<RepoResearchRes
       if (lower.includes('prettier') || lower.includes('format')) hasFormatCheck = true;
       if (lower.includes('audit') || lower.includes('security') || lower.includes('snyk'))
         hasSecurityAudit = true;
+      if (lower.includes('zizmor') || lower.includes('actionlint')) hasWorkflowSecurity = true;
     } catch {
       /* ignore */
     }
@@ -403,6 +405,7 @@ export async function researchRepo(projectPath: string): Promise<RepoResearchRes
     hasTestCheck,
     hasFormatCheck,
     hasSecurityAudit,
+    hasWorkflowSecurity,
     hasCodeRabbit,
     hasBranchProtection,
   };

--- a/packages/create-protolab/src/templates/.github/workflows/workflow-security.yml
+++ b/packages/create-protolab/src/templates/.github/workflows/workflow-security.yml
@@ -1,0 +1,36 @@
+name: Workflow Security
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  schedule:
+    - cron: '0 9 * * 1' # Weekly on Monday at 9am UTC
+  workflow_dispatch:
+
+jobs:
+  actionlint:
+    name: actionlint (workflow syntax)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check workflow files with actionlint
+        uses: rhysd/actionlint@v2
+
+  zizmor:
+    name: zizmor (security audit)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run zizmor
+        uses: pwschenck/zizmor@v1
+        with:
+          args: '--fail-informational'

--- a/packages/create-protolab/src/types.ts
+++ b/packages/create-protolab/src/types.ts
@@ -87,6 +87,7 @@ export interface RepoResearchResult {
     hasTestCheck: boolean;
     hasFormatCheck: boolean;
     hasSecurityAudit: boolean;
+    hasWorkflowSecurity: boolean;
     hasCodeRabbit: boolean;
     hasBranchProtection: boolean;
   };


### PR DESCRIPTION
## Summary

Add zizmor (GitHub Actions security linter) and actionlint to protoMaker CI to catch untrusted-expression script injection in run: blocks (e.g. github.event.head_commit.message), GITHUB_TOKEN over-privilege, and other Actions misconfigurations. (1) Add a CI job/step running actionlint + zizmor over .github/workflows. (2) Wire both into the release-tools onboarding template (libs/release-tools / branch-protection defaults) so new managed repos get them automatically. Scope: protoMaker repo + the ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-5f69970d team= created=2026-05-26T20:46:21.860Z -->