### PR TITLE
fix: dedupe triage automation before filing new GitHub issues

### DIFF
--- a/apps/server/src/services/friction-tracker-service.ts
+++ b/apps/server/src/services/friction-tracker-service.ts
@@ -18,6 +18,7 @@
 
 import { createLogger } from '@protolabsai/utils';
 import type { FeatureLoader } from './feature-loader.js';
+import { IssueDedupeService } from './issue-dedupe-service.js';
 
 const logger = createLogger('FrictionTrackerService');
 
@@ -86,6 +87,8 @@ export interface FrictionTrackerDependencies {
   featureLoader: FeatureLoader;
   /** Project path for filing System Improvement features */
   projectPath: string;
+  /** Optional: shared dedupe service for cross-service duplicate detection */
+  issueDedupe?: IssueDedupeService;
 }
 
 // ---------------------------------------------------------------------------
@@ -241,11 +244,39 @@ export class FrictionTrackerService {
       return;
     }
 
-    // Durable dedup: check the feature store for an existing open System Improvement
-    // feature with the same title. In-memory dedup resets on server restart (a known
+    const title = `System Improvement: recurring ${pattern} failures`;
+
+    // Cross-service dedup: check against all open features (not just exact-title matches)
+    if (this.deps.issueDedupe) {
+      const dedupeResult = await this.deps.issueDedupe.check(
+        this.deps.projectPath,
+        title,
+        `friction:${pattern}`
+      );
+
+      if (dedupeResult.isDuplicate) {
+        this.recentFilings.set(pattern, Date.now());
+        logger.info(
+          `Skipping System Improvement filing for pattern="${pattern}" — ` +
+            `duplicate found: ${dedupeResult.match.feature.id} (reason=${dedupeResult.match.reason})`
+        );
+        return;
+      }
+
+      if (dedupeResult.noMatch?.cooldown) {
+        const closedId = dedupeResult.noMatch.closedFeature?.id ?? 'unknown';
+        logger.info(
+          `Skipping System Improvement filing for pattern="${pattern}" — ` +
+            `cooldown active (similar feature ${closedId} recently closed)`
+        );
+        return;
+      }
+    }
+
+    // Legacy durable dedup: check the feature store for an existing open System Improvement
+    // feature with the exact same title. In-memory dedup resets on server restart (a known
     // P1 issue), which previously caused the same pattern to be re-filed after each
     // crash. Using the feature store as the source of truth makes dedup survive restarts.
-    const title = `System Improvement: recurring ${pattern} failures`;
     try {
       const existing = await this.deps.featureLoader.findByTitle(this.deps.projectPath, title);
       if (existing && existing.status !== 'done' && existing.status !== 'interrupted') {

--- a/apps/server/src/services/friction-tracker-service.ts
+++ b/apps/server/src/services/friction-tracker-service.ts
@@ -307,7 +307,11 @@ export class FrictionTrackerService {
         `indicating a systemic issue that warrants investigation and remediation.\n\n` +
         `**Action required:** Investigate the root cause of recurring ${pattern} failures ` +
         `and implement a durable fix to prevent future occurrences.` +
-        contextSection;
+        contextSection +
+        // Fingerprint marker (hidden) so IssueDedupeService can exact-match a re-file
+        // by fingerprint, not just fuzzy title similarity. Mirrors the `friction:${pattern}`
+        // fingerprint passed to issueDedupe.check() above.
+        `\n\n<!-- fp:friction:${pattern} -->`;
 
       const feature = await this.deps.featureLoader.create(this.deps.projectPath, {
         title,

--- a/apps/server/src/services/hitl-pattern-analysis-service.ts
+++ b/apps/server/src/services/hitl-pattern-analysis-service.ts
@@ -395,7 +395,10 @@ export class HitlPatternAnalysisService {
     });
 
     try {
-      const description = this.buildFeatureDescription(signature, latestRecord);
+      // Append a hidden fingerprint marker so IssueDedupeService can exact-match a
+      // re-file by fingerprint (mirrors the `hitl:${signature}` passed to check()).
+      const description =
+        this.buildFeatureDescription(signature, latestRecord) + `\n\n<!-- fp:hitl:${signature} -->`;
       const feature = await this.deps.featureLoader.create(this.deps.projectPath, {
         title,
         description,

--- a/apps/server/src/services/hitl-pattern-analysis-service.ts
+++ b/apps/server/src/services/hitl-pattern-analysis-service.ts
@@ -26,6 +26,7 @@ import { join } from 'node:path';
 import { atomicWriteJson, createLogger } from '@protolabsai/utils';
 import type { FeatureLoader } from './feature-loader.js';
 import type { EventEmitter } from '../lib/events.js';
+import { IssueDedupeService } from './issue-dedupe-service.js';
 
 const logger = createLogger('HitlPatternAnalysisService');
 
@@ -133,6 +134,8 @@ export interface HitlPatternAnalysisDeps {
   /** Project path where backlog features will be filed */
   projectPath: string;
   events: EventEmitter;
+  /** Optional: shared dedupe service for cross-service duplicate detection */
+  issueDedupe?: IssueDedupeService;
 }
 
 // ---------------------------------------------------------------------------
@@ -331,8 +334,40 @@ export class HitlPatternAnalysisService {
       }
     }
 
-    // Durable dedup: check feature store for an open feature with the same title
     const title = buildFeatureTitle(signature);
+
+    // Cross-service dedup: check against all open features (not just exact-title matches)
+    if (this.deps.issueDedupe) {
+      const dedupeResult = await this.deps.issueDedupe.check(
+        this.deps.projectPath,
+        title,
+        `hitl:${signature}`
+      );
+
+      if (dedupeResult.isDuplicate) {
+        this.patterns.set(signature, {
+          ...state,
+          filedFeatureId: dedupeResult.match.feature.id,
+          filedAt: new Date().toISOString(),
+        });
+        logger.info(
+          `Skipping auto-file for pattern="${signature}" — duplicate found: ` +
+            `${dedupeResult.match.feature.id} (reason=${dedupeResult.match.reason})`
+        );
+        return;
+      }
+
+      if (dedupeResult.noMatch?.cooldown) {
+        const closedId = dedupeResult.noMatch.closedFeature?.id ?? 'unknown';
+        logger.info(
+          `Skipping auto-file for pattern="${signature}" — cooldown active ` +
+            `(similar feature ${closedId} recently closed)`
+        );
+        return;
+      }
+    }
+
+    // Legacy durable dedup: check feature store for an open feature with the exact title
     try {
       const existing = await this.deps.featureLoader.findByTitle(this.deps.projectPath, title);
       if (existing && existing.status !== 'done' && existing.status !== 'interrupted') {

--- a/apps/server/src/services/issue-dedupe-service.ts
+++ b/apps/server/src/services/issue-dedupe-service.ts
@@ -188,11 +188,11 @@ export class IssueDedupeService {
   private findFingerprintMatch(features: Feature[], fingerprint: string): Feature | null {
     const fpTag = `fp:${fingerprint}`;
     for (const feature of features) {
-      // Check title for fingerprint marker
+      // The fingerprint marker `fp:{fingerprint}` is embedded in the filed
+      // feature's description (and may also appear in the title).
       if (feature.title?.includes(fpTag)) {
         return feature;
       }
-      // Check description for fingerprint marker
       if (feature.description?.includes(fpTag)) {
         return feature;
       }

--- a/apps/server/src/services/issue-dedupe-service.ts
+++ b/apps/server/src/services/issue-dedupe-service.ts
@@ -1,0 +1,388 @@
+/**
+ * IssueDedupeService — deduplicate automation-filed features against open issues.
+ *
+ * Before the triage/intake automation opens a new feature, check against OPEN
+ * features using title similarity (Jaccard word-set overlap) and fingerprint
+ * matching. If a matching open feature exists, return it so the caller can
+ * skip filing or comment on it instead of creating a duplicate.
+ *
+ * Also enforces a cooldown: if a feature for the same root cause was recently
+ * closed (done/interrupted), suppress re-filing for COOLDOWN_MS to prevent
+ * closed-as-done features from being immediately recreated.
+ */
+
+import { createLogger } from '@protolabsai/utils';
+import type { Feature } from '@protolabsai/types';
+import type { FeatureLoader } from './feature-loader.js';
+
+const logger = createLogger('IssueDedupeService');
+
+/** Minimum Jaccard similarity for title-based match (0.0 – 1.0) */
+const TITLE_SIMILARITY_THRESHOLD = 0.5;
+
+/** Cooldown period after a feature reaches done/interrupted before the same
+ *  root cause can be re-filed. Prevents immediate recreation of closed issues. */
+const COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+/** How long to cache the open-features list (avoids repeated disk reads) */
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Statuses considered "open" for dedup purposes */
+const OPEN_STATUSES = new Set([
+  'backlog',
+  'in_progress',
+  'blocked',
+  'review',
+  'done_pending_merge',
+  'done_pr_open',
+]);
+
+/** Statuses considered "closed" for cooldown purposes */
+const CLOSED_STATUSES = new Set(['done', 'interrupted']);
+
+/** Title prefixes/patterns that mark a feature as automation-filed (self-improvement, triage, etc.) */
+const AUTOMATION_TITLE_PATTERNS = [
+  /^\[Auto\]/i,
+  /^\[Triage\]/i,
+  /^\[TRIAGED\]/i,
+  /^System\s+Improvement:/i,
+  /^auto-remediate:/i,
+];
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Result when a duplicate is found */
+export interface DedupeMatch {
+  /** The existing feature that matches */
+  feature: Feature;
+  /** How the match was determined */
+  reason: 'title_similarity' | 'fingerprint' | 'source_id';
+  /** Similarity score (0.0 – 1.0) for title matches */
+  similarity?: number;
+}
+
+/** Result when no duplicate is found */
+export interface DedupeNoMatch {
+  /** Whether the feature was suppressed due to cooldown */
+  cooldown?: boolean;
+  /** The recently closed feature that triggered cooldown */
+  closedFeature?: Feature;
+}
+
+export type DedupeResult =
+  | { isDuplicate: true; match: DedupeMatch }
+  | { isDuplicate: false; noMatch?: DedupeNoMatch };
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export class IssueDedupeService {
+  /** Cached open features per projectPath */
+  private cache = new Map<string, { features: Feature[]; timestamp: number }>();
+
+  /** Recently closed features per projectPath (for cooldown) */
+  private closedCache = new Map<string, { features: Feature[]; timestamp: number }>();
+
+  constructor(private featureLoader: FeatureLoader) {}
+
+  /**
+   * Check if filing a feature with the given title would be a duplicate.
+   *
+   * @param projectPath - Project to check against
+   * @param title - Title of the feature about to be filed
+   * @param fingerprint - Optional fingerprint (e.g. pattern signature) for exact matching
+   * @param sourceId - Optional source ID (e.g. GitHub issue number) for exact matching
+   * @returns DedupeResult indicating whether a match was found
+   */
+  async check(
+    projectPath: string,
+    title: string,
+    fingerprint?: string,
+    sourceId?: string
+  ): Promise<DedupeResult> {
+    const allFeatures = await this.fetchFeatures(projectPath);
+    const openFeatures = allFeatures.filter((f) => f.status && OPEN_STATUSES.has(f.status));
+    const closedFeatures = allFeatures.filter((f) => f.status && CLOSED_STATUSES.has(f.status));
+
+    // 1. Fingerprint match (exact) — highest confidence
+    if (fingerprint && openFeatures.length > 0) {
+      const fpMatch = this.findFingerprintMatch(openFeatures, fingerprint);
+      if (fpMatch) {
+        logger.info(
+          `Dedupe: fingerprint match for "${title}" → ${fpMatch.id} ("${fpMatch.title}")`
+        );
+        return { isDuplicate: true, match: { feature: fpMatch, reason: 'fingerprint' } };
+      }
+    }
+
+    // 2. Source ID match (exact) — e.g. same GitHub issue number
+    if (sourceId && openFeatures.length > 0) {
+      const srcMatch = this.findSourceIdMatch(openFeatures, sourceId);
+      if (srcMatch) {
+        logger.info(
+          `Dedupe: source_id match for "${title}" → ${srcMatch.id} ("${srcMatch.title}")`
+        );
+        return { isDuplicate: true, match: { feature: srcMatch, reason: 'source_id' } };
+      }
+    }
+
+    // 3. Title similarity (Jaccard word-set overlap)
+    if (openFeatures.length > 0) {
+      const simMatch = this.findTitleSimilarityMatch(openFeatures, title);
+      if (simMatch) {
+        logger.info(
+          `Dedupe: title similarity match for "${title}" → ${simMatch.feature.id} ` +
+            `("${simMatch.feature.title}") score=${(simMatch.similarity ?? 0).toFixed(2)}`
+        );
+        return { isDuplicate: true, match: simMatch };
+      }
+    }
+
+    // 4. Cooldown check — was a similar feature recently closed?
+    if (closedFeatures.length > 0) {
+      const cooldown = this.checkCooldown(closedFeatures, title);
+      if (cooldown) {
+        logger.info(
+          `Dedupe: cooldown active for "${title}" → ${cooldown.closedFeature.id} ` +
+            `("${cooldown.closedFeature.title}")`
+        );
+        return {
+          isDuplicate: false,
+          noMatch: { cooldown: true, closedFeature: cooldown.closedFeature },
+        };
+      }
+    }
+
+    return { isDuplicate: false };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal helpers
+  // ---------------------------------------------------------------------------
+
+  private async fetchFeatures(projectPath: string): Promise<Feature[]> {
+    // Check cache
+    const cached = this.cache.get(projectPath);
+    if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+      return cached.features;
+    }
+
+    try {
+      const features = await this.featureLoader.getAll(projectPath);
+      this.cache.set(projectPath, { features, timestamp: Date.now() });
+      return features;
+    } catch (err) {
+      logger.warn(`Failed to fetch features for dedup (project=${projectPath}):`, err);
+      // Return cached if available, otherwise empty
+      return cached?.features ?? [];
+    }
+  }
+
+  /**
+   * Find an open feature with a matching fingerprint.
+   * Fingerprint is encoded in the title as `fp:{fingerprint}` or in the description.
+   */
+  private findFingerprintMatch(features: Feature[], fingerprint: string): Feature | null {
+    const fpTag = `fp:${fingerprint}`;
+    for (const feature of features) {
+      // Check title for fingerprint marker
+      if (feature.title?.includes(fpTag)) {
+        return feature;
+      }
+      // Check description for fingerprint marker
+      if (feature.description?.includes(fpTag)) {
+        return feature;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Find an open feature with a matching source ID.
+   * Source ID is stored as githubIssueNumber or in channelContext.
+   */
+  private findSourceIdMatch(features: Feature[], sourceId: string): Feature | null {
+    const numId = Number(sourceId);
+    for (const feature of features) {
+      if (feature.githubIssueNumber === numId) {
+        return feature;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Find an open feature with title similarity above the threshold.
+   * Uses Jaccard word-set similarity. Only matches against automation-filed
+   * features (those with automation title patterns) to avoid false positives with user
+   * features that happen to share words.
+   */
+  private findTitleSimilarityMatch(features: Feature[], title: string): DedupeMatch | null {
+    const incomingWords = titleToWordSet(title);
+    let bestMatch: DedupeMatch | null = null;
+    let bestScore = 0;
+
+    for (const feature of features) {
+      // Only match against automation-filed features to avoid false positives
+      const isAutomationFiled = isAutomationFiledFeature(feature);
+
+      if (!isAutomationFiled) {
+        continue;
+      }
+
+      const existingWords = titleToWordSet(feature.title ?? '');
+      const similarity = jaccardSimilarity(incomingWords, existingWords);
+
+      if (similarity > bestScore && similarity >= TITLE_SIMILARITY_THRESHOLD) {
+        bestScore = similarity;
+        bestMatch = { feature, reason: 'title_similarity', similarity };
+      }
+    }
+
+    return bestMatch;
+  }
+
+  /**
+   * Check if a similar feature was recently closed (cooldown check).
+   */
+  private checkCooldown(
+    closedFeatures: Feature[],
+    title: string
+  ): (DedupeNoMatch & { closedFeature: Feature }) | null {
+    const now = Date.now();
+    const incomingWords = titleToWordSet(title);
+
+    for (const feature of closedFeatures) {
+      // Check if this feature was closed within the cooldown window
+      const closedAt = feature.updatedAt
+        ? new Date(feature.updatedAt).getTime()
+        : feature.startedAt
+          ? new Date(feature.startedAt).getTime()
+          : 0;
+
+      if (closedAt && now - closedAt > COOLDOWN_MS) {
+        continue; // Outside cooldown window
+      }
+
+      // Check title similarity
+      const existingWords = titleToWordSet(feature.title ?? '');
+      const similarity = jaccardSimilarity(incomingWords, existingWords);
+
+      if (similarity >= TITLE_SIMILARITY_THRESHOLD) {
+        return { cooldown: true, closedFeature: feature };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Invalidate the cache for a project (call after creating a new feature).
+   */
+  invalidateCache(projectPath: string): void {
+    this.cache.delete(projectPath);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure utility functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a title to a set of lowercase words for Jaccard similarity.
+ * Strips common prefixes like "[Auto]", "System Improvement:", etc.
+ */
+function titleToWordSet(title: string): Set<string> {
+  const STOP_WORDS = new Set([
+    'the',
+    'a',
+    'an',
+    'and',
+    'or',
+    'but',
+    'in',
+    'on',
+    'at',
+    'to',
+    'for',
+    'of',
+    'with',
+    'by',
+    'from',
+    'is',
+    'are',
+    'was',
+    'were',
+    'be',
+    'been',
+    'being',
+    'has',
+    'have',
+    'had',
+    'do',
+    'does',
+    'did',
+    'will',
+    'would',
+    'could',
+    'should',
+    'may',
+    'might',
+    'shall',
+    'can',
+    'this',
+    'that',
+    'these',
+    'those',
+    'it',
+    'its',
+    'recurring',
+    'failures',
+    'failure',
+  ]);
+
+  // Strip common prefixes
+  let normalized = title
+    .replace(/^\[Auto\]\s*/i, '')
+    .replace(/^System\s+Improvement:\s*/i, '')
+    .replace(/^auto-remediate:\s*/i, '')
+    .replace(/^\[Triage\]\s*/i, '')
+    .replace(/^\[TRIAGED\]\s*/i, '')
+    .trim();
+
+  return new Set(
+    normalized
+      .toLowerCase()
+      .split(/[\s\-_:]+/)
+      .filter((w) => w.length > 0 && !STOP_WORDS.has(w))
+  );
+}
+
+/**
+ * Calculate Jaccard similarity between two word sets.
+ * Returns 0.0 – 1.0 (1.0 = identical).
+ */
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 1;
+  if (a.size === 0 || b.size === 0) return 0;
+
+  let intersection = 0;
+  for (const word of a) {
+    if (b.has(word)) intersection++;
+  }
+
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Check if a feature was filed by automation (self-improvement, triage, etc.).
+ * Uses title patterns since the Feature type doesn't have a tags field.
+ */
+function isAutomationFiledFeature(feature: Feature): boolean {
+  const title = feature.title ?? '';
+  return AUTOMATION_TITLE_PATTERNS.some((pattern) => pattern.test(title));
+}

--- a/apps/server/tests/unit/services/issue-dedupe-service.test.ts
+++ b/apps/server/tests/unit/services/issue-dedupe-service.test.ts
@@ -1,0 +1,466 @@
+/**
+ * IssueDedupeService — dedup decision logic tests
+ *
+ * Verifies that the dedupe service correctly identifies duplicates by:
+ * 1. Title similarity (Jaccard word-set overlap)
+ * 2. Fingerprint matching
+ * 3. Source ID matching
+ * 4. Cooldown for recently closed features
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IssueDedupeService } from '@/services/issue-dedupe-service.js';
+import type { FeatureLoader } from '@/services/feature-loader.js';
+import type { Feature } from '@protolabsai/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeFeature(overrides: Partial<Feature> = {}): Feature {
+  return {
+    id: 'feature-test-1',
+    title: 'System Improvement: recurring test_failure failures',
+    description: 'Test feature',
+    category: 'infra',
+    status: 'backlog',
+    tags: ['system-improvement', 'friction-tracker'],
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeFeatureLoader(features: Feature[]): FeatureLoader {
+  return {
+    getAll: vi.fn().mockResolvedValue(features),
+    findByTitle: vi.fn().mockResolvedValue(null),
+  } as unknown as FeatureLoader;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('IssueDedupeService', () => {
+  let service: IssueDedupeService;
+  let features: Feature[];
+  let featureLoader: ReturnType<typeof makeFeatureLoader>;
+
+  const projectPath = '/test/project';
+
+  beforeEach(() => {
+    features = [];
+    featureLoader = makeFeatureLoader(features);
+    service = new IssueDedupeService(featureLoader);
+  });
+
+  // -----------------------------------------------------------------------
+  // Title similarity matching
+  // -----------------------------------------------------------------------
+
+  describe('title similarity (Jaccard)', () => {
+    it('detects similar automation-filed titles as duplicates', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-existing',
+          title: 'System Improvement: recurring test_failure failures',
+          tags: ['system-improvement', 'friction-tracker'],
+        })
+      );
+
+      const result = await service.check(
+        projectPath,
+        'System Improvement: recurring test_failure failures',
+        undefined
+      );
+
+      expect(result.isDuplicate).toBe(true);
+      if (result.isDuplicate) {
+        expect(result.match.reason).toBe('title_similarity');
+        expect(result.match.feature.id).toBe('feature-existing');
+        expect(result.match.similarity).toBeGreaterThanOrEqual(0.5);
+      }
+    });
+
+    it('detects partially similar titles as duplicates', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-existing',
+          title: 'auto-remediate: stuck on test_failure / checks / ts_error',
+          tags: ['auto-remediation', 'hitl-pattern', 'self-improvement'],
+        })
+      );
+
+      const result = await service.check(
+        projectPath,
+        'auto-remediate: stuck on test_failure / checks / ts_error',
+        'hitl:test_failure:checks:ts_error'
+      );
+
+      expect(result.isDuplicate).toBe(true);
+      if (result.isDuplicate) {
+        expect(result.match.reason).toBe('title_similarity');
+      }
+    });
+
+    it('does NOT match user features against automation titles', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-user',
+          title: 'Add test failure reporting',
+          tags: ['feature'],
+        })
+      );
+
+      const result = await service.check(
+        projectPath,
+        'System Improvement: recurring test_failure failures'
+      );
+
+      expect(result.isDuplicate).toBe(false);
+    });
+
+    it('does NOT match dissimilar titles', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-existing',
+          title: 'System Improvement: recurring merge_conflict failures',
+          tags: ['system-improvement', 'friction-tracker'],
+        })
+      );
+
+      const result = await service.check(
+        projectPath,
+        'System Improvement: recurring authentication failures'
+      );
+
+      expect(result.isDuplicate).toBe(false);
+    });
+
+    it('strips common prefixes before comparing titles', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-existing',
+          title: '[Auto] System Improvement: recurring test_failure failures',
+          tags: ['system-improvement', 'friction-tracker'],
+        })
+      );
+
+      const result = await service.check(
+        projectPath,
+        'System Improvement: recurring test_failure failures'
+      );
+
+      expect(result.isDuplicate).toBe(true);
+    });
+
+    it('matches features with [Auto] prefix tag', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-existing',
+          title: '[Auto] Fix recurring build failures',
+          tags: ['feature'],
+        })
+      );
+
+      const result = await service.check(projectPath, 'Fix recurring build failures');
+
+      expect(result.isDuplicate).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Fingerprint matching
+  // -----------------------------------------------------------------------
+
+  describe('fingerprint matching', () => {
+    it('matches by fingerprint in description', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-existing',
+          title: 'System Improvement: recurring test failures',
+          description: 'fp:friction:test_failure Auto-filed feature',
+        })
+      );
+
+      const result = await service.check(
+        projectPath,
+        'Completely different title',
+        'friction:test_failure'
+      );
+
+      expect(result.isDuplicate).toBe(true);
+      if (result.isDuplicate) {
+        expect(result.match.reason).toBe('fingerprint');
+        expect(result.match.feature.id).toBe('feature-existing');
+      }
+    });
+
+    it('does NOT match closed features by fingerprint', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-closed',
+          title: 'Old feature',
+          status: 'done',
+          description: 'fp:friction:test_failure Auto-filed feature',
+        })
+      );
+
+      const result = await service.check(projectPath, 'New feature', 'friction:test_failure');
+
+      expect(result.isDuplicate).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Source ID matching
+  // -----------------------------------------------------------------------
+
+  describe('source ID matching', () => {
+    it('matches by githubIssueNumber', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-existing',
+          title: 'Different title',
+          githubIssueNumber: 123,
+        })
+      );
+
+      const result = await service.check(projectPath, 'New title', undefined, '123');
+
+      expect(result.isDuplicate).toBe(true);
+      if (result.isDuplicate) {
+        expect(result.match.reason).toBe('source_id');
+      }
+    });
+
+    it('does NOT match different source IDs', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-existing',
+          title: 'Existing',
+          githubIssueNumber: 456,
+        })
+      );
+
+      const result = await service.check(projectPath, 'New', undefined, '789');
+
+      expect(result.isDuplicate).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cooldown for recently closed features
+  // -----------------------------------------------------------------------
+
+  describe('cooldown for recently closed features', () => {
+    it('suppresses re-filing when similar feature was recently closed', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-closed',
+          title: 'System Improvement: recurring test_failure failures',
+          status: 'done',
+          updatedAt: new Date().toISOString(),
+          tags: ['system-improvement'],
+        })
+      );
+
+      const result = await service.check(
+        projectPath,
+        'System Improvement: recurring test_failure failures'
+      );
+
+      expect(result.isDuplicate).toBe(false);
+      expect(result.noMatch?.cooldown).toBe(true);
+      if (result.noMatch?.closedFeature) {
+        expect(result.noMatch.closedFeature.id).toBe('feature-closed');
+      }
+    });
+
+    it('does NOT suppress when closed feature is outside cooldown window', async () => {
+      const oldDate = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(); // 25 hours ago
+
+      features.push(
+        makeFeature({
+          id: 'feature-old-closed',
+          title: 'System Improvement: recurring test_failure failures',
+          status: 'done',
+          updatedAt: oldDate,
+          tags: ['system-improvement'],
+        })
+      );
+
+      const result = await service.check(
+        projectPath,
+        'System Improvement: recurring test_failure failures'
+      );
+
+      expect(result.isDuplicate).toBe(false);
+      expect(result.noMatch?.cooldown).toBe(undefined);
+    });
+
+    it('does NOT suppress when titles are dissimilar', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-closed',
+          title: 'System Improvement: recurring merge_conflict failures',
+          status: 'done',
+          updatedAt: new Date().toISOString(),
+          tags: ['system-improvement'],
+        })
+      );
+
+      const result = await service.check(
+        projectPath,
+        'System Improvement: recurring authentication failures'
+      );
+
+      expect(result.isDuplicate).toBe(false);
+      expect(result.noMatch?.cooldown).toBe(undefined);
+    });
+
+    it('does NOT suppress for interrupted status', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-interrupted',
+          title: 'System Improvement: recurring test_failure failures',
+          status: 'interrupted',
+          updatedAt: new Date().toISOString(),
+          tags: ['system-improvement'],
+        })
+      );
+
+      const result = await service.check(
+        projectPath,
+        'System Improvement: recurring test_failure failures'
+      );
+
+      expect(result.isDuplicate).toBe(false);
+      expect(result.noMatch?.cooldown).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // No match cases
+  // -----------------------------------------------------------------------
+
+  describe('no match cases', () => {
+    it('returns no match when feature store is empty', async () => {
+      const result = await service.check(
+        projectPath,
+        'System Improvement: recurring test_failure failures'
+      );
+
+      expect(result.isDuplicate).toBe(false);
+    });
+
+    it('returns no match when all features are closed and outside cooldown', async () => {
+      const oldDate = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+
+      features.push(
+        makeFeature({
+          id: 'feature-closed',
+          title: 'Some old feature',
+          status: 'done',
+          updatedAt: oldDate,
+        })
+      );
+
+      const result = await service.check(projectPath, 'New feature title');
+
+      expect(result.isDuplicate).toBe(false);
+    });
+
+    it('falls back to empty array when featureLoader.getAll throws', async () => {
+      vi.mocked(featureLoader.getAll).mockRejectedValue(new Error('FS error'));
+
+      const result = await service.check(
+        projectPath,
+        'System Improvement: recurring test_failure failures'
+      );
+
+      expect(result.isDuplicate).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cache invalidation
+  // -----------------------------------------------------------------------
+
+  describe('cache', () => {
+    it('caches feature list within TTL', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-1',
+          title: 'System Improvement: recurring test_failure failures',
+          tags: ['system-improvement'],
+        })
+      );
+
+      await service.check(projectPath, 'System Improvement: recurring test_failure failures');
+      await service.check(projectPath, 'System Improvement: recurring test_failure failures');
+
+      expect(featureLoader.getAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('invalidates cache on demand', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-1',
+          title: 'Existing',
+          tags: ['system-improvement'],
+        })
+      );
+
+      await service.check(projectPath, 'Existing');
+      expect(featureLoader.getAll).toHaveBeenCalledTimes(1);
+
+      service.invalidateCache(projectPath);
+
+      // Add a new feature
+      features.push(
+        makeFeature({
+          id: 'feature-2',
+          title: 'New feature',
+          tags: ['system-improvement'],
+        })
+      );
+
+      await service.check(projectPath, 'New feature');
+      expect(featureLoader.getAll).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Priority: fingerprint > source_id > title_similarity
+  // -----------------------------------------------------------------------
+
+  describe('match priority', () => {
+    it('prefers fingerprint match over title similarity', async () => {
+      features.push(
+        makeFeature({
+          id: 'feature-fp',
+          title: 'Some title',
+          tags: ['system-improvement', 'fp:friction:test_failure'],
+        }),
+        makeFeature({
+          id: 'feature-similar',
+          title: 'System Improvement: recurring test_failure failures',
+          tags: ['system-improvement'],
+        })
+      );
+
+      const result = await service.check(
+        projectPath,
+        'System Improvement: recurring test_failure failures',
+        'friction:test_failure'
+      );
+
+      expect(result.isDuplicate).toBe(true);
+      if (result.isDuplicate) {
+        expect(result.match.reason).toBe('fingerprint');
+        expect(result.match.feature.id).toBe('feature-fp');
+      }
+    });
+  });
+});

--- a/apps/server/tests/unit/services/issue-dedupe-service.test.ts
+++ b/apps/server/tests/unit/services/issue-dedupe-service.test.ts
@@ -441,7 +441,8 @@ describe('IssueDedupeService', () => {
         makeFeature({
           id: 'feature-fp',
           title: 'Some title',
-          tags: ['system-improvement', 'fp:friction:test_failure'],
+          description: 'Auto-filed system improvement.\n\nfp:friction:test_failure',
+          tags: ['system-improvement'],
         }),
         makeFeature({
           id: 'feature-similar',


### PR DESCRIPTION
## Summary

The triage/self-improvement automation re-files issues that already exist, creating [Triage]/[TRIAGED] companion duplicates (~20 of 34 issues one day were dupes). Before the triage/intake automation opens a new GitHub issue, dedupe against OPEN issues (title similarity / fingerprint / linked source ID). If a matching open issue exists, comment on it or skip instead of opening a new one. Cap re-filing of the same root cause; add a cooldown so a closed-as-duplicate isn't immediately recreated. Loc...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-0426132e team= created=2026-05-26T20:55:49.627Z -->