### PR TITLE
fix(merge): platform owns the merge — never enable GitHub auto-merge (#88)

### DIFF
--- a/apps/server/src/services/completion-detector-service.ts
+++ b/apps/server/src/services/completion-detector-service.ts
@@ -20,6 +20,7 @@ import type { ProjectService } from './project-service.js';
 import type { SettingsService } from './settings-service.js';
 import type { Feature, Milestone } from '@protolabsai/types';
 import { getEffectivePrBaseBranch } from '../lib/settings-helpers.js';
+import { githubMergeService } from './github-merge-service.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -451,17 +452,22 @@ export class CompletionDetectorService {
       }>;
 
       if (existing.length > 0) {
-        // PR already exists — ensure auto-merge is enabled and return it
+        // PR already exists. Do NOT enable GitHub auto-merge — merge it through the
+        // platform gate (all checks green or no merge). This detection runs on a
+        // schedule, so a checks-pending epic is re-attempted on the next cycle.
         const pr = existing[0];
-        await execFileAsync('gh', ['pr', 'merge', String(pr.number), '--merge', '--auto'], {
-          cwd: projectPath,
-          timeout: 15000,
-        }).catch(() => {
-          // auto-merge may already be enabled, ignore
-        });
-        logger.info(
-          `Epic "${epic.title}" — reusing existing PR #${pr.number} from ${epicBranch} to ${baseBranch}`
-        );
+        const mergeResult = await githubMergeService.mergePR(projectPath, pr.number, 'merge', true);
+        if (mergeResult.success) {
+          logger.info(`Epic "${epic.title}" — merged existing PR #${pr.number} into ${baseBranch}`);
+        } else if (mergeResult.checksPending) {
+          logger.info(
+            `Epic "${epic.title}" — PR #${pr.number} checks pending; will merge once green (next detection cycle)`
+          );
+        } else {
+          logger.warn(
+            `Epic "${epic.title}" — PR #${pr.number} not merged: ${mergeResult.error ?? 'gate not satisfied'}`
+          );
+        }
         return { prNumber: pr.number, prUrl: pr.url };
       }
 
@@ -501,15 +507,19 @@ export class CompletionDetectorService {
       }
       const prNumber = parseInt(prNumberMatch[1], 10);
 
-      // Enable auto-merge with --merge strategy (never squash on epic PRs)
-      await execFileAsync('gh', ['pr', 'merge', String(prNumber), '--merge', '--auto'], {
-        cwd: projectPath,
-        timeout: 15000,
-      }).catch((err) => {
-        logger.warn(`Failed to enable auto-merge on epic PR #${prNumber} (non-fatal):`, err);
-      });
-
-      logger.info(`Created epic PR #${prNumber}: ${epicBranch} → ${baseBranch} with auto-merge`);
+      // Attempt a gated merge (--merge strategy; never squash epic PRs). The PR was
+      // just created so checks are almost certainly pending — mergePR will decline
+      // and the next detection cycle re-attempts once all checks are green. No
+      // GitHub auto-merge: the platform owns the merge decision.
+      const mergeResult = await githubMergeService.mergePR(projectPath, prNumber, 'merge', true);
+      if (mergeResult.success) {
+        logger.info(`Created and merged epic PR #${prNumber}: ${epicBranch} → ${baseBranch}`);
+      } else {
+        logger.info(
+          `Created epic PR #${prNumber}: ${epicBranch} → ${baseBranch} ` +
+            `(${mergeResult.checksPending ? 'checks pending; will merge once green' : (mergeResult.error ?? 'merge gate not satisfied')})`
+        );
+      }
       return { prNumber, prUrl };
     } catch (err) {
       logger.error(`Failed to create epic PR for ${epicBranch}:`, err);

--- a/apps/server/src/services/github-merge-service.ts
+++ b/apps/server/src/services/github-merge-service.ts
@@ -191,41 +191,22 @@ export class GitHubMergeService {
       const checkStatus = await this.checkPRStatus(workDir, prNumber);
 
       if (checkStatus.pendingCount > 0) {
-        // CI is still running — enable auto-merge so GitHub merges once checks pass
+        // CI is still running. Do NOT enable GitHub auto-merge: that delegates the
+        // merge decision to GitHub, which only honors *required* branch-protection
+        // checks and will merge past non-required pending/failing checks (the leak
+        // that merged the broken #3878 linters). Report "pending, not merged"; the
+        // platform owns the merge — the REVIEW phase polls until every check is
+        // green and then merges explicitly via mergePR / MergeProcessor.
         logger.info(
-          `PR #${prNumber} has ${checkStatus.pendingCount} pending checks, enabling auto-merge`
+          `PR #${prNumber} has ${checkStatus.pendingCount} pending check(s) — not merging ` +
+            `(merge is gated on all checks completing green; no GitHub auto-merge)`
         );
-        try {
-          let autoMergeCmd = `gh pr merge ${prNumber}`;
-          switch (strategy) {
-            case 'merge':
-              autoMergeCmd += ' --merge';
-              break;
-            case 'squash':
-              autoMergeCmd += ' --squash';
-              break;
-            case 'rebase':
-              autoMergeCmd += ' --rebase';
-              break;
-          }
-          autoMergeCmd += ' --auto';
-          await execAsync(autoMergeCmd, { cwd: workDir, env: execEnv });
-          logger.info(`Auto-merge enabled for PR #${prNumber}, will merge when checks pass`);
-          return {
-            success: true,
-            autoMergeEnabled: true,
-            checksPending: true,
-          };
-        } catch (autoMergeError) {
-          const errMsg =
-            autoMergeError instanceof Error ? autoMergeError.message : String(autoMergeError);
-          logger.warn(`Failed to enable auto-merge for PR #${prNumber}: ${errMsg}`);
-          return {
-            success: false,
-            error: `${checkStatus.pendingCount} checks still pending, auto-merge failed: ${errMsg}`,
-            checksPending: true,
-          };
-        }
+        return {
+          success: false,
+          autoMergeEnabled: false,
+          checksPending: true,
+          error: `${checkStatus.pendingCount} check(s) still pending`,
+        };
       }
 
       if (checkStatus.failedCount > 0) {
@@ -260,10 +241,12 @@ export class GitHubMergeService {
           break;
       }
 
-      // Auto-confirm the merge
-      mergeCmd += ' --auto';
+      // Explicit immediate merge — all checks are green at this point (we only
+      // reach here when pendingCount === 0 && failedCount === 0). We intentionally
+      // do NOT pass --auto: the platform owns the merge decision rather than
+      // handing it to GitHub's required-checks-only auto-merge.
 
-      logger.info(`Merging PR #${prNumber} with strategy: ${strategy}`);
+      logger.info(`Merging PR #${prNumber} with strategy: ${strategy} (explicit, no auto-merge)`);
       const { stdout } = await execAsync(mergeCmd, {
         cwd: workDir,
         env: execEnv,

--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -883,31 +883,35 @@ export class ReviewProcessor implements StateProcessor {
   /**
    * Reconcile a PR into the expected managed state regardless of how it was created.
    *
-   * 1. Appends the ownership watermark to the PR body if it is missing.
-   * 2. Enables auto-merge if it is not already enabled.
+   * Appends the ownership watermark to the PR body if it is missing.
+   *
+   * Note: this intentionally does NOT enable GitHub auto-merge. The platform owns
+   * the merge decision — the REVIEW gate (getPRReviewState) requires an approving
+   * review AND every CI check green before MergeProcessor performs an explicit
+   * merge. Enabling GitHub auto-merge here would bypass that gate, since GitHub
+   * honors only *required* branch-protection checks and would merge past
+   * non-required pending or failing checks.
    *
    * This is idempotent — running it multiple times on the same PR is safe.
    */
   private async normalizePR(ctx: StateContext): Promise<void> {
     if (!ctx.prNumber) return;
 
-    // Fetch current PR body and auto-merge status in one call
+    // Fetch current PR body
     let body = '';
-    let autoMergeEnabled = false;
     try {
-      const { stdout } = await execAsync(
-        `gh pr view ${ctx.prNumber} --json body,autoMergeRequest --jq '{body: .body, autoMerge: (.autoMergeRequest != null)}'`,
-        { cwd: ctx.projectPath, timeout: 15000 }
-      );
-      const data = JSON.parse(stdout.trim()) as { body: string; autoMerge: boolean };
+      const { stdout } = await execAsync(`gh pr view ${ctx.prNumber} --json body`, {
+        cwd: ctx.projectPath,
+        timeout: 15000,
+      });
+      const data = JSON.parse(stdout.trim()) as { body?: string };
       body = data.body ?? '';
-      autoMergeEnabled = data.autoMerge ?? false;
     } catch (err) {
-      logger.warn('[REVIEW] normalizePR: failed to fetch PR body/auto-merge status:', err);
+      logger.warn('[REVIEW] normalizePR: failed to fetch PR body:', err);
       return;
     }
 
-    // 1. Patch ownership watermark if absent
+    // Patch ownership watermark if absent
     const ownership = parsePROwnershipWatermark(body);
     if (!ownership.instanceId) {
       try {
@@ -943,50 +947,6 @@ export class ReviewProcessor implements StateProcessor {
         logger.warn('[REVIEW] normalizePR: failed to patch PR ownership watermark:', err);
       }
     }
-
-    // 2. Enable auto-merge if not already enabled
-    if (!autoMergeEnabled) {
-      try {
-        const mergeFlag = await this.resolveNormalizeMergeFlag(ctx);
-        await execAsync(`gh pr merge ${ctx.prNumber} --auto ${mergeFlag}`, {
-          cwd: ctx.projectPath,
-          timeout: 30000,
-        });
-        logger.info(
-          `[REVIEW] normalizePR: enabled auto-merge on PR #${ctx.prNumber} (${mergeFlag})`
-        );
-      } catch (err) {
-        logger.warn('[REVIEW] normalizePR: failed to enable auto-merge:', err);
-      }
-    }
-  }
-
-  /**
-   * Resolve merge flag for normalization (same logic as MergeProcessor.resolveMergeFlag).
-   * Epic PRs always use --merge. Feature PRs use the configured prMergeStrategy.
-   */
-  private async resolveNormalizeMergeFlag(ctx: StateContext): Promise<string> {
-    if (ctx.prNumber) {
-      const baseBranchFlag = await resolveMergeStrategy(ctx.prNumber, ctx.projectPath);
-      if (baseBranchFlag === '--merge') return '--merge';
-    }
-
-    let strategy: PRMergeStrategy = 'squash';
-    if (this.serviceContext.settingsService) {
-      try {
-        const globalSettings = await this.serviceContext.settingsService.getGlobalSettings();
-        strategy = globalSettings.gitWorkflow?.prMergeStrategy ?? 'squash';
-      } catch (err) {
-        logger.warn('[REVIEW] normalizePR: failed to read merge strategy from settings:', err);
-      }
-    }
-
-    const flagMap: Record<PRMergeStrategy, string> = {
-      squash: '--squash',
-      merge: '--merge',
-      rebase: '--rebase',
-    };
-    return flagMap[strategy] ?? '--squash';
   }
 
   private async getPRReviewState(ctx: StateContext): Promise<string> {

--- a/apps/server/tests/unit/services/completion-detector-service.test.ts
+++ b/apps/server/tests/unit/services/completion-detector-service.test.ts
@@ -13,6 +13,16 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 const { mockExecFile } = vi.hoisted(() => ({ mockExecFile: vi.fn() }));
 vi.mock('node:child_process', () => ({
   execFile: mockExecFile,
+  // github-merge-service (imported transitively) does promisify(exec) at module
+  // load. Provide a callback-style exec so the load + any incidental calls succeed.
+  exec: (
+    _cmd: string,
+    opts: unknown,
+    cb?: (err: unknown, res: { stdout: string; stderr: string }) => void
+  ) => {
+    const callback = typeof opts === 'function' ? (opts as typeof cb) : cb;
+    callback?.(null, { stdout: '', stderr: '' });
+  },
 }));
 
 import { CompletionDetectorService } from '@/services/completion-detector-service.js';

--- a/apps/server/tests/unit/services/github-merge-service.test.ts
+++ b/apps/server/tests/unit/services/github-merge-service.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for GitHubMergeService.mergePR — the platform-owned merge gate (#88).
+ *
+ * Guarantees:
+ *   - pending checks  → NOT merged, NO GitHub auto-merge enabled (no `--auto`)
+ *   - failed checks   → NOT merged, reported as checksFailed
+ *   - all checks green → explicit `gh pr merge` WITHOUT `--auto`
+ *
+ * The whole point: protoMaker never delegates the merge to GitHub auto-merge
+ * (which honors only required checks and merged the broken #3878 linters).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  rollup: [] as Array<Record<string, unknown>>,
+  mergedAt: '2026-05-26T00:00:00Z',
+  execCalls: [] as string[],
+}));
+
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual('@protolabsai/utils');
+  return {
+    ...(actual as object),
+    createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+vi.mock('@protolabsai/git-utils', () => ({ createGitExecEnv: () => ({}) }));
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    exec: (
+      cmd: string,
+      _opts: unknown,
+      cb?: (err: unknown, res: { stdout: string; stderr: string }) => void
+    ) => {
+      const callback = typeof _opts === 'function' ? (_opts as typeof cb) : cb;
+      h.execCalls.push(cmd);
+      let stdout = '';
+      if (cmd.includes('command -v gh') || cmd.includes('where gh')) {
+        stdout = '/usr/bin/gh';
+      } else if (cmd.includes('--json statusCheckRollup')) {
+        stdout = JSON.stringify({ statusCheckRollup: h.rollup });
+      } else if (cmd.includes('--json mergedAt')) {
+        stdout = JSON.stringify({ mergedAt: h.mergedAt });
+      } else if (cmd.includes('--json state')) {
+        // Post-merge verification: explicit merge lands immediately → MERGED
+        stdout = JSON.stringify({ state: 'MERGED' });
+      } else if (cmd.includes('gh pr merge')) {
+        stdout = 'Merged pull request abcdef1234567890abcdef1234567890abcdef12';
+      }
+      callback?.(null, { stdout, stderr: '' });
+    },
+  };
+});
+
+import { GitHubMergeService } from '@/services/github-merge-service.js';
+
+const svc = new GitHubMergeService();
+const mergeCmds = () => h.execCalls.filter((c) => /gh pr merge\b/.test(c));
+
+describe('GitHubMergeService.mergePR — platform-owned merge gate (#88)', () => {
+  beforeEach(() => {
+    h.execCalls.length = 0;
+    h.rollup = [];
+    h.mergedAt = '2026-05-26T00:00:00Z';
+  });
+
+  it('does NOT merge or enable auto-merge when checks are pending', async () => {
+    h.rollup = [
+      { status: 'COMPLETED', conclusion: 'SUCCESS', name: 'build' },
+      { status: 'IN_PROGRESS', name: 'test' }, // pending
+    ];
+
+    const result = await svc.mergePR('/work', 42, 'squash', true);
+
+    expect(result.success).toBe(false);
+    expect(result.checksPending).toBe(true);
+    expect(result.autoMergeEnabled).toBe(false);
+    // Crucially: no `gh pr merge` command was ever issued (no --auto, no merge)
+    expect(mergeCmds()).toHaveLength(0);
+  });
+
+  it('does NOT merge when a check has failed', async () => {
+    h.rollup = [
+      { status: 'COMPLETED', conclusion: 'SUCCESS', name: 'build' },
+      { status: 'COMPLETED', conclusion: 'FAILURE', name: 'zizmor (security audit)' },
+    ];
+
+    const result = await svc.mergePR('/work', 42, 'squash', true);
+
+    expect(result.success).toBe(false);
+    expect(result.checksFailed).toBe(true);
+    expect(result.failedChecks).toContain('zizmor (security audit)');
+    expect(mergeCmds()).toHaveLength(0);
+  });
+
+  it('merges explicitly (no --auto) when all checks are green', async () => {
+    h.rollup = [
+      { status: 'COMPLETED', conclusion: 'SUCCESS', name: 'build' },
+      { status: 'COMPLETED', conclusion: 'SUCCESS', name: 'test' },
+      { status: 'COMPLETED', conclusion: 'SUCCESS', name: 'checks' },
+    ];
+
+    const result = await svc.mergePR('/work', 42, 'squash', true);
+
+    expect(result.success).toBe(true);
+    const merges = mergeCmds();
+    expect(merges.length).toBeGreaterThan(0);
+    for (const cmd of merges) {
+      expect(cmd).toContain('--squash');
+      expect(cmd).not.toContain('--auto');
+    }
+  });
+});


### PR DESCRIPTION
Closes the #1 leak from #3881: **PRs merging with pending/failing checks.**

## Root cause

`gh pr merge --auto` (GitHub-native auto-merge) honors only **required** branch-protection checks. The crew's #3878 added linter checks that weren't required, so GitHub merged it the moment `build`/`test`/`checks` went green — even though those linters were failing. protoMaker's own gate (`ReviewProcessor.getPRReviewState`) is correct — it requires an **approving review AND every CI check green** (pending ≠ success, any FAILURE → back to EXECUTE) — but it was **bypassed** because the merge was delegated to GitHub.

## Fix — the platform owns the merge

- **`github-merge-service.mergePR`**: pending checks no longer enable `--auto` — returns `{ success:false, checksPending:true, autoMergeEnabled:false }` so the REVIEW phase waits and merges once everything's green. All-green path merges **explicitly** (`--auto` removed). Also fixes a latent bug where the pending path returned `success:true` and wrongly emitted `feature:pr-merged`.
- **`ReviewProcessor.normalizePR`**: removed the per-REVIEW-cycle auto-merge enablement (and the now-unused `resolveNormalizeMergeFlag`). It only patches the ownership watermark now. Merge is owned by `getPRReviewState` → `MergeProcessor` explicit `gh pr merge`.

**Net effect:** every managed app's PR merges only via an explicit `gh pr merge` *after* the platform confirms all checks are green — independent of that repo's required-checks list. Pending/failing checks can never merge. With #3878, the gate would have returned `ci_failed` and never merged.

## Tests

New `github-merge-service.test.ts`: pending → no merge & no `--auto`; failed → no merge; all-green → explicit merge without `--auto`. 30 merge-path tests pass (3 new + 27 existing review/merge processor tests). `tsc` + prettier clean.

## Follow-ups (tracked)
- Epic-path `--auto` in `completion-detector-service` (#3881)
- Fleet standard in release-tools incl. `.gitignore` + verified linters (#89)
- Compliance gate: hard-refuse non-compliant apps + env opt-out (#90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * PR merge process now correctly waits for pending CI checks to complete before proceeding.
  * Improved handling of failed CI checks with clearer status reporting.

* **Refactor**
  * Streamlined PR merge workflow for more explicit control over merge timing and behavior.

* **Tests**
  * Added comprehensive unit test suite validating merge service behavior across various CI check states and outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3882?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->