### PR TITLE
feat(create-protolab): add recommended .gitignore to the fleet standard (#89)

### DIFF
--- a/packages/create-protolab/src/phases/ci.ts
+++ b/packages/create-protolab/src/phases/ci.ts
@@ -60,6 +60,18 @@ export async function setupCI(options: CIOptions): Promise<CIResult> {
       filesCreated.push(`.github/workflows/${templateName}`);
     }
 
+    // 5. Write the recommended .gitignore (fleet standard). Idempotent and
+    //    non-invasive: if the project already has a .gitignore, leave it alone —
+    //    we suggest the standard, we don't fight an existing setup.
+    const gitignorePath = path.join(projectPath, '.gitignore');
+    if (await fileExists(gitignorePath)) {
+      filesCreated.push('.gitignore (already exists)');
+    } else {
+      const gitignoreContent = await loadTemplate('gitignore');
+      await fs.writeFile(gitignorePath, gitignoreContent, 'utf-8');
+      filesCreated.push('.gitignore');
+    }
+
     return {
       success: true,
       filesCreated,

--- a/packages/create-protolab/src/phases/ci.ts
+++ b/packages/create-protolab/src/phases/ci.ts
@@ -7,7 +7,7 @@
 
 import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { loadTemplate } from '../templates.js';
 
 export interface CIOptions {
   projectPath: string;
@@ -94,25 +94,6 @@ async function fileExists(filePath: string): Promise<boolean> {
     return true;
   } catch {
     return false;
-  }
-}
-
-/**
- * Load a template file from the templates directory.
- */
-async function loadTemplate(templatePath: string): Promise<string> {
-  // Resolve template directory using import.meta.url
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const templatesDir = path.join(__dirname, '..', 'templates');
-  const fullPath = path.join(templatesDir, templatePath);
-
-  try {
-    const content = await fs.readFile(fullPath, 'utf-8');
-    return content;
-  } catch (err) {
-    throw new Error(
-      `Failed to load template "${templatePath}" at ${fullPath}: ${err instanceof Error ? err.message : String(err)}`
-    );
   }
 }
 

--- a/packages/create-protolab/templates/cicd/branch-protection/main.json
+++ b/packages/create-protolab/templates/cicd/branch-protection/main.json
@@ -21,7 +21,7 @@
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": true,
+        "strict_required_status_checks_policy": false,
         "required_status_checks": [
           { "context": "build" },
           { "context": "test" },

--- a/packages/create-protolab/templates/cicd/branch-protection/main.json
+++ b/packages/create-protolab/templates/cicd/branch-protection/main.json
@@ -21,7 +21,7 @@
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": false,
+        "strict_required_status_checks_policy": true,
         "required_status_checks": [
           { "context": "build" },
           { "context": "test" },

--- a/packages/create-protolab/templates/gitignore
+++ b/packages/create-protolab/templates/gitignore
@@ -1,0 +1,47 @@
+# Dependencies
+node_modules/
+.pnp/
+.pnp.js
+
+# Build output
+dist/
+build/
+out/
+*.tsbuildinfo
+
+# Environment & secrets — never commit these
+.env
+.env.*
+!.env.example
+*.pem
+credentials.json
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+logs/
+
+# Test / coverage
+coverage/
+.nyc_output/
+
+# Caches
+.cache/
+.turbo/
+.eslintcache
+
+# Editor / OS
+.DS_Store
+Thumbs.db
+.idea/
+*.swp
+
+# protoLabs / Automaker local state
+# (issues.jsonl is committed; the SQLite DB is rebuildable and ignored)
+.beads/beads.db
+.beads/*.db-*
+data/
+.worktrees/


### PR DESCRIPTION
Part of #3881. Strengthens the standard every protoMaker-scaffolded app inherits.

## Changes
- **Branch protection**: `strict_required_status_checks_policy: true` — a PR must be up to date with base (so its checks reflect the latest base) before merging. Defense-in-depth behind the platform merge gate (#88 / #3882).
- **Recommended `.gitignore`**: new template, written during scaffolding **idempotently** — if the project already has one, we leave it (suggest the standard, don't fight existing setups). Covers env/secrets, build output, logs, caches, and Automaker local state (`.beads` DB, `data/`, `.worktrees/`).

## Notes
- The separate `protoLabsAI/release-tools` repo is the release-*notes* generator — the fleet **setup** standard lives in `create-protolab` (the scaffolder).
- The reverted workflow-security linters (#3819) will be re-added with **verified, SHA-pinned** action refs separately — not guessed (guessing is what broke #3878).

## Tests
create-protolab suite passes (23); tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically creates a recommended `.gitignore` file when generating new projects, with preconfigured patterns for Node.js modules, environment files, logs, and editor artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->