### PR TITLE
feat(compliance): hard-refuse non-compliant apps before auto-mode (#90)

### DIFF
--- a/apps/server/src/services/app-compliance-service.ts
+++ b/apps/server/src/services/app-compliance-service.ts
@@ -1,0 +1,154 @@
+/**
+ * App Compliance Service
+ *
+ * Verifies a managed app meets the protoLabs fleet standard before protoMaker
+ * runs auto-mode against it. The platform refuses to operate non-compliant apps
+ * (a missing merge-blocking standard is "not worth the headache") and tells the
+ * operator exactly what to set up.
+ *
+ * Default: HARD-REFUSE on verified non-compliance.
+ * Escape hatch: set AUTOMAKER_SKIP_COMPLIANCE_CHECK=1 (truthy) to bypass — we
+ * suggest the standard, we don't fight an operator's existing system.
+ *
+ * Checks are deliberately conservative: a check only counts as a *violation*
+ * when it is positively verified absent. When it can't be determined (no remote,
+ * gh unavailable, API/permission error) it is reported as "unverified" and does
+ * NOT block — refusing to run a legitimate local/limited-permission repo would
+ * be worse than the gap.
+ */
+
+import { exec } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { createLogger } from '@protolabsai/utils';
+
+const execAsync = promisify(exec);
+const logger = createLogger('AppCompliance');
+
+/** Env var operators can set (truthy) to bypass the compliance gate entirely. */
+export const COMPLIANCE_SKIP_ENV = 'AUTOMAKER_SKIP_COMPLIANCE_CHECK';
+
+export interface ComplianceViolation {
+  /** Short stable id for the failing check. */
+  check: 'gitignore' | 'branch-protection';
+  /** Human-readable description of what's wrong. */
+  message: string;
+  /** What the operator should do to fix it. */
+  remediation: string;
+}
+
+export interface ComplianceResult {
+  /** True when there are no violations (or the gate was skipped). */
+  compliant: boolean;
+  /** True when the gate was bypassed via the opt-out env var. */
+  skipped: boolean;
+  violations: ComplianceViolation[];
+}
+
+function isTruthyEnv(value: string | undefined): boolean {
+  if (!value) return false;
+  const v = value.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes' || v === 'on';
+}
+
+/**
+ * Branch-protection state for the default branch:
+ * - 'present'    → an effective rule requires status checks before merge
+ * - 'absent'     → verified that no such rule exists (a violation)
+ * - 'unverified' → could not determine (no remote / gh missing / API error)
+ */
+async function checkBranchProtection(
+  projectPath: string
+): Promise<'present' | 'absent' | 'unverified'> {
+  // Resolve owner/repo + default branch via gh (uses the repo's configured remote).
+  let owner: string;
+  let repo: string;
+  let defaultBranch: string;
+  try {
+    const { stdout } = await execAsync('gh repo view --json owner,name,defaultBranchRef', {
+      cwd: projectPath,
+      timeout: 15000,
+    });
+    const data = JSON.parse(stdout.trim()) as {
+      owner?: { login?: string };
+      name?: string;
+      defaultBranchRef?: { name?: string };
+    };
+    if (!data.owner?.login || !data.name || !data.defaultBranchRef?.name) return 'unverified';
+    owner = data.owner.login;
+    repo = data.name;
+    defaultBranch = data.defaultBranchRef.name;
+  } catch {
+    return 'unverified';
+  }
+
+  // Query the effective rules applying to the default branch (combines modern
+  // rulesets and classic branch protection).
+  try {
+    const { stdout } = await execAsync(
+      `gh api "repos/${owner}/${repo}/rules/branches/${defaultBranch}" --jq '[.[].type]'`,
+      { cwd: projectPath, timeout: 15000 }
+    );
+    const types = JSON.parse(stdout.trim() || '[]') as string[];
+    return types.includes('required_status_checks') ? 'present' : 'absent';
+  } catch {
+    return 'unverified';
+  }
+}
+
+/**
+ * Check whether the app at `projectPath` meets the fleet standard.
+ */
+export async function checkAppCompliance(projectPath: string): Promise<ComplianceResult> {
+  // Opt-out: don't fight people's systems.
+  if (isTruthyEnv(process.env[COMPLIANCE_SKIP_ENV])) {
+    logger.info(
+      `[compliance] ${COMPLIANCE_SKIP_ENV} set — skipping compliance gate for ${projectPath}`
+    );
+    return { compliant: true, skipped: true, violations: [] };
+  }
+
+  const violations: ComplianceViolation[] = [];
+
+  // 1. .gitignore present (always determinable from the working tree).
+  if (!existsSync(join(projectPath, '.gitignore'))) {
+    violations.push({
+      check: 'gitignore',
+      message: 'Repository has no .gitignore.',
+      remediation:
+        'Add a .gitignore (see the protoLabs recommended baseline scaffolded by create-protolab).',
+    });
+  }
+
+  // 2. Default branch requires status checks before merge (best-effort).
+  const bp = await checkBranchProtection(projectPath);
+  if (bp === 'absent') {
+    violations.push({
+      check: 'branch-protection',
+      message: 'The default branch has no required status checks (PRs can merge without CI).',
+      remediation:
+        'Apply branch protection requiring CI checks — e.g. the create-protolab branch-protection ruleset.',
+    });
+  }
+
+  return { compliant: violations.length === 0, skipped: false, violations };
+}
+
+/**
+ * Build a clear, operator-facing refusal message from compliance violations.
+ */
+export function buildComplianceRefusalMessage(
+  projectPath: string,
+  violations: ComplianceViolation[]
+): string {
+  const lines = [
+    `protoMaker refused to run auto-mode for ${projectPath}: the app does not meet the fleet standard.`,
+    '',
+    'Issues to fix:',
+    ...violations.map((v) => `  • [${v.check}] ${v.message}\n    → ${v.remediation}`),
+    '',
+    `Once fixed, retry. To bypass this gate (not recommended), set ${COMPLIANCE_SKIP_ENV}=1.`,
+  ];
+  return lines.join('\n');
+}

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -139,6 +139,7 @@ import {
 } from './worktree-lifecycle-service.js';
 import { runInitScript } from './init-script-service.js';
 import { checkFeatureRestartOutcome } from './startup-recovery-service.js';
+import { checkAppCompliance, buildComplianceRefusalMessage } from './app-compliance-service.js';
 import type {
   RunningFeature,
   PendingApproval,
@@ -807,6 +808,17 @@ export class AutoModeService {
     _forceStart: boolean = false,
     maxConcurrencyOverride?: number
   ): Promise<number> {
+    // Fleet-standard compliance gate. Refuse to run non-compliant apps (hard-refuse
+    // by default; AUTOMAKER_SKIP_COMPLIANCE_CHECK bypasses). Done at the very top —
+    // before the synchronous slot claim below — so this await doesn't reopen the
+    // TOCTOU window, and a refusal leaves no loop state to clean up.
+    const compliance = await checkAppCompliance(projectPath);
+    if (!compliance.compliant && !compliance.skipped) {
+      const message = buildComplianceRefusalMessage(projectPath, compliance.violations);
+      logger.warn(`[compliance] ${message}`);
+      throw new Error(message);
+    }
+
     // Compute key early so we can synchronously claim it before any await.
     // This prevents the TOCTOU race where concurrent callers all pass the
     // isRunning check before coordinator.startLoop() sets isRunning = true.

--- a/apps/server/tests/setup.ts
+++ b/apps/server/tests/setup.ts
@@ -8,6 +8,10 @@ import { vi, beforeEach } from 'vitest';
 // Set test environment variables
 process.env.NODE_ENV = 'test';
 process.env.DATA_DIR = '/tmp/test-data';
+// Skip the app-compliance gate in unit tests — it is a production concern that
+// hits the filesystem + gh and would reject the mock project paths used here.
+// (app-compliance-service.test.ts manages this var itself to exercise the real logic.)
+process.env.AUTOMAKER_SKIP_COMPLIANCE_CHECK = '1';
 
 // Reset all mocks before each test
 beforeEach(() => {

--- a/apps/server/tests/unit/services/app-compliance-service.test.ts
+++ b/apps/server/tests/unit/services/app-compliance-service.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Unit tests for the app compliance gate (#90).
+ *
+ *   - opt-out env → skipped, compliant
+ *   - missing .gitignore → violation (hard-fail)
+ *   - missing branch protection (verified absent) → violation
+ *   - undeterminable branch protection (gh error) → NOT a violation
+ *   - fully compliant → compliant
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  gitignoreExists: true,
+  failRepoView: false,
+  ruleTypes: ['required_status_checks'] as string[],
+  failRules: false,
+}));
+
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual('@protolabsai/utils');
+  return {
+    ...(actual as object),
+    createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    existsSync: (p: string) =>
+      p.endsWith('.gitignore') ? h.gitignoreExists : actual.existsSync(p),
+  };
+});
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    exec: (
+      cmd: string,
+      opts: unknown,
+      cb?: (err: unknown, res?: { stdout: string; stderr: string }) => void
+    ) => {
+      const callback = typeof opts === 'function' ? (opts as typeof cb) : cb;
+      if (cmd.includes('gh repo view')) {
+        if (h.failRepoView) return callback?.(new Error('gh failed'));
+        return callback?.(null, {
+          stdout: JSON.stringify({
+            owner: { login: 'o' },
+            name: 'r',
+            defaultBranchRef: { name: 'main' },
+          }),
+          stderr: '',
+        });
+      }
+      if (cmd.includes('rules/branches')) {
+        if (h.failRules) return callback?.(new Error('api failed'));
+        return callback?.(null, { stdout: JSON.stringify(h.ruleTypes), stderr: '' });
+      }
+      return callback?.(null, { stdout: '', stderr: '' });
+    },
+  };
+});
+
+import {
+  checkAppCompliance,
+  buildComplianceRefusalMessage,
+  COMPLIANCE_SKIP_ENV,
+} from '@/services/app-compliance-service.js';
+
+describe('app compliance gate (#90)', () => {
+  beforeEach(() => {
+    h.gitignoreExists = true;
+    h.failRepoView = false;
+    h.ruleTypes = ['required_status_checks'];
+    h.failRules = false;
+    delete process.env[COMPLIANCE_SKIP_ENV];
+  });
+  afterEach(() => {
+    delete process.env[COMPLIANCE_SKIP_ENV];
+  });
+
+  it('skips (and passes) when the opt-out env var is set', async () => {
+    process.env[COMPLIANCE_SKIP_ENV] = '1';
+    h.gitignoreExists = false; // would otherwise fail
+    const r = await checkAppCompliance('/app');
+    expect(r.skipped).toBe(true);
+    expect(r.compliant).toBe(true);
+    expect(r.violations).toHaveLength(0);
+  });
+
+  it('passes when .gitignore present and branch protection present', async () => {
+    const r = await checkAppCompliance('/app');
+    expect(r.compliant).toBe(true);
+    expect(r.skipped).toBe(false);
+  });
+
+  it('flags a missing .gitignore as a violation', async () => {
+    h.gitignoreExists = false;
+    const r = await checkAppCompliance('/app');
+    expect(r.compliant).toBe(false);
+    expect(r.violations.map((v) => v.check)).toContain('gitignore');
+  });
+
+  it('flags verified-absent branch protection as a violation', async () => {
+    h.ruleTypes = ['pull_request']; // no required_status_checks
+    const r = await checkAppCompliance('/app');
+    expect(r.compliant).toBe(false);
+    expect(r.violations.map((v) => v.check)).toContain('branch-protection');
+  });
+
+  it('does NOT flag branch protection when it cannot be determined (gh error)', async () => {
+    h.failRules = true; // API error → unverified, not a violation
+    const r = await checkAppCompliance('/app');
+    expect(r.compliant).toBe(true);
+    expect(r.violations.map((v) => v.check)).not.toContain('branch-protection');
+  });
+
+  it('refusal message names each violation and the opt-out env var', () => {
+    const msg = buildComplianceRefusalMessage('/app', [
+      { check: 'gitignore', message: 'no gitignore', remediation: 'add one' },
+    ]);
+    expect(msg).toContain('/app');
+    expect(msg).toContain('no gitignore');
+    expect(msg).toContain('add one');
+    expect(msg).toContain(COMPLIANCE_SKIP_ENV);
+  });
+});


### PR DESCRIPTION
Completes #3881. protoMaker won't silently run an app that doesn't meet the fleet standard.

## Change
- **`AppComplianceService.checkAppCompliance(projectPath)`** — verifies the repo has a `.gitignore` and that the **default branch requires status checks** before merge. Conservative: a check is a *violation* only when positively verified absent; undeterminable cases (no remote / gh unavailable / API error) are *unverified* and do **not** block (so legitimate local/limited-permission repos still run).
- **Gate** wired at the top of `AutoModeService.startAutoLoopForProject` — before the synchronous slot claim (no TOCTOU reopen; a refusal leaves no loop state). Throws a clear message listing each violation + remediation.
- **Hard-refuse by default**, with escape hatch **`AUTOMAKER_SKIP_COMPLIANCE_CHECK=1`** — we suggest the standard, we don't fight an operator's existing system.
- Server test `setup.ts` sets the skip var so unit tests (mock paths) aren't blocked; the compliance test manages the var itself to exercise the real logic.

## Tests
6 compliance tests; the auto-mode + lead-engineer suites that call `startAutoLoopForProject` pass again with the setup skip. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)