### PR TITLE
docs: document concurrency resolution chain + cap env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -642,6 +642,8 @@ Use `list_workflows` MCP tool to discover available workflows for a project. Pro
 - `ALLOWED_ROOT_DIRECTORY` - Restrict file operations to specific directory
 - `AUTOMAKER_MOCK_AGENT=true` - Enable mock agent mode for CI testing
 - `AUTOMAKER_AUTO_LOGIN=true` - Skip login prompt in development (disabled when NODE_ENV=production)
+- `AUTOMAKER_MAX_CONCURRENCY` - Instance-wide hard cap on concurrent agents (clamped 1-20, default 2). The ceiling all per-project/global concurrency settings are capped by. See `docs/reference/auto-mode.md` → Concurrency resolution.
+- `AUTOMAKER_SKIP_COMPLIANCE_CHECK=1` - Bypass the app-compliance gate that otherwise refuses to run auto-mode on apps missing the fleet standard (branch protection, .gitignore). Escape hatch only.
 - `VITE_HOSTNAME` - Hostname for frontend API URLs (default: localhost)
 - `LANGFUSE_PUBLIC_KEY` - Langfuse public key (optional, enables observability)
 - `LANGFUSE_SECRET_KEY` - Langfuse secret key (optional, enables observability)

--- a/docs/reference/auto-mode.md
+++ b/docs/reference/auto-mode.md
@@ -222,7 +222,7 @@ Effective concurrency for an auto-loop is fully config-driven. It is resolved by
 1. **Caller override** — the `maxConcurrency` passed to `POST /api/auto-mode/start` (or `startAutoLoopForProject`).
 2. **`AUTOMAKER_MAX_CONCURRENCY`** (env) — the **instance-wide hard cap**. Read once at startup by `getMaxSystemConcurrency()`, clamped to `[1, 20]`, default `2`. Nothing below can exceed it. Set it in the repo-root `.env` (the prod LaunchAgent sources it); changing it requires a server restart.
 3. **`systemMaxConcurrency`** (global setting, `data/settings.json`) — admin UI cap for the whole instance; must be `≤ AUTOMAKER_MAX_CONCURRENCY`.
-4. **`autoModeByWorktree["{projectId}::{branchName}"].maxConcurrency`** — per-project / per-worktree limit (with optional `minConcurrency` fair-share reservation, default `1`).
+4. **`autoModeByWorktree["{projectId}::{branchName}"].maxConcurrency`** — per-project / per-worktree limit (with optional `minConcurrency` fair-share reservation, default `1`). Here `projectId` is the **registered project id** (`settings.projects[].id`, resolved by `path === projectPath`), not the `projectPath` itself — and distinct from the auto-loop coordinator key `projectPath::branchName`. See `FeatureScheduler.resolveMaxConcurrency()` (`feature-scheduler.ts`).
 5. **`maxConcurrency`** (global setting) — default applied when no per-project value is set.
 6. **`DEFAULT_MAX_CONCURRENCY`** — code fallback (`1`).
 

--- a/docs/reference/auto-mode.md
+++ b/docs/reference/auto-mode.md
@@ -214,6 +214,22 @@ Settings read from `workflowSettings` in `.automaker/settings.json`:
 | `mcpServers`          | MCP server config passed to Claude SDK       | —       |
 | `planningMode`        | Enable plan approval gating                  | —       |
 
+### Concurrency resolution
+
+Effective concurrency for an auto-loop is fully config-driven. It is resolved by
+`FeatureScheduler.resolveMaxConcurrency()` highest-precedence first:
+
+1. **Caller override** — the `maxConcurrency` passed to `POST /api/auto-mode/start` (or `startAutoLoopForProject`).
+2. **`AUTOMAKER_MAX_CONCURRENCY`** (env) — the **instance-wide hard cap**. Read once at startup by `getMaxSystemConcurrency()`, clamped to `[1, 20]`, default `2`. Nothing below can exceed it. Set it in the repo-root `.env` (the prod LaunchAgent sources it); changing it requires a server restart.
+3. **`systemMaxConcurrency`** (global setting, `data/settings.json`) — admin UI cap for the whole instance; must be `≤ AUTOMAKER_MAX_CONCURRENCY`.
+4. **`autoModeByWorktree["{projectId}::{branchName}"].maxConcurrency`** — per-project / per-worktree limit (with optional `minConcurrency` fair-share reservation, default `1`).
+5. **`maxConcurrency`** (global setting) — default applied when no per-project value is set.
+6. **`DEFAULT_MAX_CONCURRENCY`** — code fallback (`1`).
+
+A **global fair-share gate** (`ConcurrencyManager`) then ensures the sum of running agents across all projects never exceeds the hard cap, distributing slots across competing projects (each guaranteed its `minConcurrency`).
+
+**Safety**: the hard cap exists because each agent allocates significant RAM (Sonnet ~4 GB, Opus ~6 GB). Heap-usage guards pause new agents at 80% and abort at 90%. Raise `AUTOMAKER_MAX_CONCURRENCY` only with headroom for the host.
+
 ## Prometheus Metrics
 
 | Metric                      | Type      | Description                             |


### PR DESCRIPTION
Per the ask to make concurrency "config-driven and documented" — it was already config-driven, this writes it down.

- `docs/reference/auto-mode.md` → new **Concurrency resolution** section: full precedence chain (caller override → `AUTOMAKER_MAX_CONCURRENCY` hard cap → `systemMaxConcurrency` → per-project `autoModeByWorktree` → global `maxConcurrency` → fallback), the global fair-share gate, and the RAM/heap safety rationale for the cap.
- `CLAUDE.md` env list: adds `AUTOMAKER_MAX_CONCURRENCY` (the instance hard cap) and `AUTOMAKER_SKIP_COMPLIANCE_CHECK` (the #90 opt-out).

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added docs for two instance-level environment variables to control auto-loop concurrency and to bypass compliance checks.
  * Added a "Concurrency resolution" section explaining how effective concurrency is determined (override order, hard caps, per-worktree and global limits), and describing fair-share gating and RAM/safety rationale.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->