### PR TITLE
feat(github): add_github_comment — post comments to existing issues (#3817)

### DIFF
--- a/apps/server/src/routes/github/index.ts
+++ b/apps/server/src/routes/github/index.ts
@@ -26,6 +26,7 @@ import { createRotateSecretHandler } from './routes/rotate-secret.js';
 
 const webhookRateLimiter = createRateLimiter();
 import { createMergePRHandler } from './routes/merge-pr.js';
+import { createAddCommentHandler } from './routes/add-comment.js';
 import { createCheckPRStatusHandler } from './routes/check-pr-status.js';
 import { createPRReviewCommentsHandler } from './routes/pr-review-comments.js';
 import { createResolvePRCommentHandler } from './routes/resolve-pr-comment.js';
@@ -92,6 +93,7 @@ export function createGitHubRoutes(
 
   // PR merge operations
   router.post('/merge-pr', validatePathParams('projectPath'), createMergePRHandler());
+  router.post('/comment', validatePathParams('projectPath'), createAddCommentHandler());
   router.post(
     '/check-pr-status',
     validatePathParams('projectPath'),

--- a/apps/server/src/routes/github/routes/add-comment.ts
+++ b/apps/server/src/routes/github/routes/add-comment.ts
@@ -1,0 +1,81 @@
+/**
+ * POST /comment endpoint
+ * Post a comment to an existing GitHub issue.
+ */
+
+import type { Request, Response } from 'express';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createLogger } from '@protolabsai/utils';
+import { createGitExecEnv } from '@protolabsai/git-utils';
+import { getErrorMessage, logError } from './common.js';
+import { checkGitHubRemote } from './check-github-remote.js';
+
+const execFileAsync = promisify(execFile);
+const logger = createLogger('AddGitHubComment');
+
+interface AddCommentRequest {
+  projectPath: string;
+  issueNumber: number;
+  body: string;
+}
+
+export function createAddCommentHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, issueNumber, body } = req.body as AddCommentRequest;
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+      if (
+        issueNumber === undefined ||
+        typeof issueNumber !== 'number' ||
+        !Number.isInteger(issueNumber) ||
+        issueNumber <= 0
+      ) {
+        res.status(400).json({
+          success: false,
+          error: 'issueNumber is required and must be a positive integer',
+        });
+        return;
+      }
+      if (!body || typeof body !== 'string' || !body.trim()) {
+        res.status(400).json({ success: false, error: 'body is required' });
+        return;
+      }
+
+      // Confirm this is a GitHub repo and resolve owner/repo.
+      const remote = await checkGitHubRemote(projectPath);
+      if (!remote.hasGitHubRemote || !remote.owner || !remote.repo) {
+        res.status(400).json({ success: false, error: 'Project does not have a GitHub remote' });
+        return;
+      }
+
+      // execFile with an argument array — the body is passed as a discrete arg and
+      // is NEVER interpreted by a shell, so arbitrary comment content (backticks,
+      // $(...), quotes, newlines) is safe. `gh issue comment` prints the comment URL.
+      const { stdout } = await execFileAsync(
+        'gh',
+        [
+          'issue',
+          'comment',
+          String(issueNumber),
+          '--repo',
+          `${remote.owner}/${remote.repo}`,
+          '--body',
+          body,
+        ],
+        { cwd: projectPath, env: createGitExecEnv(), timeout: 20000 }
+      );
+
+      const commentUrl = stdout.trim();
+      logger.info(`Posted comment to ${remote.owner}/${remote.repo}#${issueNumber}`);
+      res.json({ success: true, issueNumber, commentUrl });
+    } catch (error) {
+      logError(error, 'Add GitHub comment failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/routes/github/routes/add-comment.ts
+++ b/apps/server/src/routes/github/routes/add-comment.ts
@@ -25,8 +25,10 @@ export function createAddCommentHandler() {
     try {
       const { projectPath, issueNumber, body } = req.body as AddCommentRequest;
 
-      if (!projectPath) {
-        res.status(400).json({ success: false, error: 'projectPath is required' });
+      if (typeof projectPath !== 'string' || !projectPath.trim()) {
+        res
+          .status(400)
+          .json({ success: false, error: 'projectPath is required (non-empty string)' });
         return;
       }
       if (

--- a/apps/server/tests/unit/routes/github/add-comment.test.ts
+++ b/apps/server/tests/unit/routes/github/add-comment.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the add_github_comment route handler (#3817).
+ *
+ *   - validates projectPath / issueNumber / body
+ *   - 400 when the project has no GitHub remote
+ *   - success posts via `gh issue comment` and returns the comment URL
+ *   - the body is passed as a DISCRETE execFile arg (never shell-interpolated)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+
+const h = vi.hoisted(() => ({
+  remote: { hasGitHubRemote: true, owner: 'acme', repo: 'widgets' } as Record<string, unknown>,
+  execArgs: [] as unknown[][],
+  execStdout: 'https://github.com/acme/widgets/issues/42#issuecomment-1',
+  execError: null as Error | null,
+}));
+
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual('@protolabsai/utils');
+  return {
+    ...(actual as object),
+    createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+vi.mock('@protolabsai/git-utils', () => ({ createGitExecEnv: () => ({}) }));
+
+vi.mock('@/routes/github/routes/check-github-remote.js', () => ({
+  checkGitHubRemote: vi.fn(async () => h.remote),
+}));
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    execFile: (
+      _cmd: string,
+      args: unknown[],
+      _opts: unknown,
+      cb?: (err: unknown, res?: { stdout: string; stderr: string }) => void
+    ) => {
+      h.execArgs.push(args);
+      const callback = typeof _opts === 'function' ? (_opts as typeof cb) : cb;
+      if (h.execError) return callback?.(h.execError);
+      callback?.(null, { stdout: h.execStdout, stderr: '' });
+    },
+  };
+});
+
+import { createAddCommentHandler } from '@/routes/github/routes/add-comment.js';
+
+function makeRes() {
+  const res: Partial<Response> & { statusCode: number; body: unknown } = {
+    statusCode: 200,
+    body: undefined,
+  };
+  res.status = vi.fn((c: number) => {
+    res.statusCode = c;
+    return res as Response;
+  }) as unknown as Response['status'];
+  res.json = vi.fn((b: unknown) => {
+    res.body = b;
+    return res as Response;
+  }) as unknown as Response['json'];
+  return res;
+}
+
+async function call(body: unknown) {
+  const handler = createAddCommentHandler();
+  const res = makeRes();
+  await handler({ body } as Request, res as Response);
+  return res;
+}
+
+describe('add_github_comment route (#3817)', () => {
+  beforeEach(() => {
+    h.remote = { hasGitHubRemote: true, owner: 'acme', repo: 'widgets' };
+    h.execArgs = [];
+    h.execStdout = 'https://github.com/acme/widgets/issues/42#issuecomment-1';
+    h.execError = null;
+  });
+
+  it('400 when projectPath missing', async () => {
+    const res = await call({ issueNumber: 42, body: 'hi' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('400 when issueNumber is not a positive integer', async () => {
+    expect((await call({ projectPath: '/p', issueNumber: 0, body: 'hi' })).statusCode).toBe(400);
+    expect((await call({ projectPath: '/p', issueNumber: 1.5, body: 'hi' })).statusCode).toBe(400);
+    expect((await call({ projectPath: '/p', body: 'hi' })).statusCode).toBe(400);
+  });
+
+  it('400 when body is empty', async () => {
+    expect((await call({ projectPath: '/p', issueNumber: 42, body: '   ' })).statusCode).toBe(400);
+  });
+
+  it('400 when the project has no GitHub remote', async () => {
+    h.remote = { hasGitHubRemote: false };
+    const res = await call({ projectPath: '/p', issueNumber: 42, body: 'hi' });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('posts the comment and returns the comment URL', async () => {
+    const res = await call({ projectPath: '/p', issueNumber: 42, body: 'looks good' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({
+      success: true,
+      issueNumber: 42,
+      commentUrl: 'https://github.com/acme/widgets/issues/42#issuecomment-1',
+    });
+  });
+
+  it('passes the body as a discrete arg (no shell interpolation)', async () => {
+    const danger = 'malicious $(rm -rf /) `whoami` "quotes"';
+    await call({ projectPath: '/p', issueNumber: 42, body: danger });
+    const args = h.execArgs[0] as string[];
+    // gh issue comment 42 --repo acme/widgets --body "<danger>"
+    expect(args).toContain('comment');
+    expect(args).toContain('42');
+    expect(args).toContain('acme/widgets');
+    // The body is present verbatim as its own array element — never concatenated
+    // into a shell string.
+    expect(args).toContain(danger);
+  });
+});

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -809,6 +809,13 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         waitForCI: args.waitForCI ?? true,
       });
 
+    case 'add_github_comment':
+      return apiCall('/github/comment', {
+        projectPath: args.projectPath,
+        issueNumber: args.issueNumber,
+        body: args.body,
+      });
+
     case 'check_pr_status':
       return apiCall('/github/check-pr-status', {
         projectPath: args.projectPath,

--- a/packages/mcp-server/src/tools/git-tools.ts
+++ b/packages/mcp-server/src/tools/git-tools.ts
@@ -235,11 +235,13 @@ export const gitTools: Tool[] = [
           description: 'Absolute path to the project directory',
         },
         issueNumber: {
-          type: 'number',
+          type: 'integer',
+          minimum: 1,
           description: 'GitHub issue number to comment on',
         },
         body: {
           type: 'string',
+          minLength: 1,
           description: 'Comment body (supports markdown)',
         },
       },

--- a/packages/mcp-server/src/tools/git-tools.ts
+++ b/packages/mcp-server/src/tools/git-tools.ts
@@ -223,4 +223,27 @@ export const gitTools: Tool[] = [
       required: ['projectPath', 'threadId'],
     },
   },
+  {
+    name: 'add_github_comment',
+    description:
+      'Post a comment to an existing GitHub issue. Returns the comment URL and confirmation.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          description: 'Absolute path to the project directory',
+        },
+        issueNumber: {
+          type: 'number',
+          description: 'GitHub issue number to comment on',
+        },
+        body: {
+          type: 'string',
+          description: 'Comment body (supports markdown)',
+        },
+      },
+      required: ['projectPath', 'issueNumber', 'body'],
+    },
+  },
 ];


### PR DESCRIPTION
Implements `add_github_comment` end to end. The crew's #3873 added only the tool schema (no handler, no test) and Quinn correctly blocked it; this completes it.

- **Route** `POST /api/github/comment` — validates `projectPath`/`issueNumber`/`body`, confirms a GitHub remote, posts via `gh issue comment` using **`execFile` with an arg array** so the body can't shell-inject (safe for backticks/`$(…)`/quotes/newlines).
- **MCP tool** — `add_github_comment` schema + dispatch to `/github/comment`.
- **6 unit tests** — validation, no-remote 400, success returns comment URL, and the body-as-discrete-arg security property.

Closes #3817. Supersedes #3873 (will close that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add ability to post comments to existing GitHub issues via a new API endpoint and MCP tool; returns confirmation with the comment URL
  * Input validation for project path, issue number, and comment text
  
* **Tests**
  * Add unit tests covering validation, missing GitHub remote, successful posting, and the underlying command invocation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->