### PR TITLE
docs: merge gate, compliance gate, issue dedupe, add_github_comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -712,7 +712,7 @@ The MCP server exposes ~159 tools organized by category:
 
 **Agent Templates:** Removed — agent spawning is handled by Claude Code's native Agent tool.
 
-**GitHub Operations:** `merge_pr`, `check_pr_status`, `resolve_pr_threads`
+**GitHub Operations:** `merge_pr`, `check_pr_status`, `resolve_pr_threads`, `add_github_comment` (post a comment to an existing issue)
 
 **Observability:** `langfuse_list_traces`, `langfuse_get_trace`, `langfuse_get_costs`, `langfuse_score_trace`, `langfuse_list_datasets`, `langfuse_add_to_dataset`
 

--- a/docs/internal/index.md
+++ b/docs/internal/index.md
@@ -82,6 +82,8 @@ This directory is NOT included in the public VitePress build. Content here is fo
 - [Worktree Recovery Service](./server/worktree-recovery-service.md)
 - [Merge Eligibility Service](./server/merge-eligibility-service.md)
 - [GitHub Merge Service](./server/github-merge-service.md)
+- [App Compliance Gate](./server/app-compliance.md)
+- [Issue Dedupe](./server/issue-dedupe.md)
 - [CodeRabbit Resolver](./server/coderabbit-resolver-service.md)
 - [Reactive Spawner](./server/reactive-spawner.md)
 - [Project Service](./server/project-service.md)

--- a/docs/internal/server/app-compliance.md
+++ b/docs/internal/server/app-compliance.md
@@ -1,0 +1,31 @@
+# App Compliance Gate
+
+Before protoMaker runs auto-mode for a managed app, it verifies the app meets the fleet standard — and **refuses to run** (with a clear operator message) if it doesn't, rather than silently operating an under-protected repo.
+
+## What it checks
+
+`checkAppCompliance(projectPath)` (`apps/server/src/services/app-compliance-service.ts`) returns `{ compliant, skipped, violations[] }`:
+
+| Check               | Violation when…                                               | Remediation surfaced                                               |
+| ------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `gitignore`         | the repo has no `.gitignore`                                  | add one (the create-protolab recommended baseline)                 |
+| `branch-protection` | the default branch has **verified** no required status checks | apply branch protection requiring CI (the create-protolab ruleset) |
+
+**Conservative by design:** a check counts as a _violation_ only when it is positively verified absent. When it can't be determined — no remote, `gh` unavailable, or an API/permission error — it is reported as _unverified_ and does **not** block. Refusing to run a legitimate local or limited-permission repo would be worse than the gap.
+
+## Where it's enforced
+
+The gate runs at the top of `AutoModeService.startAutoLoopForProject()` — before the synchronous slot claim, so the `await` doesn't reopen the TOCTOU window and a refusal leaves no loop state. On a violation it throws a message listing each problem + its fix; the start route surfaces that to the operator.
+
+## Opt-out
+
+Set **`AUTOMAKER_SKIP_COMPLIANCE_CHECK=1`** (truthy) to bypass the gate entirely. We suggest the standard; we don't fight an operator's existing system. The server test setup sets this so unit tests aren't blocked.
+
+## Relationship to the merge gate
+
+The compliance gate is **defense-in-depth**, not the primary safety. Even on a non-compliant repo, the platform-owned [merge gate](./github-merge-service.md) still refuses to merge a PR with pending or failing checks. The compliance gate ensures the _GitHub-side_ protections (required checks, branch protection) and repo hygiene (`.gitignore`) are also in place before the crew runs.
+
+## Key files
+
+- `apps/server/src/services/app-compliance-service.ts` — `checkAppCompliance`, `buildComplianceRefusalMessage`, `COMPLIANCE_SKIP_ENV`
+- `apps/server/src/services/auto-mode-service.ts` — gate at `startAutoLoopForProject()`

--- a/docs/internal/server/github-merge-service.md
+++ b/docs/internal/server/github-merge-service.md
@@ -1,22 +1,29 @@
 # GitHub Merge Service
 
-Merges pull requests via the `gh` CLI with CI status awareness, auto-merge support, and CodeRabbit failure tolerance.
+Merges pull requests via the `gh` CLI with CI status awareness and CodeRabbit failure tolerance. **The platform owns the merge decision** — it never enables GitHub-native auto-merge.
 
 ## Overview
 
 `GitHubMergeService` is the low-level PR merge executor used by `GitWorkflowService`. It:
 
-- **Checks CI status** before attempting merge
-- **Enables auto-merge** when checks are still pending (lets GitHub merge once CI passes)
+- **Checks CI status** before attempting merge (`checkPRStatus` over the full status-check rollup; `allChecksPassed = 0 failed && 0 pending`)
+- **Never enables GitHub auto-merge.** `gh pr merge --auto` was removed (see "Why no auto-merge"). On pending checks it reports `checksPending` and does **not** merge; the caller (e.g. the REVIEW phase) re-checks later.
+- **Merges explicitly only when every check is green** — `gh pr merge --<strategy>` with no `--auto`.
 - **Treats CodeRabbit FAILURE as transient** — counts it as pending, not a hard failure
-- **Verifies PR state** after the merge command to confirm success vs auto-merge-pending
+- **Verifies PR state** after the merge command to confirm it actually merged
+
+## Why no auto-merge
+
+GitHub-native auto-merge (`gh pr merge --auto`) honors only the repo's **required** branch-protection checks. A check that isn't in the required set (e.g. a newly-added linter) can be **failing** while auto-merge still merges the moment the required ones go green — exactly how a broken PR once landed (#3878 / #3881). Delegating the merge to GitHub also bypasses this service's own stricter gate.
+
+So the platform owns the merge end to end: it merges **only** via an explicit `gh pr merge` after confirming **all** non-soft checks are complete and green. This holds for every managed app regardless of how complete that repo's required-checks list is. (The same applies to epic→base PRs in `completion-detector-service`, which route through `mergePR` rather than `--auto`.)
 
 ## Architecture
 
 ```text
 GitHubMergeService
-  ├── checkPRStatus()    — gh pr view → CI check breakdown
-  ├── mergePR()          — CI gate + gh pr merge --auto
+  ├── checkPRStatus()    — gh pr view → CI check breakdown (allChecksPassed = 0 failed && 0 pending)
+  ├── mergePR()          — CI gate + explicit gh pr merge (NO --auto)
   └── canMergePR()       — lightweight eligibility check
 ```
 
@@ -29,15 +36,16 @@ mergePR(workDir, prNumber, strategy, waitForCI)
       → Classify each check: passed / failed / pending
       → CodeRabbit FAILURE → reclassified as pending (transient)
   → If pendingCount > 0:
-      → gh pr merge --auto  (GitHub merges when checks pass)
-      → return { success: true, autoMergeEnabled: true, checksPending: true }
+      → DO NOT merge, DO NOT enable auto-merge
+      → return { success: false, checksPending: true, autoMergeEnabled: false }
+        (the REVIEW phase polls and retries once checks are green)
   → If failedCount > 0:
       → return { success: false, checksFailed: true, failedChecks: [...] }
   → If all checks pass:
-      → gh pr merge --<strategy> --auto
+      → gh pr merge --<strategy>     ← explicit, immediate, no --auto
       → Verify PR state via gh pr view --json state
       → MERGED  → { success: true, mergeCommitSha }
-      → OPEN    → { success: false, autoMergeEnabled: true }  ← waiting for checks
+      → OPEN    → { success: false }  ← branch protection still blocking; retry later
       → Other   → { success: false, error: "unexpected state" }
 ```
 

--- a/docs/internal/server/issue-dedupe.md
+++ b/docs/internal/server/issue-dedupe.md
@@ -1,0 +1,37 @@
+# Issue Dedupe
+
+Stops the triage / self-improvement automation from re-filing issues that already exist. Before a producer opens a new System Improvement / auto-remediation feature, it checks against open features and skips (or respects a cooldown) on a match.
+
+## The service
+
+`IssueDedupeService.check(projectPath, title, fingerprint?, sourceId?)` (`apps/server/src/services/issue-dedupe-service.ts`) returns `{ isDuplicate, match?, noMatch? }`, evaluated in priority order:
+
+1. **Fingerprint** (exact) — an open feature whose **description or title** contains the marker `fp:{fingerprint}`. Strongest signal.
+2. **Source ID** (exact) — an open feature whose `githubIssueNumber` equals `sourceId`.
+3. **Title similarity** (fuzzy) — Jaccard word-set overlap above threshold, after stripping common automation prefixes (`[Auto]`, `System Improvement:`, etc.). Only matches automation-filed titles, not user features.
+4. **Cooldown** — if a _recently closed_ feature is similar, suppress re-filing for a window (avoids immediately recreating a closed-as-duplicate).
+
+The open-feature list is fetched via `featureLoader.getAll` and cached briefly (TTL); a fetch failure fails open (returns no match) so a transient outage never blocks a legitimate filing.
+
+## The fingerprint marker convention
+
+For the exact-fingerprint path to work, the filing producer must **stamp** the marker into the feature it creates. Producers append a hidden HTML comment to the description:
+
+- `friction-tracker-service` → `<!-- fp:friction:${pattern} -->` (and passes `friction:${pattern}` to `check()`)
+- `hitl-pattern-analysis-service` → `<!-- fp:hitl:${signature} -->` (and passes `hitl:${signature}` to `check()`)
+
+The marker is invisible in rendered markdown but `findFingerprintMatch` matches it via `description.includes('fp:...')`. Without stamping, only the title-similarity + cooldown paths apply.
+
+## Where it's wired
+
+Both producers call `issueDedupe.check(...)` **before** creating the feature and skip on `isDuplicate` or `noMatch.cooldown`:
+
+- `apps/server/src/services/friction-tracker-service.ts` — `maybeFileImprovement`
+- `apps/server/src/services/hitl-pattern-analysis-service.ts` — `doMaybeFileFeature`
+
+A legacy exact-title `findByTitle` check remains as a second line of defense (survives restarts).
+
+## Key files
+
+- `apps/server/src/services/issue-dedupe-service.ts` — the service
+- `apps/server/tests/unit/services/issue-dedupe-service.test.ts` — match-priority + cooldown coverage


### PR DESCRIPTION
Documents the work that landed this session: the platform-owned merge gate (#88, github-merge-service.md was stale), the app-compliance gate (#90, new), issue dedupe (#3850, new), and adds `add_github_comment` to the CLAUDE.md MCP tools list. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)