### PR TITLE
fix(qa): stop Quinn CHANGES_REQUESTED from blocking on pending CI (#3886)

### DIFF
--- a/.claude/commands/quinn.md
+++ b/.claude/commands/quinn.md
@@ -545,6 +545,14 @@ Gaps: [count]
 - **WARN** — All critical checks passed but gaps exist or medium/low issues found. Release is acceptable with noted caveats.
 - **FAIL** — One or more critical checks failed. Release has verified defects that need remediation.
 
+### Pending CI is never a FAIL (#3886)
+
+A blocking verdict must reflect a **real defect**, never a timing artifact. When you review a PR whose diff you have no objection to but CI has not finished:
+
+- Do **not** return `FAIL` / submit a `CHANGES_REQUESTED` review solely because CI is queued, pending, or in progress. A `CHANGES_REQUESTED` blocks the merge until manually dismissed, and pushing a fix re-triggers both CI and your review — creating a loop.
+- Either **wait** until all checks are terminal before forming a verdict, or return a non-blocking **WARN** (or a `COMMENT`-only review) noting the diff looks good pending CI. Record the pending checks under **Gaps**, not **Failed**.
+- Only escalate to `FAIL` once checks are terminal and one actually failed, or you find a genuine diff defect.
+
 **Severity definitions:**
 
 - **CRITICAL** — Service not wired, endpoint returns 500, types don't compile, data loss risk

--- a/apps/server/src/services/maintenance/checks/auto-dismiss-stale-bot-reviews-check.ts
+++ b/apps/server/src/services/maintenance/checks/auto-dismiss-stale-bot-reviews-check.ts
@@ -10,8 +10,10 @@
  * `mergeStateStatus: BLOCKED` even after all flagged concerns are
  * resolved and CI is green — a maintainer has to manually dismiss.
  *
- * This check identifies the exact "stale" shape and dismisses the
- * blocking review automatically:
+ * This check identifies two "no longer reflects a real defect" shapes and
+ * dismisses the blocking review automatically.
+ *
+ * Path A — superseded stale review (#3732):
  *
  *   1. PR is OPEN
  *   2. Latest CHANGES_REQUESTED review is from a `[bot]` user
@@ -20,10 +22,25 @@
  *      on a more recent commit (proves it's seen and acked the fix)
  *   5. All required CI checks on the current head are SUCCESS
  *
- * When all 5 hold, the stale CHANGES_REQUESTED is dismissed with a
- * message citing the follow-up review and the head SHA.
+ * Path B — CI-pending timing artifact (#3886):
  *
- * See: protoLabsAI/protoMaker#3732
+ *   1. PR is OPEN
+ *   2. A CHANGES_REQUESTED review is from a `[bot]` user, ON the current
+ *      head (not stale — no new commit, no follow-up review)
+ *   3. The review body cites pending/queued CI as the *only* blocker
+ *      (e.g. "CI checks still queued — I cannot approve until all checks
+ *      resolve") rather than a real diff finding
+ *   4. All required CI checks on the current head are now SUCCESS
+ *
+ * Path B handles the case where a QA reviewer (protoquinn) reviewed before
+ * CI finished and hard-failed purely on "CI pending." Once CI settles green
+ * the verdict no longer reflects a defect, but Path A never fires (the review
+ * is on head, with no superseding follow-up), so the PR would sit blocked.
+ *
+ * When either shape holds, the blocking CHANGES_REQUESTED is dismissed with a
+ * message citing the reason and the head SHA.
+ *
+ * See: protoLabsAI/protoMaker#3732, protoLabsAI/protoMaker#3886
  */
 
 import { execFile } from 'child_process';
@@ -53,6 +70,7 @@ interface PRReview {
   state: 'APPROVED' | 'CHANGES_REQUESTED' | 'COMMENTED' | 'DISMISSED' | 'PENDING';
   commit_id: string | null;
   submitted_at: string | null;
+  body?: string | null;
 }
 
 interface PRCheck {
@@ -69,6 +87,31 @@ interface RepoCoords {
 /** Identify a user that's a GitHub App / bot (login ends with `[bot]`). */
 function isBot(login: string): boolean {
   return login.endsWith('[bot]');
+}
+
+/**
+ * Phrasings a QA bot uses when its CHANGES_REQUESTED is blocked *solely* on
+ * CI not having finished yet — not on a real diff finding (#3886).
+ * Matching any one, combined with the caller's "CI is now green" guard, is a
+ * strong, conservative signal that the verdict was a timing artifact.
+ */
+const CI_PENDING_ONLY_PATTERNS: RegExp[] = [
+  /cannot\s+approve\s+until\b[^.]*\b(check|ci)/i,
+  /once\s+ci\b[^.]*\bgreen\b/i,
+  /waiting\s+(on|for)\s+ci\b/i,
+  /\bci\s+(checks?\s+)?(are\s+)?(still\s+)?(queued|pending|running|in[-\s]?progress)\b/i,
+  /\bchecks?\s+(are\s+)?(still\s+)?(queued|pending|running|in[-\s]?progress)\b/i,
+  /\bci\s+(has\s+not|hasn't|not\s+yet)\s+(completed|finished|resolved)\b/i,
+];
+
+/**
+ * True when the review body attributes the block to pending/queued CI only.
+ * Empty/missing bodies never match (we never dismiss without an explicit
+ * CI-pending statement).
+ */
+function isCiPendingOnlyReview(body: string | null | undefined): boolean {
+  if (!body || !body.trim()) return false;
+  return CI_PENDING_ONLY_PATTERNS.some((re) => re.test(body));
 }
 
 export class AutoDismissStaleBotReviewsCheck implements MaintenanceCheck {
@@ -168,6 +211,38 @@ export class AutoDismissStaleBotReviewsCheck implements MaintenanceCheck {
           dismissed.push(sr.id);
           logger.info(
             `Dismissed stale CHANGES_REQUESTED review ${sr.id} on PR #${pr.number} (bot=${sr.user?.login})`
+          );
+        }
+      }
+    }
+
+    // Path B (#3886): on-head CHANGES_REQUESTED whose body cites only pending
+    // CI as the blocker. Dismiss once CI has settled green — the verdict was a
+    // timing artifact, not a real defect.
+    for (const [_login, list] of byAuthor) {
+      const ciPendingOnHead = list.filter(
+        (r) =>
+          r.state === 'CHANGES_REQUESTED' &&
+          r.commit_id === pr.headRefOid &&
+          !dismissed.includes(r.id) &&
+          isCiPendingOnlyReview(r.body)
+      );
+      if (ciPendingOnHead.length === 0) continue;
+
+      const checksClean = await this.allChecksGreen(projectPath, pr.number);
+      if (!checksClean) continue;
+
+      for (const sr of ciPendingOnHead) {
+        const ok = await this.dismiss(
+          projectPath,
+          pr.number,
+          sr.id,
+          `Auto-dismissed: review blocked only on pending CI, which is now green on head ${pr.headRefOid.slice(0, 7)} (#3886).`
+        );
+        if (ok) {
+          dismissed.push(sr.id);
+          logger.info(
+            `Dismissed CI-pending CHANGES_REQUESTED review ${sr.id} on PR #${pr.number} (bot=${sr.user?.login})`
           );
         }
       }

--- a/apps/server/tests/unit/services/maintenance/auto-dismiss-stale-bot-reviews-check.test.ts
+++ b/apps/server/tests/unit/services/maintenance/auto-dismiss-stale-bot-reviews-check.test.ts
@@ -390,3 +390,155 @@ describe('AutoDismissStaleBotReviewsCheck (#3732)', () => {
     expect(issues).toEqual([]);
   });
 });
+
+describe('AutoDismissStaleBotReviewsCheck — CI-pending timing artifact (#3886)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('dismisses an on-head CHANGES_REQUESTED that cites only pending CI once CI is green', async () => {
+    const head = 'cafe1234cafe1234cafe1234cafe1234cafe1234';
+    const responses = new Map<string, string>();
+    responses.set(
+      'pr list --state open',
+      JSON.stringify([
+        {
+          number: 3884,
+          headRefOid: head,
+          mergeStateStatus: 'BLOCKED',
+          reviewDecision: 'CHANGES_REQUESTED',
+          url: 'https://github.com/protoLabsAI/protoMaker/pull/3884',
+        },
+      ])
+    );
+    responses.set(
+      'pulls/3884/reviews',
+      JSON.stringify([
+        {
+          id: 9001,
+          user: { login: 'protoquinn[bot]' },
+          state: 'CHANGES_REQUESTED',
+          commit_id: head, // on head — not stale
+          submitted_at: '2026-05-26T08:00:00Z',
+          body: 'Diff looks good. VERDICT: FAIL — CI checks still queued; I cannot approve until all checks resolve. Once CI reports green, a re-run of this review will likely reach PASS.',
+        },
+      ])
+    );
+    responses.set(
+      'pr view 3884 --json statusCheckRollup',
+      JSON.stringify({
+        statusCheckRollup: [
+          { name: 'checks', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'build', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'test', status: 'COMPLETED', conclusion: 'SUCCESS' },
+        ],
+      })
+    );
+    responses.set('dismissals', JSON.stringify({ ok: true }));
+
+    const { exec, calls } = buildExec(responses);
+    const check = new AutoDismissStaleBotReviewsCheck(REPO_COORDS, exec);
+
+    const issues = await check.run(PROJECT_PATH);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({
+      checkId: 'auto-dismiss-stale-bot-reviews',
+      severity: 'info',
+      context: { prNumber: 3884, reviewId: 9001, headSha: head },
+    });
+    expect(calls.some((c) => c.args.join(' ').includes('dismissals'))).toBe(true);
+  });
+
+  it('does NOT dismiss an on-head CHANGES_REQUESTED that cites a real defect (no CI-pending phrasing)', async () => {
+    const head = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    const responses = new Map<string, string>();
+    responses.set(
+      'pr list --state open',
+      JSON.stringify([
+        {
+          number: 700,
+          headRefOid: head,
+          mergeStateStatus: 'BLOCKED',
+          reviewDecision: 'CHANGES_REQUESTED',
+          url: 'u',
+        },
+      ])
+    );
+    responses.set(
+      'pulls/700/reviews',
+      JSON.stringify([
+        {
+          id: 1,
+          user: { login: 'protoquinn[bot]' },
+          state: 'CHANGES_REQUESTED',
+          commit_id: head,
+          submitted_at: '2026-05-26T08:00:00Z',
+          body: 'VERDICT: FAIL — CRITICAL: getUser endpoint returns 500 on missing id; add input validation.',
+        },
+      ])
+    );
+    // statusCheckRollup is green, but the body cites a real defect — must NOT dismiss.
+    responses.set(
+      'pr view 700 --json statusCheckRollup',
+      JSON.stringify({
+        statusCheckRollup: [{ name: 'checks', status: 'COMPLETED', conclusion: 'SUCCESS' }],
+      })
+    );
+
+    const { exec, calls } = buildExec(responses);
+    const check = new AutoDismissStaleBotReviewsCheck(REPO_COORDS, exec);
+
+    const issues = await check.run(PROJECT_PATH);
+
+    expect(issues).toEqual([]);
+    expect(calls.every((c) => !c.args.join(' ').includes('dismissals'))).toBe(true);
+  });
+
+  it('does NOT dismiss a CI-pending on-head review while CI is still IN_PROGRESS', async () => {
+    const head = 'feed0000feed0000feed0000feed0000feed0000';
+    const responses = new Map<string, string>();
+    responses.set(
+      'pr list --state open',
+      JSON.stringify([
+        {
+          number: 800,
+          headRefOid: head,
+          mergeStateStatus: 'BLOCKED',
+          reviewDecision: 'CHANGES_REQUESTED',
+          url: 'u',
+        },
+      ])
+    );
+    responses.set(
+      'pulls/800/reviews',
+      JSON.stringify([
+        {
+          id: 1,
+          user: { login: 'protoquinn[bot]' },
+          state: 'CHANGES_REQUESTED',
+          commit_id: head,
+          submitted_at: '2026-05-26T08:00:00Z',
+          body: 'CI checks still queued — I cannot approve until all checks resolve.',
+        },
+      ])
+    );
+    responses.set(
+      'pr view 800 --json statusCheckRollup',
+      JSON.stringify({
+        statusCheckRollup: [
+          { name: 'checks', status: 'COMPLETED', conclusion: 'SUCCESS' },
+          { name: 'test', status: 'IN_PROGRESS', conclusion: null },
+        ],
+      })
+    );
+
+    const { exec, calls } = buildExec(responses);
+    const check = new AutoDismissStaleBotReviewsCheck(REPO_COORDS, exec);
+
+    const issues = await check.run(PROJECT_PATH);
+
+    expect(issues).toEqual([]);
+    expect(calls.every((c) => !c.args.join(' ').includes('dismissals'))).toBe(true);
+  });
+});

--- a/docs/internal/dev/qa-engineer.md
+++ b/docs/internal/dev/qa-engineer.md
@@ -146,6 +146,12 @@ The verdict is one of:
 | CONDITIONAL PASS | Minor issues found. Safe to promote with follow-up fixes noted. |
 | FAIL             | Blocking issues found. Do not promote until resolved.           |
 
+### Pending CI is never a FAIL (#3886)
+
+A `FAIL` / `CHANGES_REQUESTED` must reflect a real defect, not a timing artifact. If Quinn reviews a PR before CI finishes, it must **not** hard-fail solely because checks are queued or in progress — that blocks the merge on a non-defect and loops (a fix push re-triggers both CI and the review). Instead Quinn waits for checks to be terminal, or returns a non-blocking WARN / `COMMENT` noting "diff looks good pending CI" and records the pending checks under Gaps.
+
+Defense in depth: even if a CI-pending `CHANGES_REQUESTED` slips through, the `auto-dismiss-stale-bot-reviews` maintenance check clears it once CI settles green (Path B). See [Merge Eligibility Service](../server/merge-eligibility-service.md) and the merge gate (the platform never merges on pending/failing checks regardless).
+
 ## agent-browser Setup
 
 ### Install


### PR DESCRIPTION
## Problem

Quinn (protoquinn) reviews a PR **before CI finishes** and returns `CHANGES_REQUESTED` with the reason "CI checks still queued — I cannot approve until all checks resolve." That sets `reviewDecision=CHANGES_REQUESTED` and blocks the merge on a **timing artifact**, not a defect. Worse, pushing a fix re-triggers both CI and Quinn, which may again review before CI completes and FAIL again — a loop. This stale-blocked four PRs this cycle (#3877/#3884/#3879/#3891), each needing a manual dismissal.

## Fix (two layers)

**Prevention (source).** `quinn.md` now states: *pending CI is never a FAIL*. Quinn waits until checks are terminal before forming a verdict, or returns a non-blocking `WARN`/`COMMENT` noting the diff looks good pending CI, recording pending checks under **Gaps** — never **Failed**.

**Defense in depth (recovery).** `auto-dismiss-stale-bot-reviews-check` gains **Path B**: an on-head bot `CHANGES_REQUESTED` whose body cites *only* pending CI as the blocker is auto-dismissed once CI settles green. The existing Path A (#3732, superseded stale review) never fires for this shape because the review is on the current head with no superseding follow-up review.

- `isCiPendingOnlyReview()` matches the known CI-pending phrasings; empty bodies and real-defect bodies never match.
- Path B is gated on `allChecksGreen()` — it holds while any check is still `IN_PROGRESS` and never dismisses if a check failed.

## Tests

3 new tests (dismiss on green / keep on real defect / hold while `IN_PROGRESS`); all 10 in the suite pass. Server typecheck clean.

## Acceptance (from #3886)

- ✅ Quinn never returns `CHANGES_REQUESTED` solely because CI is queued/pending.
- ✅ A PR whose diff Quinn approves of is not left blocked while CI runs; the block clears once checks complete green.

Closes #3886.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot-supplied code review rejections are now automatically dismissed once CI passes, if the only reason for rejection was pending CI checks.

* **Documentation**
  * Clarified review policies: pending or queued CI status must not be treated as grounds for hard rejections. Reviewers should either wait for terminal CI results or provide non-blocking feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->