### PR TITLE
feat(docker): install rabbit-hole-cli (rh) in the server image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,10 +78,15 @@ RUN cd apps/server && find src -name '*.md' -o -name '*.json' | while read f; do
 # RABBIT-HOLE CLI BUILD STAGE
 # =============================================================================
 FROM node:22-trixie-slim AS rh-build
+# RABBIT_HOLE_REF pins the rabbit-hole.io ref the CLI is built from. Defaults to
+# `main` (latest) so the image tracks the published CLI out of the box; override
+# with a tag/commit (e.g. --build-arg RABBIT_HOLE_REF=v1.2.3) for a reproducible
+# build pinned to an immutable ref.
+ARG RABBIT_HOLE_REF=main
 RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
     && apt-get clean && corepack enable
 WORKDIR /src
-RUN git clone --depth=1 --branch main https://github.com/protoLabsAI/rabbit-hole.io .
+RUN git clone --depth=1 --branch "${RABBIT_HOLE_REF}" https://github.com/protoLabsAI/rabbit-hole.io .
 RUN pnpm install --frozen-lockfile --filter @protolabsai/rabbit-hole-cli...
 RUN pnpm --filter @protolabsai/rabbit-hole-cli build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,17 @@ RUN cd apps/server && find src -name '*.md' -o -name '*.json' | while read f; do
     done
 
 # =============================================================================
+# RABBIT-HOLE CLI BUILD STAGE
+# =============================================================================
+FROM node:22-trixie-slim AS rh-build
+RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates \
+    && apt-get clean && corepack enable
+WORKDIR /src
+RUN git clone --depth=1 --branch main https://github.com/protoLabsAI/rabbit-hole.io .
+RUN pnpm install --frozen-lockfile --filter @protolabsai/rabbit-hole-cli...
+RUN pnpm --filter @protolabsai/rabbit-hole-cli build
+
+# =============================================================================
 # SERVER PRODUCTION STAGE
 # =============================================================================
 FROM node:22-trixie-slim AS server
@@ -124,6 +135,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && chmod +x /usr/local/bin/br \
     && rm -f br.tar.gz \
     && rm -rf /var/lib/apt/lists/*
+
+# rabbit-hole CLI (`rh`) — Node.js CLI for search / deep-research / media ingest.
+# Built in the rh-build stage from the rabbit-hole.io monorepo (packages/cli).
+COPY --from=rh-build /src/packages/cli/dist /opt/rh/dist
+COPY --from=rh-build /src/packages/cli/node_modules /opt/rh/node_modules
+RUN ln -s /opt/rh/dist/index.js /usr/local/bin/rh && chmod +x /opt/rh/dist/index.js
 
 # Install Claude CLI globally (available to all users via npm global bin)
 RUN npm install -g @anthropic-ai/claude-code


### PR DESCRIPTION
## Summary

Make the rh CLI available inside the protoMaker server container so agents can shell out for search / deep-research / media ingest without going through MCP HTTP. Mirror the existing gh and br install pattern already in the server Dockerfile (find those stages and copy their structure exactly): add a build stage that fetches the rabbit-hole.io repo, installs and builds the rabbit-hole-cli package, then copies the built output into the runner stage and symlinks rh into the PATH. Keep it consisten...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-cf038d4f team= created=2026-05-27T03:36:40.840Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `rabbit-hole.io` CLI is now bundled and available in the Docker image, allowing users to invoke it via the `rh` command directly from the container environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->