### PR TITLE
fix(create-protolab): wire zizmor + actionlint into onboarding CI (#3819)

### DIFF
--- a/docs/internal/protolabs/ci-cd-setup.md
+++ b/docs/internal/protolabs/ci-cd-setup.md
@@ -57,10 +57,10 @@ For complete control, manually configure workflows and branch protection using t
 
 **5. workflow-security-lint.yml** (Workflow Security)
 
-- Triggers: PRs and pushes to main
+- Triggers: PRs and pushes to main and develop
 - Runs **zizmor** (GitHub Actions security linter) at `--min-severity=medium` and **actionlint**
 - Catches untrusted-expression script injection (CWE-94, e.g. `${{ github.event.head_commit.message }}` in a `run:` block), `GITHUB_TOKEN` over-privilege, and workflow misconfigurations
-- Both linters install without a third-party action reference: zizmor from PyPI (`pip install zizmor`), actionlint via its official download script — so there is no action SHA to pin or get wrong
+- Both linters install without a third-party action reference and are version-pinned for reproducibility: zizmor from PyPI (`pip install zizmor==1.25.2`); actionlint via its official download script, fetched from an immutable commit SHA and pinned to an exact version — so there is no third-party action to vet and the tooling is deterministic
 - Part of the fleet security baseline (protoLabsAI/protoMaker#3819), motivated by the #3812 script-injection fix
 
 ### Branch Protection Rules

--- a/docs/internal/protolabs/ci-cd-setup.md
+++ b/docs/internal/protolabs/ci-cd-setup.md
@@ -55,6 +55,14 @@ For complete control, manually configure workflows and branch protection using t
 - Runs npm/pnpm audit
 - Reports vulnerabilities
 
+**5. workflow-security-lint.yml** (Workflow Security)
+
+- Triggers: PRs and pushes to main
+- Runs **zizmor** (GitHub Actions security linter) at `--min-severity=medium` and **actionlint**
+- Catches untrusted-expression script injection (CWE-94, e.g. `${{ github.event.head_commit.message }}` in a `run:` block), `GITHUB_TOKEN` over-privilege, and workflow misconfigurations
+- Both linters install without a third-party action reference: zizmor from PyPI (`pip install zizmor`), actionlint via its official download script — so there is no action SHA to pin or get wrong
+- Part of the fleet security baseline (protoLabsAI/protoMaker#3819), motivated by the #3812 script-injection fix
+
 ### Branch Protection Rules
 
 **For main branch:**

--- a/packages/create-protolab/package.json
+++ b/packages/create-protolab/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json && npm run postbuild",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "postbuild": "cp -r templates dist/",
+    "postbuild": "cp -r templates dist/ && cp -R src/templates/. dist/templates/",
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/create-protolab/src/phases/ci.ts
+++ b/packages/create-protolab/src/phases/ci.ts
@@ -34,7 +34,13 @@ export async function setupCI(options: CIOptions): Promise<CIResult> {
     filesCreated.push('.github/workflows/');
 
     // 2. Load workflow templates
-    const templateNames = ['build.yml', 'test.yml', 'format-check.yml', 'security-audit.yml'];
+    const templateNames = [
+      'build.yml',
+      'test.yml',
+      'format-check.yml',
+      'security-audit.yml',
+      'workflow-security-lint.yml',
+    ];
 
     // 3. Get package manager specific variables
     const pmVars = getPackageManagerVars(packageManager);

--- a/packages/create-protolab/src/templates/.github/workflows/workflow-security-lint.yml
+++ b/packages/create-protolab/src/templates/.github/workflows/workflow-security-lint.yml
@@ -1,0 +1,47 @@
+name: Workflow Security Lint
+
+# Lints .github/workflows/ for security issues (untrusted-expression script
+# injection, GITHUB_TOKEN over-privilege) and misconfigurations. Part of the
+# fleet security baseline — see protoLabsAI/protoMaker#3819 and #3812 (the
+# CWE-94 script-injection fix that motivated a fleet-wide guardrail).
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  workflow-security-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # zizmor — GitHub Actions security linter. Installed from PyPI so there is
+      # no third-party action reference to pin or get wrong. min-severity=medium
+      # fails the build on script injection (high) and token over-privilege
+      # (medium) while not breaking on low-severity style findings.
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install zizmor
+        run: pip install zizmor
+
+      - name: Run zizmor
+        run: zizmor --min-severity=medium .github/workflows/
+
+      # actionlint — workflow syntax, expression typing, and shellcheck linter.
+      # Installed via the project's official download script (no third-party
+      # action reference).
+      - name: Install actionlint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash -o /tmp/download-actionlint.bash
+          bash /tmp/download-actionlint.bash
+
+      - name: Run actionlint
+        run: ./actionlint -color

--- a/packages/create-protolab/src/templates/.github/workflows/workflow-security-lint.yml
+++ b/packages/create-protolab/src/templates/.github/workflows/workflow-security-lint.yml
@@ -21,27 +21,30 @@ jobs:
       - uses: actions/checkout@v4
 
       # zizmor — GitHub Actions security linter. Installed from PyPI so there is
-      # no third-party action reference to pin or get wrong. min-severity=medium
-      # fails the build on script injection (high) and token over-privilege
-      # (medium) while not breaking on low-severity style findings.
+      # no third-party action reference to pin or get wrong. Pinned to an exact
+      # version for reproducible lint runs. min-severity=medium fails the build
+      # on script injection (high) and token over-privilege (medium) while not
+      # breaking on low-severity style findings.
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
       - name: Install zizmor
-        run: pip install zizmor
+        run: pip install zizmor==1.25.2
 
       - name: Run zizmor
         run: zizmor --min-severity=medium .github/workflows/
 
       # actionlint — workflow syntax, expression typing, and shellcheck linter.
       # Installed via the project's official download script (no third-party
-      # action reference).
+      # action reference). The script is fetched from an immutable commit SHA
+      # (not a mutable branch) and pinned to an exact actionlint version, so the
+      # tooling is deterministic and the fetched code cannot change underneath us.
       - name: Install actionlint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash -o /tmp/download-actionlint.bash
-          bash /tmp/download-actionlint.bash
+          curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/62c50a97a146fe36a8951a2a365158c4a4795ba8/scripts/download-actionlint.bash -o /tmp/download-actionlint.bash
+          bash /tmp/download-actionlint.bash 1.7.12
 
       - name: Run actionlint
         run: ./actionlint -color

--- a/packages/create-protolab/tests/integration.test.ts
+++ b/packages/create-protolab/tests/integration.test.ts
@@ -311,13 +311,16 @@ describe('CI Phase — workflow security lint (#3819)', () => {
         path.join(tempDir, '.github', 'workflows', 'workflow-security-lint.yml'),
         'utf-8'
       );
-      // Both linters are wired, installed without a third-party action ref.
-      expect(content).toContain('pip install zizmor');
+      // Both linters are wired and version-pinned for reproducible runs.
+      expect(content).toContain('pip install zizmor==1.25.2');
       expect(content).toContain('zizmor --min-severity=medium .github/workflows/');
       expect(content).toContain('download-actionlint.bash');
       expect(content).toContain('./actionlint');
+      // actionlint installs without a third-party action — no `uses: ...actionlint`.
+      expect(content).not.toMatch(/uses:.*actionlint/i);
       // Least-privilege token for the lint job.
       expect(content).toContain('permissions:');
+      expect(content).toContain('contents: read');
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });
     }

--- a/packages/create-protolab/tests/integration.test.ts
+++ b/packages/create-protolab/tests/integration.test.ts
@@ -8,6 +8,9 @@ import {
   checkEnvironment,
 } from '../src/lib/validators.js';
 import type { RepoResearchResult, GapAnalysisReport } from '../src/types.js';
+import { setupCI } from '../src/phases/ci.js';
+import { promises as fsp } from 'node:fs';
+import os from 'node:os';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -292,5 +295,46 @@ describe('Fixture Validation', () => {
         expect(fs.existsSync(filePath)).toBe(true);
       });
     });
+  });
+});
+
+describe('CI Phase — workflow security lint (#3819)', () => {
+  it('emits the workflow-security-lint workflow wiring zizmor + actionlint', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'protolab-ci-'));
+    try {
+      const result = await setupCI({ projectPath: tempDir, packageManager: 'npm' });
+
+      expect(result.success).toBe(true);
+      expect(result.filesCreated).toContain('.github/workflows/workflow-security-lint.yml');
+
+      const content = await fsp.readFile(
+        path.join(tempDir, '.github', 'workflows', 'workflow-security-lint.yml'),
+        'utf-8'
+      );
+      // Both linters are wired, installed without a third-party action ref.
+      expect(content).toContain('pip install zizmor');
+      expect(content).toContain('zizmor --min-severity=medium .github/workflows/');
+      expect(content).toContain('download-actionlint.bash');
+      expect(content).toContain('./actionlint');
+      // Least-privilege token for the lint job.
+      expect(content).toContain('permissions:');
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('is idempotent — does not overwrite an existing security-lint workflow', async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'protolab-ci-'));
+    try {
+      await setupCI({ projectPath: tempDir, packageManager: 'npm' });
+      const second = await setupCI({ projectPath: tempDir, packageManager: 'npm' });
+      expect(
+        second.filesCreated.some((f) =>
+          f.includes('workflow-security-lint.yml (already exists)')
+        )
+      ).toBe(true);
+    } finally {
+      await fsp.rm(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/create-protolab/tests/integration.test.ts
+++ b/packages/create-protolab/tests/integration.test.ts
@@ -329,9 +329,7 @@ describe('CI Phase — workflow security lint (#3819)', () => {
       await setupCI({ projectPath: tempDir, packageManager: 'npm' });
       const second = await setupCI({ projectPath: tempDir, packageManager: 'npm' });
       expect(
-        second.filesCreated.some((f) =>
-          f.includes('workflow-security-lint.yml (already exists)')
-        )
+        second.filesCreated.some((f) => f.includes('workflow-security-lint.yml (already exists)'))
       ).toBe(true);
     } finally {
       await fsp.rm(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## What

Every repo scaffolded via `create-protolab` now gets a **workflow security linter** in CI, closing the fleet detection gap that let the CWE-94 script-injection hole (#3812) land.

New `workflow-security-lint.yml` template runs:
- **zizmor** (`--min-severity=medium`) — catches untrusted-expression script injection (high) and `GITHUB_TOKEN` over-privilege (medium) without breaking new repos on low-severity style findings.
- **actionlint** — workflow syntax, expression typing, shellcheck.

### No hallucinated action refs

Both linters install **without a third-party GitHub Action reference** — zizmor from PyPI (`pip install zizmor`), actionlint via its official download script. There is no action SHA to pin or get wrong. This deliberately avoids the failure mode behind #3878 (a crew agent hallucinated `actionlint`/`zizmor` action refs and the bad workflow merged). The lint job runs with `permissions: contents: read`.

## Also fixes a pre-existing packaging gap

Workflow templates live in `src/templates/.github/workflows/`, but `postbuild` only copied the top-level `templates/` (`context/`, `cicd/`) into `dist/templates/` — so **no CI workflow shipped in a published build** (build/test/format-check/security-audit all affected). The loader's prod path (`dist/templates`) and dev fallback both missed `.github/workflows`. `postbuild` now also copies `src/templates` into `dist/templates`; the build was verified to place all 5 workflows under `dist/templates/.github/workflows/`.

## Tests

2 new tests (security-lint workflow emitted with both linters wired; idempotent re-run). 25 pass. Package typecheck clean.

## Scope note

This covers **new repos scaffolded via create-protolab**. Back-filling the linter into existing managed repos (and the release-tools side of #3819) is a separate fleet rollout — tracked as a follow-up on #3819 rather than closed here.

Refs #3819, #3812.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project templates now include an automated GitHub Actions workflow that scans other workflows for security issues (e.g., untrusted expressions, token over-privilege) using two linters.

* **Documentation**
  * Updated guide describing the workflow security scan, installed tools, triggers, and issues it flags.

* **Chores**
  * Template generation updated to pull templates from additional sources so the new workflow is included in new projects.

* **Tests**
  * Integration tests added to verify workflow generation, idempotency, and inclusion of the linters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->