### PR TITLE
feat(types): add github + defaultBranch fields to ProjectRef

### DIFF
--- a/apps/server/src/routes/settings/routes/enrich-projects.ts
+++ b/apps/server/src/routes/settings/routes/enrich-projects.ts
@@ -1,0 +1,69 @@
+/**
+ * Enrich ProjectRef entries with github owner/repo and defaultBranch.
+ *
+ * Both operations are best-effort — failures are caught and fields omitted.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { ProjectRef } from '@protolabsai/types';
+import { checkGitHubRemote } from '../../github/routes/check-github-remote.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Resolve the default branch from `git symbolic-ref refs/remotes/origin/HEAD`.
+ * Returns null on any failure (best-effort).
+ */
+export async function resolveDefaultBranch(projectPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
+      cwd: projectPath,
+      timeout: 5000,
+      encoding: 'utf-8',
+    });
+    const ref = stdout.trim(); // e.g., refs/remotes/origin/main
+    const branch = ref.replace('refs/remotes/origin/', '');
+    return branch || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Enrich a list of ProjectRef entries with github owner/repo and defaultBranch.
+ * Each project is enriched independently — failures on one project don't affect others.
+ * Within each project, github and defaultBranch are resolved in parallel.
+ */
+export async function enrichProjects(projects: ProjectRef[]): Promise<ProjectRef[]> {
+  return Promise.all(
+    projects.map(async (project) => {
+      const enriched = { ...project };
+
+      // Resolve github owner/repo (best-effort)
+      try {
+        const remoteStatus = await checkGitHubRemote(project.path);
+        if (remoteStatus.owner && remoteStatus.repo) {
+          enriched.github = {
+            owner: remoteStatus.owner,
+            repo: remoteStatus.repo,
+          };
+        }
+      } catch {
+        // Omit github on failure
+      }
+
+      // Resolve defaultBranch (best-effort)
+      try {
+        const defaultBranch = await resolveDefaultBranch(project.path);
+        if (defaultBranch) {
+          enriched.defaultBranch = defaultBranch;
+        }
+      } catch {
+        // Omit defaultBranch on failure
+      }
+
+      return enriched;
+    })
+  );
+}

--- a/apps/server/src/routes/settings/routes/get-global.ts
+++ b/apps/server/src/routes/settings/routes/get-global.ts
@@ -10,6 +10,7 @@
 import type { Request, Response } from 'express';
 import type { SettingsService } from '../../../services/settings-service.js';
 import { getErrorMessage, logError } from '../common.js';
+import { enrichProjects } from './enrich-projects.js';
 
 /**
  * Create handler factory for GET /api/settings/global
@@ -21,6 +22,11 @@ export function createGetGlobalHandler(settingsService: SettingsService) {
   return async (_req: Request, res: Response): Promise<void> => {
     try {
       const settings = await settingsService.getGlobalSettings();
+
+      // Enrich projects[] with github owner/repo and defaultBranch (best-effort)
+      if (settings.projects && settings.projects.length > 0) {
+        settings.projects = await enrichProjects(settings.projects);
+      }
 
       res.json({
         success: true,

--- a/apps/server/tests/unit/routes/get-global-enrichment.test.ts
+++ b/apps/server/tests/unit/routes/get-global-enrichment.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for enrichProjects() — enrichment of ProjectRef[] with github + defaultBranch.
+ *
+ * Verifies that:
+ *   - github.owner/repo is populated from checkGitHubRemote (best-effort)
+ *   - defaultBranch is populated from git symbolic-ref (best-effort)
+ *   - failures are tolerated (fields omitted, never thrown)
+ *   - empty array returns empty array
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ProjectRef } from '@protolabsai/types';
+
+const h = vi.hoisted(() => ({
+  checkGitHubRemoteResults: [] as Array<Record<string, unknown> | Error>,
+  execFileAsyncResults: [] as Array<{ stdout: string } | Error>,
+  checkGitHubRemoteIdx: 0,
+  execFileAsyncIdx: 0,
+}));
+
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual('@protolabsai/utils');
+  return {
+    ...(actual as object),
+    createLogger: () => ({ info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  };
+});
+
+vi.mock('@protolabsai/git-utils', () => ({ createGitExecEnv: () => ({}) }));
+
+vi.mock('@/routes/github/routes/check-github-remote.js', () => ({
+  checkGitHubRemote: vi.fn(async () => {
+    const result = h.checkGitHubRemoteResults[h.checkGitHubRemoteIdx++];
+    if (result instanceof Error) throw result;
+    return result;
+  }),
+}));
+
+// Also mock the relative path that enrich-projects.ts uses
+vi.mock('@/routes/settings/../../github/routes/check-github-remote.js', () => ({
+  checkGitHubRemote: vi.fn(async () => {
+    const result = h.checkGitHubRemoteResults[h.checkGitHubRemoteIdx++];
+    if (result instanceof Error) throw result;
+    return result;
+  }),
+}));
+
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    execFile: vi.fn(
+      (
+        _cmd: string,
+        _args: string[],
+        _opts: unknown,
+        cb?: (err: unknown, res?: { stdout: string; stderr: string }) => void
+      ) => {
+        const result = h.execFileAsyncResults[h.execFileAsyncIdx++];
+        if (result instanceof Error) return cb?.(result);
+        cb?.(null, result);
+      }
+    ),
+    // Mock exec so checkGitHubRemote's internal execAsync doesn't hit real git
+    exec: vi.fn((_cmd: string, _opts: unknown, cb?: (err: unknown, stdout?: string) => void) => {
+      cb?.(null, '');
+      return { kill: vi.fn(), stdout: { on: vi.fn() }, stderr: { on: vi.fn() } };
+    }),
+  };
+});
+
+import { enrichProjects } from '@/routes/settings/routes/enrich-projects.js';
+
+function makeProject(overrides: Partial<ProjectRef> = {}): ProjectRef {
+  return {
+    id: 'p1',
+    name: 'Test',
+    path: '/test',
+    ...overrides,
+  };
+}
+
+describe('enrichProjects()', () => {
+  beforeEach(() => {
+    h.checkGitHubRemoteResults = [];
+    h.execFileAsyncResults = [];
+    h.checkGitHubRemoteIdx = 0;
+    h.execFileAsyncIdx = 0;
+  });
+
+  it('enriches with github and defaultBranch when both resolve', async () => {
+    h.checkGitHubRemoteResults = [
+      { hasGitHubRemote: true, owner: 'protolabs', repo: 'protomaker' },
+    ];
+    h.execFileAsyncResults = [{ stdout: 'refs/remotes/origin/main\n' }];
+
+    const result = await enrichProjects([makeProject()]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].github).toEqual({ owner: 'protolabs', repo: 'protomaker' });
+    expect(result[0].defaultBranch).toBe('main');
+  });
+
+  it('omits github when checkGitHubRemote returns no owner/repo', async () => {
+    h.checkGitHubRemoteResults = [{ hasGitHubRemote: false, owner: null, repo: null }];
+    h.execFileAsyncResults = [{ stdout: 'refs/remotes/origin/dev\n' }];
+
+    const result = await enrichProjects([makeProject()]);
+
+    expect(result[0].github).toBeUndefined();
+    expect(result[0].defaultBranch).toBe('dev');
+  });
+
+  it('omits defaultBranch when git symbolic-ref fails', async () => {
+    h.checkGitHubRemoteResults = [{ hasGitHubRemote: true, owner: 'acme', repo: 'widgets' }];
+    h.execFileAsyncResults = [new Error('no remote HEAD')];
+
+    const result = await enrichProjects([makeProject()]);
+
+    expect(result[0].github).toEqual({ owner: 'acme', repo: 'widgets' });
+    expect(result[0].defaultBranch).toBeUndefined();
+  });
+
+  it('tolerates checkGitHubRemote throwing — returns project unchanged', async () => {
+    h.checkGitHubRemoteResults = [new Error('network error')];
+    h.execFileAsyncResults = [{ stdout: 'refs/remotes/origin/main\n' }];
+
+    const result = await enrichProjects([makeProject()]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].github).toBeUndefined();
+    expect(result[0].defaultBranch).toBe('main');
+  });
+
+  it('tolerates execFileAsync throwing — returns project unchanged', async () => {
+    h.checkGitHubRemoteResults = [{ hasGitHubRemote: true, owner: 'acme', repo: 'widgets' }];
+    h.execFileAsyncResults = [new Error('not a git repo')];
+
+    const result = await enrichProjects([makeProject()]);
+
+    expect(result[0].github).toEqual({ owner: 'acme', repo: 'widgets' });
+    expect(result[0].defaultBranch).toBeUndefined();
+  });
+
+  it('returns empty array for empty input', async () => {
+    const result = await enrichProjects([]);
+    expect(result).toEqual([]);
+  });
+
+  it('enriches multiple projects independently', async () => {
+    h.checkGitHubRemoteResults = [
+      { hasGitHubRemote: true, owner: 'org1', repo: 'repo1' },
+      { hasGitHubRemote: false, owner: null, repo: null },
+    ];
+    h.execFileAsyncResults = [
+      { stdout: 'refs/remotes/origin/main\n' },
+      { stdout: 'refs/remotes/origin/develop\n' },
+    ];
+
+    const result = await enrichProjects([
+      makeProject({ id: 'a', path: '/a' }),
+      makeProject({ id: 'b', path: '/b' }),
+    ]);
+
+    expect(result[0].github).toEqual({ owner: 'org1', repo: 'repo1' });
+    expect(result[0].defaultBranch).toBe('main');
+    expect(result[1].github).toBeUndefined();
+    expect(result[1].defaultBranch).toBe('develop');
+  });
+});

--- a/libs/types/src/project-settings.ts
+++ b/libs/types/src/project-settings.ts
@@ -65,6 +65,10 @@ export interface ProjectRef {
   icon?: string;
   /** Custom icon image path for project switcher */
   customIconPath?: string;
+  /** GitHub owner and repo derived from the project's git remote origin (best-effort, omitted on failure) */
+  github?: { owner: string; repo: string };
+  /** Default branch derived from the remote HEAD (best-effort, omitted on failure) */
+  defaultBranch?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Add two optional fields to the ProjectRef type in libs/types so consumers (e.g. workstacean) don't derive them locally: github?: { owner: string; repo: string } and defaultBranch?: string. Populate them server-side where the project list is returned (GET /api/settings/global → settings.projects[]): derive github owner/repo from the repo's git remote origin and defaultBranch from the remote HEAD (reuse existing helpers like checkGitHubRemote / getEffectivePrBaseBranch rather than re-parsing .git/...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-4b4aeedf team= created=2026-05-27T03:37:32.277Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project references are now enriched with GitHub repository information (owner and repository name).
  * Project references are now enriched with default branch information from the Git repository.
  * Enrichments are automatically applied when retrieving global settings with best-effort reliability.

* **Tests**
  * Added comprehensive test coverage for project enrichment functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->