### PR TITLE
fix(maintenance): run stale-bot-review sweep on critical tier (5min) (#3901)

### DIFF
--- a/apps/server/src/services/maintenance.module.ts
+++ b/apps/server/src/services/maintenance.module.ts
@@ -8,6 +8,7 @@
  * - post-merge-reconciler (critical tier, 5min): Poll-based fallback for missed PR merge webhooks
  * - done-worktree-cleanup (full tier, 6h): Removes worktrees for done features and orphaned worktrees
  * - epic-adoption-sweep (full tier + 1h poll): Links orphaned features to parent epics via bracket-prefix matching
+ * - auto-dismiss-stale-bot-reviews (critical tier, 5min): Clears stale CHANGES_REQUESTED bot reviews that block merge
  */
 
 import { createLogger } from '@protolabsai/utils';
@@ -245,7 +246,11 @@ export function register(container: ServiceContainer): void {
   const autoDismissStaleBotReviewsCheck: MaintenanceCheck = {
     id: 'auto-dismiss-stale-bot-reviews',
     name: 'Auto-Dismiss Stale Bot Reviews',
-    tier: 'full',
+    // critical tier (5min): a stale CHANGES_REQUESTED blocks merge and stalls the
+    // REVIEW loop, so it must clear fast — 6h was far too slow. The expensive
+    // per-PR gh calls only fire for PRs that are BLOCKED + CHANGES_REQUESTED
+    // (normally few), so the tighter cadence is cheap on the GitHub API. (#3901)
+    tier: 'critical',
     async run(context: MaintenanceCheckContext): Promise<MaintenanceCheckResult> {
       const t0 = Date.now();
       let totalDismissed = 0;

--- a/apps/server/src/services/maintenance.module.ts
+++ b/apps/server/src/services/maintenance.module.ts
@@ -231,7 +231,7 @@ export function register(container: ServiceContainer): void {
   // See protoLabsAI/protoMaker#3511.
   const backlogTitleReconcilerCheck = new BacklogTitleReconcilerCheck(featureLoader, events);
 
-  // Auto-dismiss stale bot CHANGES_REQUESTED reviews (full tier) — protoquinn /
+  // Auto-dismiss stale bot CHANGES_REQUESTED reviews (critical tier) — protoquinn /
   // coderabbit re-review fix commits as COMMENTED rather than APPROVED, which
   // leaves PRs permanently BLOCKED on the original CHANGES_REQUESTED. This
   // check finds and dismisses those superseded reviews when the same bot has


### PR DESCRIPTION
First, lowest-risk piece of #3901. A stale `CHANGES_REQUESTED` bot review blocks merge and stalls the REVIEW loop; clearing it on a **6h** cadence was far too slow. Moves the `auto-dismiss-stale-bot-reviews` check from `full` (6h) → `critical` (5min).

The expensive per-PR `gh` calls only fire for PRs that are `BLOCKED + CHANGES_REQUESTED` (normally few), so the tighter cadence is cheap on the GitHub API.

This is the "clear mechanically-stale reviews fast" layer. The centerpiece — a reasoning-tier feedback audit over the feature trajectory (to catch *confidently-wrong* current reviews, not just mechanically-stale ones) plus a repeat-CR loop guard — lands in a follow-up PR.

Refs #3901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the stale bot review dismissal system check for faster execution with reduced API overhead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3902?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->