### PR TITLE
feat(review): reasoning-tier audit of bot review feedback over the trajectory (#3901)

### DIFF
--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -14,6 +14,10 @@ import {
   buildFreshEyesReviewPrompt,
   parseFreshEyesVerdict,
   FRESH_EYES_REVIEW_SYSTEM_PROMPT,
+  buildFeedbackAuditPrompt,
+  parseFeedbackAuditVerdict,
+  FEEDBACK_AUDIT_SYSTEM_PROMPT,
+  type FeedbackAuditResult,
 } from '@protolabsai/prompts';
 import { resolveModelString } from '@protolabsai/model-resolver';
 import { resolveMergeStrategy } from '../lib/merge-strategy.js';
@@ -339,6 +343,14 @@ export class ReviewProcessor implements StateProcessor {
     }
 
     if (reviewState === 'changes_requested') {
+      // #3901: audit bot-authored CHANGES_REQUESTED before spending a remediation
+      // cycle. A confidently-wrong or stale bot review (e.g. protoquinn) otherwise
+      // sends the feature back to EXECUTE and burns the budget on a phantom finding.
+      // Returns a short-circuit transition (dismiss+re-check, or escalate) or null
+      // to fall through to remediation (VALID finding, human review, or audit off).
+      const auditGate = await this.gateBotReviewFeedback(ctx);
+      if (auditGate) return auditGate;
+
       // Check remediation budget using split budget enforcer
       const reviewWorkflowSettings = await getWorkflowSettings(
         ctx.projectPath,
@@ -575,6 +587,279 @@ export class ReviewProcessor implements StateProcessor {
     logger.info('[REVIEW] Review phase completed');
     // Clean up review start timestamp when leaving REVIEW state
     this.reviewStartedAt.delete(ctx.feature.id);
+  }
+
+  /**
+   * #3901 — gate bot-authored CHANGES_REQUESTED reviews through a reasoning-tier
+   * audit before remediating. Returns a short-circuit StateTransitionResult when
+   * the gate handles the review (dismiss + re-check, or escalate), or null to
+   * fall through to the normal remediation path.
+   *
+   * Decision flow:
+   *  - No CHANGES_REQUESTED *reviews* (e.g. only CodeRabbit threads) → null.
+   *  - Any human CHANGES_REQUESTED → null (human feedback is authoritative; never
+   *    auto-dismissed — it remediates or, via the normal path, escalates).
+   *  - Bot CHANGES_REQUESTED → reasoning audit over trajectory + diff:
+   *      VALID     → null (remediate against the real finding).
+   *      INVALID   → dismiss the bot review(s), record loop-guard state, re-check.
+   *      UNCERTAIN → escalate to a human.
+   *  - Loop guard: if a bot re-requests changes on a head we already audited and
+   *    dismissed twice, escalate instead of dismissing again.
+   */
+  private async gateBotReviewFeedback(ctx: StateContext): Promise<StateTransitionResult | null> {
+    if (!ctx.prNumber) return null;
+    if (!this.serviceContext.trajectoryStoreService) return null;
+
+    const workflowSettings = await getWorkflowSettings(
+      ctx.projectPath,
+      this.serviceContext.settingsService,
+      '[ReviewProcessor]'
+    );
+    // Default ON: a stale/wrong bot review otherwise burns the remediation budget.
+    if (workflowSettings.reviewFeedbackAudit?.enabled === false) return null;
+
+    // Resolve repo slug + head SHA + CHANGES_REQUESTED reviews (with REST ids,
+    // needed for the dismissals endpoint).
+    let slug = '';
+    let headSha = '';
+    let crReviews: Array<{ id: number; login: string; body: string }> = [];
+    try {
+      const { stdout: slugOut } = await execAsync(
+        'gh repo view --json nameWithOwner -q .nameWithOwner',
+        {
+          cwd: ctx.projectPath,
+          timeout: 10000,
+        }
+      );
+      slug = slugOut.trim();
+      if (!slug) return null;
+
+      const { stdout: headOut } = await execAsync(
+        `gh pr view ${ctx.prNumber} --json headRefOid -q .headRefOid`,
+        { cwd: ctx.projectPath, timeout: 10000 }
+      );
+      headSha = headOut.trim();
+
+      const { stdout: reviewsOut } = await execAsync(
+        `gh api repos/${slug}/pulls/${ctx.prNumber}/reviews`,
+        { cwd: ctx.projectPath, timeout: 15000 }
+      );
+      const all = JSON.parse(reviewsOut) as Array<{
+        id: number;
+        user: { login: string } | null;
+        state: string;
+        body: string | null;
+      }>;
+      crReviews = all
+        .filter((r) => r.state === 'CHANGES_REQUESTED' && r.user)
+        .map((r) => ({ id: r.id, login: r.user!.login, body: r.body ?? '' }));
+    } catch (err) {
+      logger.warn('[REVIEW] Feedback audit: failed to resolve reviews, skipping gate', err);
+      return null;
+    }
+
+    if (crReviews.length === 0) return null; // CodeRabbit-thread case → normal path
+
+    const isBot = (login: string) => login.endsWith('[bot]');
+    const botCRs = crReviews.filter((r) => isBot(r.login));
+    const humanCRs = crReviews.filter((r) => !isBot(r.login));
+
+    // Human reviews are authoritative — never auto-dismissed. Fall through.
+    if (humanCRs.length > 0 || botCRs.length === 0) return null;
+
+    // Loop guard: a bot re-requesting changes on a head we already audited and
+    // dismissed (twice) is contested or unsatisfiable — escalate to a human.
+    const prevSha = ctx.feature.reviewAuditDismissSha;
+    const prevCount = ctx.feature.reviewAuditDismissCount ?? 0;
+    if (prevSha && prevSha === headSha && prevCount >= 2) {
+      ctx.escalationReason =
+        `Bot reviewer keeps requesting changes on head ${headSha.slice(0, 7)} after the ` +
+        `feedback audit dismissed it ${prevCount}x as invalid — needs human review (#3901).`;
+      return { nextState: 'ESCALATE', shouldContinue: true, reason: ctx.escalationReason };
+    }
+
+    const reviewers = [...new Set(botCRs.map((r) => r.login))];
+    const botFeedback = botCRs.map((r) => `[${r.login}]\n${r.body}`).join('\n\n---\n\n');
+    const audit = await this.runReviewFeedbackAudit(ctx, botFeedback, reviewers);
+
+    logger.info('[REVIEW] Feedback audit verdict', {
+      featureId: ctx.feature.id,
+      prNumber: ctx.prNumber,
+      verdict: audit.verdict,
+      reviewers,
+      rationale: audit.rationale.slice(0, 200),
+    });
+
+    if (audit.verdict === 'VALID') {
+      // Real, current defect — remediate against it via the normal path.
+      return null;
+    }
+
+    if (audit.verdict === 'UNCERTAIN') {
+      ctx.escalationReason =
+        `Review feedback audit could not confidently adjudicate bot feedback on PR #${ctx.prNumber}: ` +
+        `${audit.rationale}`;
+      return { nextState: 'ESCALATE', shouldContinue: true, reason: ctx.escalationReason };
+    }
+
+    // INVALID — dismiss the bot review(s) with the audit rationale and re-check.
+    const dismissMessage =
+      `Auto-dismissed by reasoning feedback audit (#3901): ${audit.rationale}`.slice(0, 250);
+    let dismissed = 0;
+    for (const r of botCRs) {
+      try {
+        await execAsync(
+          `gh api repos/${slug}/pulls/${ctx.prNumber}/reviews/${r.id}/dismissals -X PUT -f message=${JSON.stringify(dismissMessage)}`,
+          { cwd: ctx.projectPath, timeout: 15000 }
+        );
+        dismissed++;
+      } catch (err) {
+        logger.warn(`[REVIEW] Failed to dismiss bot review ${r.id} on PR #${ctx.prNumber}`, err);
+      }
+    }
+
+    if (dismissed === 0) {
+      // Could not dismiss — don't loop; let the normal path handle it.
+      return null;
+    }
+
+    // Post the audit rationale as a PR comment for traceability + the flywheel.
+    try {
+      const comment =
+        `**Review feedback audit (#3901) — INVALID**\n\n` +
+        `The ${reviewers.join(', ')} CHANGES_REQUESTED review was audited against this feature's ` +
+        `work trajectory and the PR diff, and dismissed as not a real, current defect:\n\n> ${audit.rationale}`;
+      await execAsync(`gh pr comment ${ctx.prNumber} --body ${JSON.stringify(comment)}`, {
+        cwd: ctx.projectPath,
+        timeout: 15000,
+      });
+    } catch (err) {
+      logger.debug('[REVIEW] Failed to post audit comment (non-fatal)', err);
+    }
+
+    await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+      reviewAuditDismissSha: headSha,
+      reviewAuditDismissCount: prevSha === headSha ? prevCount + 1 : 1,
+    });
+
+    // Wait one poll interval so GitHub recomputes reviewDecision before re-checking.
+    await new Promise((r) => setTimeout(r, REVIEW_POLL_DELAY_MS));
+    return {
+      nextState: 'REVIEW',
+      shouldContinue: true,
+      reason: `Bot review audited INVALID and dismissed (${dismissed}), re-checking`,
+    };
+  }
+
+  /**
+   * Run the reasoning-tier feedback audit: judge bot review feedback against the
+   * feature's work trajectory + PR diff + CI status. (#3901)
+   */
+  private async runReviewFeedbackAudit(
+    ctx: StateContext,
+    botFeedback: string,
+    reviewers: string[]
+  ): Promise<FeedbackAuditResult> {
+    // PR diff
+    let prDiff = '';
+    try {
+      const { stdout } = await execAsync(`gh pr diff ${ctx.prNumber}`, {
+        cwd: ctx.projectPath,
+        timeout: 30000,
+      });
+      prDiff = stdout;
+    } catch (err) {
+      logger.warn('[REVIEW] Feedback audit: failed to fetch PR diff', err);
+    }
+
+    // CI status summary
+    let ciStatus = 'Unknown.';
+    try {
+      const { stdout } = await execAsync(
+        `gh pr view ${ctx.prNumber} --json statusCheckRollup --jq '[(.statusCheckRollup // [])[] | {name: (.name // .context), conclusion}]'`,
+        { cwd: ctx.projectPath, timeout: 15000 }
+      );
+      const checks = JSON.parse(stdout) as Array<{ name: string; conclusion: string | null }>;
+      const failed = checks.filter((c) => c.conclusion === 'FAILURE').map((c) => c.name);
+      ciStatus =
+        failed.length > 0
+          ? `Failing checks: ${failed.join(', ')}`
+          : `All ${checks.length} checks non-failing.`;
+    } catch {
+      // leave default
+    }
+
+    // Trajectory summaries
+    const trajectorySummaries: string[] = [];
+    try {
+      const trajectories = await this.serviceContext.trajectoryStoreService!.loadTrajectories(
+        ctx.projectPath,
+        ctx.feature.id
+      );
+      for (const t of trajectories) {
+        const parts = [`Plan: ${t.planSummary}`, `Execution: ${t.executionSummary}`];
+        if (t.escalationReason) parts.push(`Escalation: ${t.escalationReason}`);
+        trajectorySummaries.push(parts.join('\n'));
+      }
+    } catch (err) {
+      logger.debug('[REVIEW] Feedback audit: failed to load trajectory (non-fatal)', err);
+    }
+
+    const featureAny = ctx.feature as unknown as Record<string, unknown>;
+    const acceptanceCriteria: string[] = [];
+    const rawCriteria = featureAny['acceptanceCriteria'];
+    if (Array.isArray(rawCriteria)) {
+      for (const c of rawCriteria) {
+        if (typeof c === 'string') acceptanceCriteria.push(c);
+        else if (typeof c === 'object' && c !== null && 'description' in c) {
+          acceptanceCriteria.push((c as { description: string }).description);
+        }
+      }
+    }
+
+    const workflowSettings = await getWorkflowSettings(
+      ctx.projectPath,
+      this.serviceContext.settingsService,
+      '[ReviewProcessor]'
+    );
+    const model = resolveModelString(workflowSettings.reviewFeedbackAudit?.model ?? 'reasoning');
+    const prompt = buildFeedbackAuditPrompt({
+      reviewFeedback: botFeedback,
+      reviewers,
+      featureTitle: ctx.feature.title || 'Untitled',
+      featureDescription: ctx.feature.description || 'No description provided.',
+      acceptanceCriteria,
+      trajectorySummaries,
+      prDiff,
+      ciStatus,
+    });
+
+    try {
+      const result = await simpleQuery({
+        prompt,
+        model,
+        cwd: ctx.projectPath,
+        systemPrompt: FEEDBACK_AUDIT_SYSTEM_PROMPT,
+        maxTurns: 1,
+        allowedTools: [],
+        traceContext: {
+          featureId: ctx.feature.id,
+          featureName: ctx.feature.title,
+          agentRole: 'review-feedback-audit',
+          phase: 'REVIEW',
+        },
+      });
+      return parseFeedbackAuditVerdict(result.text);
+    } catch (err) {
+      // On audit failure, return UNCERTAIN so the feature escalates rather than
+      // either looping or silently dismissing.
+      logger.warn('[REVIEW] Feedback audit call failed, defaulting to UNCERTAIN', err);
+      return {
+        verdict: 'UNCERTAIN',
+        rationale: `Audit call failed: ${err instanceof Error ? err.message : String(err)}`,
+        raw: '',
+      };
+    }
   }
 
   /**

--- a/apps/server/tests/unit/services/lead-engineer-review-feedback-audit.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-review-feedback-audit.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for the REVIEW-phase bot-review feedback audit gate (#3901).
+ *
+ * Verifies gateBotReviewFeedback's decision branches:
+ *  - no trajectory store / human review present → fall through (null)
+ *  - reasoning audit VALID    → fall through (remediate)
+ *  - reasoning audit UNCERTAIN → escalate
+ *  - reasoning audit INVALID   → dismiss bot review + persist loop-guard + re-check
+ *  - loop guard (already dismissed 2x on this head) → escalate without auditing
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// REVIEW_POLL_DELAY_MS is parsed from env at module load; zero it so the
+// INVALID path's post-dismissal wait is instant. (hoisted → runs before imports)
+vi.hoisted(() => {
+  process.env.REVIEW_POLL_DELAY_MS = '0';
+});
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+const { mockExec } = vi.hoisted(() => ({ mockExec: vi.fn() }));
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, exec: mockExec };
+});
+
+const { mockSimpleQuery } = vi.hoisted(() => ({ mockSimpleQuery: vi.fn() }));
+vi.mock('../../../src/providers/simple-query-service.js', () => ({
+  simpleQuery: mockSimpleQuery,
+}));
+
+import { ReviewProcessor } from '../../../src/services/lead-engineer-review-merge-processors.js';
+import type {
+  ProcessorServiceContext,
+  StateContext,
+} from '../../../src/services/lead-engineer-types.js';
+
+function makeCtx(featureOverrides: Record<string, unknown> = {}): StateContext {
+  return {
+    feature: {
+      id: 'feat-001',
+      title: 'Install rh',
+      description: 'Add the rh CLI to the image',
+      status: 'in-progress',
+      ...featureOverrides,
+    },
+    projectPath: '/test/project',
+    retryCount: 0,
+    infraRetryCount: 0,
+    planRequired: false,
+    remediationAttempts: 0,
+    mergeRetryCount: 0,
+    planRetryCount: 0,
+    prNumber: 42,
+  } as unknown as StateContext;
+}
+
+function makeServiceContext(
+  overrides: Partial<ProcessorServiceContext> = {}
+): ProcessorServiceContext {
+  return {
+    featureLoader: { update: vi.fn().mockResolvedValue(undefined), get: vi.fn() } as any,
+    events: { emit: vi.fn() } as any,
+    autoModeService: {} as any,
+    settingsService: {
+      getGlobalSettings: vi.fn().mockResolvedValue({}),
+      getProjectSettings: vi.fn().mockResolvedValue({}),
+    } as any,
+    trajectoryStoreService: {
+      loadTrajectories: vi.fn().mockResolvedValue([]),
+    } as any,
+    ...overrides,
+  } as ProcessorServiceContext;
+}
+
+/** Route exec calls by command substring (callback style for promisify). */
+function routeExec(reviewsJson: string) {
+  return (
+    cmd: string,
+    _opts: unknown,
+    cb: (e: null, r: { stdout: string; stderr: string }) => void
+  ) => {
+    const ok = (stdout: string) => cb(null, { stdout, stderr: '' });
+    if (cmd.includes('repo view')) return ok('protoLabsAI/protoMaker\n');
+    if (cmd.includes('--json headRefOid')) return ok('abc1234deadbeef\n');
+    if (cmd.includes('/reviews') && !cmd.includes('dismissals')) return ok(reviewsJson);
+    if (cmd.includes('pr diff')) return ok('diff --git a/Dockerfile b/Dockerfile\n+RUN ...');
+    if (cmd.includes('statusCheckRollup')) return ok('[]');
+    if (cmd.includes('dismissals')) return ok('{}');
+    if (cmd.includes('pr comment')) return ok('');
+    return ok('');
+  };
+}
+
+const BOT_CR = JSON.stringify([
+  {
+    id: 999,
+    user: { login: 'protoquinn[bot]' },
+    state: 'CHANGES_REQUESTED',
+    body: 'frozen-lockfile deadlock',
+  },
+]);
+const HUMAN_CR = JSON.stringify([
+  {
+    id: 1,
+    user: { login: 'mabry1985' },
+    state: 'CHANGES_REQUESTED',
+    body: 'please fix the naming',
+  },
+]);
+
+describe('ReviewProcessor.gateBotReviewFeedback (#3901)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('falls through (null) when no trajectory store is available', async () => {
+    const proc = new ReviewProcessor(makeServiceContext({ trajectoryStoreService: undefined }));
+    const result = await (proc as any).gateBotReviewFeedback(makeCtx());
+    expect(result).toBeNull();
+    expect(mockSimpleQuery).not.toHaveBeenCalled();
+  });
+
+  it('falls through (null) when a human requested changes (never auto-dismissed)', async () => {
+    mockExec.mockImplementation(routeExec(HUMAN_CR));
+    const proc = new ReviewProcessor(makeServiceContext());
+    const result = await (proc as any).gateBotReviewFeedback(makeCtx());
+    expect(result).toBeNull();
+    expect(mockSimpleQuery).not.toHaveBeenCalled();
+  });
+
+  it('falls through (null) on a VALID audit verdict (remediate the real finding)', async () => {
+    mockExec.mockImplementation(routeExec(BOT_CR));
+    mockSimpleQuery.mockResolvedValue({ text: 'VALID: the endpoint lacks input validation.' });
+    const proc = new ReviewProcessor(makeServiceContext());
+    const result = await (proc as any).gateBotReviewFeedback(makeCtx());
+    expect(result).toBeNull();
+    expect(mockSimpleQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('escalates on an UNCERTAIN audit verdict', async () => {
+    mockExec.mockImplementation(routeExec(BOT_CR));
+    mockSimpleQuery.mockResolvedValue({ text: 'UNCERTAIN: needs context beyond the diff.' });
+    const proc = new ReviewProcessor(makeServiceContext());
+    const result = await (proc as any).gateBotReviewFeedback(makeCtx());
+    expect(result?.nextState).toBe('ESCALATE');
+  });
+
+  it('dismisses the bot review and persists loop-guard state on INVALID', async () => {
+    mockExec.mockImplementation(routeExec(BOT_CR));
+    mockSimpleQuery.mockResolvedValue({
+      text: 'INVALID: shallow clone includes the committed lockfile; premise is false.',
+    });
+    const svc = makeServiceContext();
+    const proc = new ReviewProcessor(svc);
+    const result = await (proc as any).gateBotReviewFeedback(makeCtx());
+
+    expect(result?.nextState).toBe('REVIEW');
+    // dismissal call landed
+    const calls = mockExec.mock.calls.map((c) => c[0] as string);
+    expect(calls.some((c) => c.includes('/reviews/999/dismissals'))).toBe(true);
+    // loop-guard persisted
+    expect(svc.featureLoader.update).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-001',
+      expect.objectContaining({
+        reviewAuditDismissSha: 'abc1234deadbeef',
+        reviewAuditDismissCount: 1,
+      })
+    );
+  });
+
+  it('escalates (loop guard) when already dismissed 2x on the same head', async () => {
+    mockExec.mockImplementation(routeExec(BOT_CR));
+    const proc = new ReviewProcessor(makeServiceContext());
+    const ctx = makeCtx({ reviewAuditDismissSha: 'abc1234deadbeef', reviewAuditDismissCount: 2 });
+    const result = await (proc as any).gateBotReviewFeedback(ctx);
+    expect(result?.nextState).toBe('ESCALATE');
+    // audit never runs — short-circuited by the loop guard
+    expect(mockSimpleQuery).not.toHaveBeenCalled();
+  });
+});

--- a/docs/internal/server/lead-engineer-service.md
+++ b/docs/internal/server/lead-engineer-service.md
@@ -117,6 +117,33 @@ On `LoopDetectedError`, execution retries once with recovery guidance injected i
 - On CI failure → back to EXECUTE with failure context
 - Max 4 total remediation cycles before escalation to ESCALATE
 
+### Bot review feedback audit (#3901)
+
+Before spending a remediation cycle on a **bot-authored** `CHANGES_REQUESTED`
+review (e.g. protoquinn), `gateBotReviewFeedback` audits the feedback so a
+stale or confidently-wrong finding can't loop the agent and exhaust the budget:
+
+1. **Human reviews are never audited or auto-dismissed** — a human
+   `CHANGES_REQUESTED` falls straight through to remediation. Only bot reviews
+   are gated. Unresolved CodeRabbit _threads_ (not reviews) also fall through.
+2. **Reasoning-tier audit** (`runReviewFeedbackAudit`, default `protolabs/reasoning`)
+   judges the bot feedback against the feature's recorded **trajectory**
+   (`TrajectoryStoreService.loadTrajectories`), the PR diff, and terminal CI status:
+   - **VALID** → fall through and remediate the real finding.
+   - **INVALID** (wrong / stale / already-addressed) → dismiss the bot review with
+     the audit rationale, post a PR comment for traceability, persist loop-guard
+     state, wait one poll interval, and re-check.
+   - **UNCERTAIN** → escalate to a human (the audit must never guess INVALID;
+     dismissing a real defect would risk merging broken code).
+3. **Loop guard** — `reviewAuditDismissSha` / `reviewAuditDismissCount` on the
+   feature. If a bot re-requests changes on a head already dismissed twice, the
+   feature escalates instead of dismissing in a loop.
+
+Configurable via `WorkflowSettings.reviewFeedbackAudit` (`{ enabled, model }`,
+default `enabled: true`, `model: 'reasoning'`). The mechanically-stale shapes
+(superseded commit, CI-pending) are also cleared out-of-band by the
+`auto-dismiss-stale-bot-reviews` maintenance check (critical tier, 5min).
+
 ## MERGE Phase
 
 `MergeProcessor` verifies CI is green and merges the PR using the strategy configured in `workflowSettings` (squash, merge, or rebase). Emits `feature:pr-merged`. Board status transitions to `done`.

--- a/libs/prompts/src/feedback-audit-prompt.ts
+++ b/libs/prompts/src/feedback-audit-prompt.ts
@@ -1,0 +1,131 @@
+/**
+ * Review Feedback Audit Prompt
+ *
+ * Builds the prompt for the reasoning-tier audit that runs in the REVIEW phase
+ * when a bot reviewer (e.g. protoquinn) requests changes. The audit judges the
+ * feedback against what the feature actually did — its work trajectory and the
+ * real PR diff — and returns VALID / INVALID / UNCERTAIN so the pipeline can
+ * remediate a real defect, dismiss a wrong/stale one, or escalate to a human
+ * rather than burning the remediation budget on a phantom finding.
+ *
+ * Safety bias: when the audit cannot confidently adjudicate, it must return
+ * UNCERTAIN (escalate), never INVALID. Dismissing a real defect risks merging
+ * broken code, so the cost of a false INVALID is higher than a false UNCERTAIN.
+ */
+
+export interface FeedbackAuditInput {
+  /** The bot review feedback under audit (concatenated bodies). */
+  reviewFeedback: string;
+  /** Reviewer logins that authored the feedback (for context). */
+  reviewers: string[];
+  featureTitle: string;
+  featureDescription: string;
+  acceptanceCriteria?: string[];
+  /** Per-attempt trajectory summaries (plan + execution + outcome). */
+  trajectorySummaries?: string[];
+  /** The PR diff under review. */
+  prDiff: string;
+  /** Terminal CI status summary (e.g. "all checks passed" or named failures). */
+  ciStatus?: string;
+}
+
+export type FeedbackAuditVerdict = 'VALID' | 'INVALID' | 'UNCERTAIN';
+
+export interface FeedbackAuditResult {
+  verdict: FeedbackAuditVerdict;
+  rationale: string;
+  raw: string;
+}
+
+export const FEEDBACK_AUDIT_SYSTEM_PROMPT =
+  'You are a staff engineer auditing automated code-review feedback against the actual work a feature performed. ' +
+  'Your job is NOT to re-review the PR — it is to decide whether the reviewer findings identify a real, current ' +
+  'defect in this diff. Reviewers are sometimes confidently wrong (false premises about the code, stale concerns ' +
+  'already addressed, or assumptions contradicted by the diff). Be rigorous and cite evidence from the diff or ' +
+  'trajectory. When you cannot confidently adjudicate, return UNCERTAIN — never guess INVALID, because dismissing ' +
+  'a real defect risks merging broken code.';
+
+/**
+ * Build the user prompt for a review-feedback audit.
+ */
+export function buildFeedbackAuditPrompt(input: FeedbackAuditInput): string {
+  const criteria =
+    input.acceptanceCriteria && input.acceptanceCriteria.length > 0
+      ? input.acceptanceCriteria.map((c, i) => `${i + 1}. ${c}`).join('\n')
+      : 'No explicit criteria provided.';
+
+  const trajectory =
+    input.trajectorySummaries && input.trajectorySummaries.length > 0
+      ? input.trajectorySummaries.map((t, i) => `### Attempt ${i + 1}\n${t}`).join('\n\n')
+      : 'No recorded trajectory for this feature.';
+
+  return `Audit the review feedback below against what this feature actually implemented. Decide whether the findings reflect a real, current defect in the diff.
+
+## Feature
+**Title:** ${input.featureTitle}
+**Description:** ${input.featureDescription}
+
+## Acceptance Criteria
+${criteria}
+
+## Work Trajectory (what the agent did)
+${trajectory}
+
+## CI Status
+${input.ciStatus ?? 'Unknown.'}
+
+## Review Feedback Under Audit
+**Reviewer(s):** ${input.reviewers.join(', ') || 'unknown'}
+
+${input.reviewFeedback.slice(0, 12000)}
+
+## PR Diff
+\`\`\`diff
+${input.prDiff.slice(0, 20000)}
+\`\`\`
+
+Cross-check each finding against the diff and trajectory. A finding is only VALID if it points to a real defect present in THIS diff. A finding is INVALID if it rests on a false premise about the code, is contradicted by the diff, or describes something already handled. Respond with exactly one of:
+
+VALID: [reason] — At least one finding identifies a real, current defect that must be fixed before merge.
+INVALID: [reason] — The findings are wrong, stale, or already addressed; there is no real defect to fix here.
+UNCERTAIN: [reason] — You cannot confidently determine whether the findings are real (e.g. needs context outside the diff, or genuinely ambiguous).
+
+Respond with only the verdict line, the verdict keyword first, followed by one or two sentences of evidence-based reasoning.`;
+}
+
+/**
+ * Parse the LLM response into a structured FeedbackAuditResult.
+ * Defaults to UNCERTAIN (escalate) when the response cannot be parsed — the
+ * safe direction, since UNCERTAIN routes to a human rather than dismissing.
+ */
+export function parseFeedbackAuditVerdict(responseText: string): FeedbackAuditResult {
+  const text = responseText.trim();
+  const upper = text.toUpperCase();
+
+  if (upper.startsWith('VALID')) {
+    const rationale = text.replace(/^valid\s*[:\-—]?\s*/i, '').trim();
+    return { verdict: 'VALID', rationale: rationale || 'Real defect identified.', raw: text };
+  }
+  if (upper.startsWith('INVALID')) {
+    const rationale = text.replace(/^invalid\s*[:\-—]?\s*/i, '').trim();
+    return {
+      verdict: 'INVALID',
+      rationale: rationale || 'Findings are wrong, stale, or already addressed.',
+      raw: text,
+    };
+  }
+  if (upper.startsWith('UNCERTAIN')) {
+    const rationale = text.replace(/^uncertain\s*[:\-—]?\s*/i, '').trim();
+    return {
+      verdict: 'UNCERTAIN',
+      rationale: rationale || 'Could not confidently adjudicate the findings.',
+      raw: text,
+    };
+  }
+
+  return {
+    verdict: 'UNCERTAIN',
+    rationale: `Audit response could not be parsed: ${text.slice(0, 200)}`,
+    raw: text,
+  };
+}

--- a/libs/prompts/src/index.ts
+++ b/libs/prompts/src/index.ts
@@ -188,6 +188,18 @@ export type {
   FreshEyesReviewResult,
 } from './fresh-eyes-review-prompt.js';
 
+// Review feedback audit (reasoning-tier validity check over the work trajectory)
+export {
+  FEEDBACK_AUDIT_SYSTEM_PROMPT,
+  buildFeedbackAuditPrompt,
+  parseFeedbackAuditVerdict,
+} from './feedback-audit-prompt.js';
+export type {
+  FeedbackAuditInput,
+  FeedbackAuditVerdict,
+  FeedbackAuditResult,
+} from './feedback-audit-prompt.js';
+
 // Release notes rewriter
 export { RELEASE_NOTES_SYSTEM_PROMPT, buildReleaseNotesPrompt } from './release-notes.js';
 export type { ReleaseNotesInput } from './release-notes.js';

--- a/libs/prompts/tests/feedback-audit.test.ts
+++ b/libs/prompts/tests/feedback-audit.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildFeedbackAuditPrompt,
+  parseFeedbackAuditVerdict,
+} from '../src/feedback-audit-prompt.js';
+
+describe('parseFeedbackAuditVerdict', () => {
+  it('parses VALID with rationale', () => {
+    const r = parseFeedbackAuditVerdict('VALID: the endpoint is missing input validation.');
+    expect(r.verdict).toBe('VALID');
+    expect(r.rationale).toBe('the endpoint is missing input validation.');
+  });
+
+  it('parses INVALID with rationale', () => {
+    const r = parseFeedbackAuditVerdict(
+      'INVALID: the shallow clone still includes the committed lockfile, so the premise is wrong.'
+    );
+    expect(r.verdict).toBe('INVALID');
+    expect(r.rationale).toContain('committed lockfile');
+  });
+
+  it('parses UNCERTAIN with rationale', () => {
+    const r = parseFeedbackAuditVerdict('UNCERTAIN: needs context outside the diff.');
+    expect(r.verdict).toBe('UNCERTAIN');
+  });
+
+  it('is case-insensitive on the verdict keyword', () => {
+    expect(parseFeedbackAuditVerdict('invalid: stale').verdict).toBe('INVALID');
+    expect(parseFeedbackAuditVerdict('Valid - real bug').verdict).toBe('VALID');
+  });
+
+  it('defaults to UNCERTAIN (escalate) when the response is unparseable', () => {
+    const r = parseFeedbackAuditVerdict('I think this is probably fine but not sure.');
+    expect(r.verdict).toBe('UNCERTAIN');
+    expect(r.rationale).toContain('could not be parsed');
+  });
+
+  it('does not confuse INVALID for VALID (prefix order)', () => {
+    // "INVALID" starts with "I" not "V"; ensure VALID check does not match it.
+    expect(parseFeedbackAuditVerdict('INVALID: x').verdict).toBe('INVALID');
+  });
+});
+
+describe('buildFeedbackAuditPrompt', () => {
+  it('includes feedback, trajectory, diff, and CI status', () => {
+    const prompt = buildFeedbackAuditPrompt({
+      reviewFeedback: 'frozen-lockfile deadlock',
+      reviewers: ['protoquinn[bot]'],
+      featureTitle: 'Install rh',
+      featureDescription: 'Add the rh CLI to the image',
+      acceptanceCriteria: ['rh --version works'],
+      trajectorySummaries: ['Plan: clone + build\nExecution: built dist/index.js'],
+      prDiff: 'diff --git a/Dockerfile b/Dockerfile',
+      ciStatus: 'All 3 checks non-failing.',
+    });
+    expect(prompt).toContain('frozen-lockfile deadlock');
+    expect(prompt).toContain('protoquinn[bot]');
+    expect(prompt).toContain('rh --version works');
+    expect(prompt).toContain('built dist/index.js');
+    expect(prompt).toContain('All 3 checks non-failing.');
+    expect(prompt).toContain('diff --git a/Dockerfile');
+  });
+
+  it('handles missing trajectory and criteria gracefully', () => {
+    const prompt = buildFeedbackAuditPrompt({
+      reviewFeedback: 'x',
+      reviewers: [],
+      featureTitle: 'T',
+      featureDescription: 'D',
+      prDiff: 'd',
+    });
+    expect(prompt).toContain('No recorded trajectory');
+    expect(prompt).toContain('No explicit criteria');
+  });
+});

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -446,6 +446,18 @@ export interface Feature {
    */
   reviewRemediationCount?: number;
   /**
+   * Head commit SHA at which the review feedback audit last auto-dismissed a
+   * bot CHANGES_REQUESTED review. Paired with reviewAuditDismissCount as a loop
+   * guard: if a bot re-requests changes on the same head we already cleared,
+   * the feature escalates instead of dismissing in a loop. (#3901)
+   */
+  reviewAuditDismissSha?: string;
+  /**
+   * Count of audit auto-dismissals performed on reviewAuditDismissSha. Reset
+   * when the head SHA changes. (#3901)
+   */
+  reviewAuditDismissCount?: number;
+  /**
    * Number of CI failure remediation cycles.
    * Tracks how many times the agent has fixed CI failures.
    */

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -455,6 +455,22 @@ export interface WorkflowSettings {
     model?: string;
   };
   /**
+   * Review feedback audit configuration (#3901).
+   * When enabled, a bot-authored CHANGES_REQUESTED review is audited by a
+   * reasoning-tier model against the feature's work trajectory and the PR diff
+   * before the pipeline spends a remediation cycle. A finding judged INVALID
+   * (wrong/stale/already-addressed) auto-dismisses the bot review; UNCERTAIN
+   * escalates to a human; VALID proceeds to remediation. Human reviews are
+   * never auto-dismissed.
+   * @default { enabled: true, model: 'reasoning' }
+   */
+  reviewFeedbackAudit?: {
+    /** Enable the review feedback audit step. @default true */
+    enabled: boolean;
+    /** Model alias to use for the audit call. @default 'reasoning' */
+    model?: string;
+  };
+  /**
    * Trajectory injection configuration.
    * When enabled, relevant past trajectories are injected into agent prompts
    * as a "Lessons from Similar Features" section. Omitting this field defaults


### PR DESCRIPTION
## Problem

A bot-authored `CHANGES_REQUESTED` (e.g. protoquinn) sent the feature straight back to EXECUTE. So a **stale or confidently-wrong** finding burned the remediation budget and stalled the feature — exactly what happened with Quinn's false-positive frozen-lockfile HIGH on #3896. Mechanical heuristics (superseded commit, CI-pending) can't catch a *current, wrong* finding; that needs judgment.

## Solution — audit feedback against what the feature actually did

`gateBotReviewFeedback` runs in the REVIEW phase before any remediation:

- **Human `CHANGES_REQUESTED` is never audited or auto-dismissed** — it falls through to remediation. CodeRabbit threads (not reviews) also fall through. Only **bot** reviews are gated.
- **Reasoning-tier audit** (`runReviewFeedbackAudit`, default `protolabs/reasoning`) judges the bot feedback against the feature's recorded **trajectory** (`TrajectoryStoreService.loadTrajectories`) + the PR diff + terminal CI status:
  - **VALID** → fall through, remediate the real finding.
  - **INVALID** (wrong / stale / already-addressed) → dismiss the bot review with the rationale, post a PR comment for traceability, persist loop-guard state, wait one poll interval, re-check.
  - **UNCERTAIN** → escalate to a human. The audit must **never guess INVALID** — dismissing a real defect would risk merging broken code (preserves the never-merge-broken rule).
- **Loop guard** — `reviewAuditDismissSha` / `reviewAuditDismissCount` on the feature; a bot re-requesting changes on a head already dismissed 2× escalates instead of looping.

The audit makes the feature's **own work trajectory the arbiter** of whether feedback is worth acting on. Quinn's frozen-lockfile HIGH on #3896 would be judged INVALID (the diff clones the full repo → lockfile present), so no cycle is wasted.

## Surface

- New `@protolabsai/prompts` module: `buildFeedbackAuditPrompt` / `parseFeedbackAuditVerdict` / `FEEDBACK_AUDIT_SYSTEM_PROMPT`. Parser defaults to **UNCERTAIN** on unparseable output (safe, escalating direction).
- New `WorkflowSettings.reviewFeedbackAudit` (`{ enabled, model }`, default `enabled: true`, `model: 'reasoning'`).
- `Feature` gains `reviewAuditDismissSha` / `reviewAuditDismissCount`.
- Audit call is Langfuse-traced (`agentRole: review-feedback-audit`).

## Tests

- 8 prompt-module tests (parser branches incl. case-insensitivity + unparseable→UNCERTAIN; builder content).
- 6 gate tests: no-trajectory→null, human→null, VALID→null, UNCERTAIN→escalate, INVALID→dismiss+persist, loop-guard→escalate.
- Full lead-engineer suite green (221). Server typecheck clean.

## Composes with

- #3902 — the `auto-dismiss-stale-bot-reviews` sweep bumped to critical (5min) handles the *mechanically*-stale shapes out-of-band.
- #3900 — Quinn cross-repo accuracy cuts false positives at the source.

Closes #3901.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated validation of bot-generated code review feedback. Invalid bot reviews are automatically dismissed with reasoning posted to pull requests, uncertain cases escalate for human review, and loop-guard protection prevents repeated dismissals on the same commit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->