### PR TITLE
fix(bus): emit feature.completed/failed correctly for workstacean Linear bridge (#3810)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,6 +652,9 @@ Use `list_workflows` MCP tool to discover available workflows for a project. Pro
 - `GITHUB_TOKEN` - GitHub personal access token for repository operations
 - `GITHUB_REPO_OWNER` - GitHub repository owner/organization name
 - `GITHUB_REPO_NAME` - GitHub repository name
+- `WORKSTACEAN_URL` - protoWorkstacean base URL for the outbound lifecycle bus (`POST {url}/publish`). When set, `FeatureLifecycleBusPublisher` publishes `feature.completed`/`feature.failed` on terminal transitions (#3810). Unset = disabled (no-op).
+- `WORKSTACEAN_API_KEY` - `X-API-Key` for workstacean's `/publish` (401 without it). Symmetric counterpart to `AUTOMAKER_API_KEY` in the other direction.
+- `WORKSTACEAN_PROJECT_SLUG` - Fallback `projectSlug` on lifecycle events when a feature has none (default `protomaker`); workstacean's feature-notifier requires it to resolve the dev channel.
 - `DISCORD_TOKEN` - Discord bot token for event routing and notifications
 - `DISCORD_GUILD_ID` - Discord server (guild) ID
 - `DISCORD_CHANNEL_SUGGESTIONS` - Channel ID for #suggestions

--- a/apps/server/src/client/workstacean-api.client.ts
+++ b/apps/server/src/client/workstacean-api.client.ts
@@ -40,11 +40,19 @@ export async function publish(
 ): Promise<WorkstaceanPublishResponse> {
   const url = `${getBaseUrl()}/publish`;
 
+  // Workstacean's /publish reads `{ topic, payload }` and republishes
+  // `payload` onto its in-memory bus under `topic`. Map our `{ event, data }`
+  // interface onto that wire shape (callers are unchanged). It also requires an
+  // X-API-Key, matching the reverse-direction AUTOMAKER_API_KEY.
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const apiKey = process.env.WORKSTACEAN_API_KEY;
+  if (apiKey) headers['X-API-Key'] = apiKey;
+
   try {
     const response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
+      headers,
+      body: JSON.stringify({ topic: payload.event, payload: payload.data }),
       signal: AbortSignal.timeout(10_000),
     });
 

--- a/apps/server/src/services/feature-lifecycle-bus-publisher.ts
+++ b/apps/server/src/services/feature-lifecycle-bus-publisher.ts
@@ -97,33 +97,42 @@ export class FeatureLifecycleBusPublisher {
       logger.warn(`Could not load feature ${featureId} for lifecycle event:`, err);
     }
 
-    const event = isTerminal ? 'protomaker.feature.completed' : 'protomaker.feature.failed';
+    // Dotted, unprefixed topics — exactly what workstacean's consumers
+    // subscribe to (`feature.completed` / `feature.failed`). The earlier
+    // `protomaker.`-prefixed names never matched, so #482 stayed silent.
+    const topic = isTerminal ? 'feature.completed' : 'feature.failed';
+    const owner = process.env.GITHUB_REPO_OWNER;
+    const name = process.env.GITHUB_REPO_NAME;
+    const repo = owner && name ? `${owner}/${name}` : undefined;
+    // Lineage so consumers correlate to their source record without persisted
+    // state. Prefer the echoed manage_feature meta; fall back to intake signal.
+    const sourceMeta =
+      feature?.sourceMeta && typeof feature.sourceMeta === 'object'
+        ? feature.sourceMeta
+        : { sourceChannel: feature?.sourceChannel, signalMetadata: feature?.signalMetadata };
+    const data: Record<string, unknown> = {
+      // projectSlug is REQUIRED by workstacean's feature-notifier (resolves the
+      // dev channel); fall back so the event is never dropped for lacking it.
+      projectSlug: feature?.projectSlug ?? process.env.WORKSTACEAN_PROJECT_SLUG ?? 'protomaker',
+      featureId,
+      featureTitle: feature?.title,
+      prNumber: feature?.prNumber,
+      branchName: feature?.branchName,
+      repo,
+      previousStatus: oldStatus,
+      sourceMeta,
+      [isTerminal ? 'completedAt' : 'failedAt']: new Date().toISOString(),
+    };
+    if (!isTerminal) {
+      data.error = (feature?.statusChangeReason ?? payload?.reason ?? 'failed').slice(0, 400);
+    }
     try {
-      const result = await this.publishFn({
-        event,
-        data: {
-          featureId,
-          projectPath,
-          status: newStatus,
-          prNumber: feature?.prNumber,
-          reason: feature?.statusChangeReason ?? payload?.reason,
-          projectSlug: feature?.projectSlug,
-          title: feature?.title,
-          completedAt: Date.now(),
-          previousStatus: oldStatus,
-          // Echo the originating signal so consumers reconstruct lineage (e.g.
-          // sourceLinearIssueId lives in signalMetadata) without a second query.
-          sourceMeta: {
-            sourceChannel: feature?.sourceChannel,
-            signalMetadata: feature?.signalMetadata,
-          },
-        },
-      });
+      const result = await this.publishFn({ event: topic, data });
       if (!result.ok) {
-        logger.warn(`Failed to publish ${event} for ${featureId}: ${result.error}`);
+        logger.warn(`Failed to publish ${topic} for ${featureId}: ${result.error}`);
       }
     } catch (err) {
-      logger.warn(`Error publishing ${event} for ${featureId}:`, err);
+      logger.warn(`Error publishing ${topic} for ${featureId}:`, err);
     }
   }
 }

--- a/apps/server/tests/integration/hitl-routing.test.ts
+++ b/apps/server/tests/integration/hitl-routing.test.ts
@@ -65,12 +65,14 @@ describe('HITLGateService', () => {
       expect(url).toBe('http://workstacean-test:8082/publish');
       expect(init.method).toBe('POST');
 
+      // Wire shape is { topic, payload } — workstacean's /publish republishes
+      // `payload` onto its bus under `topic`.
       const body = JSON.parse(init.body as string);
-      expect(body.event).toBe('hitl.request.gate-hold');
-      expect(body.data.featureId).toBe('feature-123');
-      expect(body.data.channelId).toBe('1469195643590541353');
-      expect(body.data.phase).toBe('REVIEW');
-      expect(body.data.source).toBe('protomaker');
+      expect(body.topic).toBe('hitl.request.gate-hold');
+      expect(body.payload.featureId).toBe('feature-123');
+      expect(body.payload.channelId).toBe('1469195643590541353');
+      expect(body.payload.phase).toBe('REVIEW');
+      expect(body.payload.source).toBe('protomaker');
     });
 
     it('tracks pending gate after successful publish', async () => {
@@ -134,8 +136,8 @@ describe('HITLGateService', () => {
       const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
       expect(calls).toHaveLength(2);
       const cancelBody = JSON.parse((calls[1] as [string, RequestInit])[1].body as string);
-      expect(cancelBody.event).toBe('hitl.request.cancel');
-      expect(cancelBody.data.featureId).toBe('feature-cancel-test');
+      expect(cancelBody.topic).toBe('hitl.request.cancel');
+      expect(cancelBody.payload.featureId).toBe('feature-cancel-test');
     });
 
     it('no-ops gracefully when gate does not exist', async () => {

--- a/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
+++ b/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
@@ -15,11 +15,12 @@ function makePublisher(opts?: { feature?: unknown; publishFn?: ReturnType<typeof
 }
 
 describe('FeatureLifecycleBusPublisher', () => {
-  it('publishes protomaker.feature.completed on transition to done', async () => {
+  it('publishes feature.completed (dotted, unprefixed) on transition to done', async () => {
     const feature = {
       id: 'f1',
       title: 'Ship it',
       projectSlug: 'proj',
+      branchName: 'feature/ship-it',
       sourceChannel: 'github',
       signalMetadata: { sourceLinearIssueId: 'LIN-1' },
     };
@@ -34,13 +35,37 @@ describe('FeatureLifecycleBusPublisher', () => {
 
     expect(publishFn).toHaveBeenCalledTimes(1);
     const arg = publishFn.mock.calls[0][0];
-    expect(arg.event).toBe('protomaker.feature.completed');
+    // The topic must match what workstacean's consumers subscribe to.
+    expect(arg.event).toBe('feature.completed');
     expect(arg.data.featureId).toBe('f1');
-    expect(arg.data.title).toBe('Ship it');
+    expect(arg.data.featureTitle).toBe('Ship it');
     expect(arg.data.projectSlug).toBe('proj');
+    expect(arg.data.branchName).toBe('feature/ship-it');
     expect(arg.data.previousStatus).toBe('review');
+    expect(arg.data.completedAt).toBeDefined();
     expect(arg.data.sourceMeta.signalMetadata).toEqual({ sourceLinearIssueId: 'LIN-1' });
     expect(arg.data.sourceMeta.sourceChannel).toBe('github');
+  });
+
+  it('echoes feature.sourceMeta when present (manage_feature meta)', async () => {
+    const feature = {
+      id: 'f1',
+      title: 'X',
+      projectSlug: 'proj',
+      sourceMeta: { sourceLinearIssueId: 'LIN-9', custom: true },
+    };
+    const { pub, publishFn } = makePublisher({ feature });
+    await pub.handleStatusChange({ featureId: 'f1', projectPath: '/p', newStatus: 'done' });
+    expect(publishFn.mock.calls[0][0].data.sourceMeta).toEqual({
+      sourceLinearIssueId: 'LIN-9',
+      custom: true,
+    });
+  });
+
+  it('defaults projectSlug so the event is never dropped for lacking it', async () => {
+    const { pub, publishFn } = makePublisher({ feature: { id: 'f1', title: 'X' } });
+    await pub.handleStatusChange({ featureId: 'f1', projectPath: '/p', newStatus: 'done' });
+    expect(publishFn.mock.calls[0][0].data.projectSlug).toBe('protomaker');
   });
 
   it('ignores non-terminal transitions', async () => {
@@ -61,7 +86,7 @@ describe('FeatureLifecycleBusPublisher', () => {
     expect(publishFn).not.toHaveBeenCalled();
   });
 
-  it('still publishes (with empty sourceMeta) when the feature cannot be loaded', async () => {
+  it('still publishes when the feature cannot be loaded', async () => {
     const featureLoader = { get: vi.fn().mockRejectedValue(new Error('gone')) };
     const publishFn = vi.fn().mockResolvedValue({ ok: true });
     const pub = new FeatureLifecycleBusPublisher(
@@ -74,7 +99,7 @@ describe('FeatureLifecycleBusPublisher', () => {
     await pub.handleStatusChange({ featureId: 'f1', projectPath: '/p', newStatus: 'done' });
 
     expect(publishFn).toHaveBeenCalledTimes(1);
-    expect(publishFn.mock.calls[0][0].data.title).toBeUndefined();
+    expect(publishFn.mock.calls[0][0].data.featureTitle).toBeUndefined();
     expect(publishFn.mock.calls[0][0].data.featureId).toBe('f1');
   });
 
@@ -98,7 +123,7 @@ describe('FeatureLifecycleBusPublisher', () => {
     expect(onSpy).not.toHaveBeenCalled();
   });
 
-  it('publishes protomaker.feature.failed on transition to blocked', async () => {
+  it('publishes feature.failed with error on transition to blocked', async () => {
     const feature = {
       id: 'f2',
       title: 'Blocked feature',
@@ -118,20 +143,16 @@ describe('FeatureLifecycleBusPublisher', () => {
 
     expect(publishFn).toHaveBeenCalledTimes(1);
     const arg = publishFn.mock.calls[0][0];
-    expect(arg.event).toBe('protomaker.feature.failed');
+    expect(arg.event).toBe('feature.failed');
     expect(arg.data.featureId).toBe('f2');
-    expect(arg.data.status).toBe('blocked');
     expect(arg.data.prNumber).toBe(42);
-    expect(arg.data.reason).toBe('CI checks failed after 3 retries');
+    expect(arg.data.error).toBe('CI checks failed after 3 retries');
+    expect(arg.data.failedAt).toBeDefined();
     expect(arg.data.previousStatus).toBe('in_progress');
   });
 
-  it('publishes protomaker.feature.failed on transition to escalated', async () => {
-    const feature = {
-      id: 'f3',
-      title: 'Escalated feature',
-      projectSlug: 'proj',
-    };
+  it('publishes feature.failed on transition to escalated', async () => {
+    const feature = { id: 'f3', title: 'Escalated feature', projectSlug: 'proj' };
     const { pub, publishFn } = makePublisher({ feature });
 
     await pub.handleStatusChange({
@@ -142,20 +163,12 @@ describe('FeatureLifecycleBusPublisher', () => {
     });
 
     expect(publishFn).toHaveBeenCalledTimes(1);
-    const arg = publishFn.mock.calls[0][0];
-    expect(arg.event).toBe('protomaker.feature.failed');
-    expect(arg.data.featureId).toBe('f3');
-    expect(arg.data.status).toBe('escalated');
+    expect(publishFn.mock.calls[0][0].event).toBe('feature.failed');
+    expect(publishFn.mock.calls[0][0].data.featureId).toBe('f3');
   });
 
-  it('includes prNumber and reason in completed event payload', async () => {
-    const feature = {
-      id: 'f4',
-      title: 'Completed with PR',
-      projectSlug: 'proj',
-      prNumber: 99,
-      statusChangeReason: 'Workflow completed',
-    };
+  it('includes prNumber in completed payload (no status/reason fields)', async () => {
+    const feature = { id: 'f4', title: 'Completed with PR', projectSlug: 'proj', prNumber: 99 };
     const { pub, publishFn } = makePublisher({ feature });
 
     await pub.handleStatusChange({
@@ -165,20 +178,15 @@ describe('FeatureLifecycleBusPublisher', () => {
       newStatus: 'done',
     });
 
-    expect(publishFn).toHaveBeenCalledTimes(1);
     const arg = publishFn.mock.calls[0][0];
-    expect(arg.event).toBe('protomaker.feature.completed');
+    expect(arg.event).toBe('feature.completed');
     expect(arg.data.prNumber).toBe(99);
-    expect(arg.data.reason).toBe('Workflow completed');
-    expect(arg.data.status).toBe('done');
+    // completed carries no `error` field
+    expect(arg.data.error).toBeUndefined();
   });
 
-  it('falls back to payload reason when feature has no statusChangeReason', async () => {
-    const feature = {
-      id: 'f5',
-      title: 'No reason on feature',
-      projectSlug: 'proj',
-    };
+  it('falls back to payload reason for the error when feature has none', async () => {
+    const feature = { id: 'f5', title: 'No reason on feature', projectSlug: 'proj' };
     const { pub, publishFn } = makePublisher({ feature });
 
     await pub.handleStatusChange({
@@ -189,34 +197,6 @@ describe('FeatureLifecycleBusPublisher', () => {
       reason: 'from payload',
     });
 
-    expect(publishFn).toHaveBeenCalledTimes(1);
-    const arg = publishFn.mock.calls[0][0];
-    expect(arg.data.reason).toBe('from payload');
-  });
-
-  it('still publishes feature.failed when the feature cannot be loaded', async () => {
-    const featureLoader = { get: vi.fn().mockRejectedValue(new Error('gone')) };
-    const publishFn = vi.fn().mockResolvedValue({ ok: true });
-    const pub = new FeatureLifecycleBusPublisher(
-      { on: vi.fn() } as never,
-      featureLoader as never,
-      publishFn,
-      true
-    );
-
-    await pub.handleStatusChange({
-      featureId: 'f6',
-      projectPath: '/p',
-      oldStatus: 'in_progress',
-      newStatus: 'blocked',
-      reason: 'max retries exceeded',
-    });
-
-    expect(publishFn).toHaveBeenCalledTimes(1);
-    const arg = publishFn.mock.calls[0][0];
-    expect(arg.event).toBe('protomaker.feature.failed');
-    expect(arg.data.featureId).toBe('f6');
-    expect(arg.data.reason).toBe('max retries exceeded');
-    expect(arg.data.prNumber).toBeUndefined();
+    expect(publishFn.mock.calls[0][0].data.error).toBe('from payload');
   });
 });

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -213,6 +213,14 @@ export interface Feature {
   isEpic?: boolean; // True if this feature is an epic (container for child features)
   epicId?: string; // ID of parent epic (if this feature belongs to an epic)
   epicColor?: string; // Color for epic badge display (hex color)
+  /**
+   * Opaque metadata echoed from the originating creation request (e.g. the
+   * `meta` on a `manage_feature` / create_feature call). Carried through to the
+   * feature lifecycle bus events (#3810) so external consumers — e.g. the
+   * workstacean Linear bridge — can correlate back to their own source record
+   * (sourceMeta.sourceLinearIssueId) without persisted state on either side.
+   */
+  sourceMeta?: Record<string, unknown>;
   // Project/milestone tracking for milestone-gated execution
   projectSlug?: string; // Project this feature belongs to
   milestoneSlug?: string; // Milestone this feature belongs to


### PR DESCRIPTION
Closes the protoMaker side of **workstacean #482**. The lifecycle publisher existed (#3549) but **never fired on a topic workstacean listens to** — three bugs vs the verified `/publish` contract, each independently fatal:

| Bug | Was | Should be |
|---|---|---|
| **Topic** | `protomaker.feature.completed/failed` (prefixed) | `feature.completed` / `feature.failed` (dotted) |
| **Wire shape** | client POSTed `{event, data}` | `{topic, payload}` (workstacean republishes `payload` under `topic`) |
| **Auth** | no header | `X-API-Key: WORKSTACEAN_API_KEY` (else 401) |

## Changes
- **`workstacean-api.client`** — maps the `{event,data}` interface onto the wire `{topic, payload}` + sends `X-API-Key`. Fixes the HITL publish path too (its tests updated to assert the new shape).
- **`FeatureLifecycleBusPublisher`** — dotted topics; payload aligned to the contract: required `projectSlug` (with fallback so an event is never dropped for lacking it), `featureTitle`, `prNumber`, `branchName`, `repo`, `error` (failed only), `completedAt`/`failedAt`, and `sourceMeta` (echoes `feature.sourceMeta`, falls back to intake signal lineage). Subscribes to the single `feature:status-changed` chokepoint so all done/blocked paths are covered.
- **`Feature.sourceMeta`** — echoed from creation; flows via the existing `Partial<Feature>` create spread (no schema change).
- **CLAUDE.md** — `WORKSTACEAN_URL` / `WORKSTACEAN_API_KEY` / `WORKSTACEAN_PROJECT_SLUG`.

## Validation
20 tests pass (publisher 12 + HITL 8), server typecheck clean, eval gate green.

## Deploy note
Set `WORKSTACEAN_URL` (`http://workstacean:3000` on the docker-ai net) + `WORKSTACEAN_API_KEY` (same key already in Infisical for workstacean) on the protoMaker container. Once set, **#482 closes automatically** — the bridge + feature-notifier start firing on terminal transitions. No code needed on the workstacean side (consumers already subscribe).

Closes #3810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Workstacean event publishing integration with configurable environment variables.
  * Added source metadata support to features for tracking correlations with external systems through lifecycle events.

* **Documentation**
  * Updated environment configuration documentation with Workstacean integration settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->