### PR TITLE
feat(execute): verifier-evidence gate at EXECUTE exit (beads zg4, #3906)

### DIFF
--- a/apps/server/eval/baseline.json
+++ b/apps/server/eval/baseline.json
@@ -2,5 +2,5 @@
   "_comment": "Regression thresholds for the harness eval (#3904). The gate (npm run eval:gate) fails a PR whose scorecard.json drops below these. Tighten as the golden scenario set grows. successRate is the headline metric; escalationRate is capped so the pipeline doesn't 'pass' by escalating everything.",
   "minSuccessRate": 1.0,
   "maxEscalationRate": 0.5,
-  "minScenarios": 6
+  "minScenarios": 9
 }

--- a/apps/server/eval/review-pipeline.eval.ts
+++ b/apps/server/eval/review-pipeline.eval.ts
@@ -28,6 +28,7 @@ const { mockSimpleQuery } = vi.hoisted(() => ({ mockSimpleQuery: vi.fn() }));
 vi.mock('../src/providers/simple-query-service.js', () => ({ simpleQuery: mockSimpleQuery }));
 
 import { ReviewProcessor } from '../src/services/lead-engineer-review-merge-processors.js';
+import { ExecuteProcessor } from '../src/services/lead-engineer-execute-processor.js';
 import type { ProcessorServiceContext, StateContext } from '../src/services/lead-engineer-types.js';
 
 const DOMAIN: EvalDomain = 'review';
@@ -191,12 +192,106 @@ describe('eval: REVIEW bot-feedback audit gate', () => {
       expect(actual).toBe(s.expected);
     });
   }
+});
 
-  afterAll(() => {
-    const card = writeScorecard(new URL('./scorecard.json', import.meta.url).pathname);
-    // Visible in the run log for quick inspection.
-    console.log(
-      `[eval] scorecard: ${card.passed}/${card.total} passed (successRate ${card.successRate})`
-    );
-  });
+// ── EXECUTE domain: verifier-evidence gate (beads zg4) ───────────────────────
+// Drives the real ExecuteProcessor.runVerificationGate with the gate setting
+// supplied via the mocked settingsService (no module mock — keeps the REVIEW
+// scenarios' real getWorkflowSettings intact) and a stubbed worktree resolver.
+
+function execSvc(requireVerificationEvidence: unknown): ProcessorServiceContext {
+  return {
+    featureLoader: { update: vi.fn().mockResolvedValue(undefined), get: vi.fn() } as any,
+    events: { emit: vi.fn() } as any,
+    autoModeService: {} as any,
+    settingsService: {
+      getGlobalSettings: vi.fn().mockResolvedValue({}),
+      getProjectSettings: vi.fn().mockResolvedValue({ workflow: { requireVerificationEvidence } }),
+    } as any,
+  } as ProcessorServiceContext;
+}
+
+function execCtx(): StateContext {
+  return {
+    feature: { id: 'eval-exec', title: 'Eval execute', branchName: 'feature/x' },
+    projectPath: '/eval/project',
+  } as unknown as StateContext;
+}
+
+const cmdPass = (
+  _c: string,
+  _o: unknown,
+  cb: (e: null, r: { stdout: string; stderr: string }) => void
+) => cb(null, { stdout: '', stderr: '' });
+const cmdFail = (_c: string, _o: unknown, cb: (e: Error) => void) => cb(new Error('tsc failed'));
+
+interface ExecScenario {
+  id: string;
+  description: string;
+  expected: string;
+  setup: () => { proc: ExecuteProcessor; context: StateContext };
+}
+
+const execScenarios: ExecScenario[] = [
+  {
+    id: 'execute-verify-pass-proceeds',
+    description: 'Verifier gate enabled + check passes → pass (proceed to REVIEW)',
+    expected: 'pass',
+    setup: () => {
+      mockExec.mockImplementation(cmdPass);
+      const proc = new ExecuteProcessor(execSvc({ enabled: true, command: 'npm run typecheck' }));
+      (proc as any).resolveWorktreeDir = vi.fn().mockResolvedValue('/wt');
+      return { proc, context: execCtx() };
+    },
+  },
+  {
+    id: 'execute-verify-fail-blocks',
+    description: 'Verifier gate enabled + check fails → fail (blocks before REVIEW)',
+    expected: 'fail',
+    setup: () => {
+      mockExec.mockImplementation(cmdFail);
+      const proc = new ExecuteProcessor(execSvc({ enabled: true }));
+      (proc as any).resolveWorktreeDir = vi.fn().mockResolvedValue('/wt');
+      return { proc, context: execCtx() };
+    },
+  },
+  {
+    id: 'execute-verify-disabled-skips',
+    description: 'Verifier gate disabled → skipped (no run, no gate)',
+    expected: 'skipped',
+    setup: () => {
+      const proc = new ExecuteProcessor(execSvc({ enabled: false }));
+      (proc as any).resolveWorktreeDir = vi.fn().mockResolvedValue('/wt');
+      return { proc, context: execCtx() };
+    },
+  },
+];
+
+describe('eval: EXECUTE verifier-evidence gate', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  for (const s of execScenarios) {
+    it(s.id, async () => {
+      const { proc, context } = s.setup();
+      const actual = await (proc as any).runVerificationGate(context);
+      const passed = actual === s.expected;
+      record({
+        id: s.id,
+        domain: 'execute',
+        description: s.description,
+        expected: s.expected,
+        actual: String(actual),
+        passed,
+      });
+      expect(actual).toBe(s.expected);
+    });
+  }
+});
+
+// Top-level: write the aggregate scorecard after every domain's scenarios run.
+afterAll(() => {
+  const card = writeScorecard(new URL('./scorecard.json', import.meta.url).pathname);
+  console.log(
+    `[eval] scorecard: ${card.passed}/${card.total} passed (successRate ${card.successRate})`
+  );
 });

--- a/apps/server/src/lib/settings-helpers.ts
+++ b/apps/server/src/lib/settings-helpers.ts
@@ -832,6 +832,21 @@ export async function getWorkflowSettings(
         },
         ciClassification: projectSettings.workflow.ciClassification,
         a2aSkillExecution: projectSettings.workflow.a2aSkillExecution,
+        // Newer review/verification/eval fields — these were dropped by this
+        // explicit reconstruction, so a project that set any workflow settings
+        // silently lost them (freshEyesReview / reviewFeedbackAudit / etc. fell
+        // back to defaults regardless of config). Propagate them. (beads zg4)
+        freshEyesReview:
+          projectSettings.workflow.freshEyesReview ?? DEFAULT_WORKFLOW_SETTINGS.freshEyesReview,
+        reviewFeedbackAudit:
+          projectSettings.workflow.reviewFeedbackAudit ??
+          DEFAULT_WORKFLOW_SETTINGS.reviewFeedbackAudit,
+        requireVerificationEvidence:
+          projectSettings.workflow.requireVerificationEvidence ??
+          DEFAULT_WORKFLOW_SETTINGS.requireVerificationEvidence,
+        trajectoryInjection:
+          projectSettings.workflow.trajectoryInjection ??
+          DEFAULT_WORKFLOW_SETTINGS.trajectoryInjection,
       };
     }
     return DEFAULT_WORKFLOW_SETTINGS;

--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -970,11 +970,86 @@ export class ExecuteProcessor implements StateProcessor {
     // before transitioning to REVIEW, regardless of how the agent committed.
     await this.runPostAgentFormatting(ctx);
 
+    // Verifier-evidence gate (beads zg4): opt-in objective check on the diff
+    // before REVIEW. Records Feature.verificationEvidence; blocks (escalates to
+    // a human) on failure when the gate is enabled. No-op when disabled.
+    const verification = await this.runVerificationGate(ctx);
+    if (verification === 'fail') {
+      const reason =
+        'Verification gate failed at EXECUTE exit — the configured check did not pass on the diff. ' +
+        'See feature.verificationEvidence. Blocked before REVIEW.';
+      logger.warn('[EXECUTE][verify] gate failed — blocking before REVIEW', {
+        featureId: ctx.feature.id,
+      });
+      await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+        status: 'blocked',
+        statusChangeReason: reason,
+      });
+      return { nextState: null, shouldContinue: false, reason };
+    }
+
     return {
       nextState: 'REVIEW',
       shouldContinue: true,
       reason: 'Execution completed, moving to review',
     };
+  }
+
+  /**
+   * Verifier-evidence gate (beads zg4 / #3906). When
+   * `WorkflowSettings.requireVerificationEvidence.enabled`, run the configured
+   * objective command (default `npm run typecheck`) in the feature's worktree,
+   * record the result as `Feature.verificationEvidence`, and return 'fail' so
+   * the caller blocks REVIEW. Disabled or unresolvable → 'skipped' (no-op, no
+   * added latency for installs that don't opt in). Never throws.
+   */
+  private async runVerificationGate(ctx: StateContext): Promise<'pass' | 'fail' | 'skipped'> {
+    try {
+      const { getWorkflowSettings } = await import('../lib/settings-helpers.js');
+      const ws = await getWorkflowSettings(
+        ctx.projectPath,
+        this.serviceContext.settingsService,
+        '[EXECUTE][verify]'
+      );
+      const cfg = ws.requireVerificationEvidence;
+      if (!cfg?.enabled) return 'skipped';
+
+      const branchName = ctx.feature.branchName;
+      if (!branchName) return 'skipped';
+      const worktreeDir = await this.resolveWorktreeDir(ctx.projectPath, branchName);
+      if (!worktreeDir) return 'skipped';
+
+      const command = cfg.command ?? 'npm run typecheck';
+      const timeout = cfg.timeoutMs ?? 300_000;
+      const started = Date.now();
+      let passed = false;
+      let output = '';
+      try {
+        await execAsync(command, { cwd: worktreeDir, timeout });
+        passed = true;
+      } catch (err) {
+        const e = err as { stdout?: string; stderr?: string; message?: string };
+        output = `${e.stdout ?? ''}\n${e.stderr ?? e.message ?? ''}`.trim();
+      }
+
+      await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+        verificationEvidence: {
+          command,
+          passed,
+          ranAt: new Date().toISOString(),
+          durationMs: Date.now() - started,
+          ...(passed ? {} : { output: output.slice(-1500) }),
+        },
+      });
+      logger.info(`[EXECUTE][verify] ${command} → ${passed ? 'pass' : 'fail'}`, {
+        featureId: ctx.feature.id,
+      });
+      return passed ? 'pass' : 'fail';
+    } catch (err) {
+      // A gate that errors must not silently block; log and skip.
+      logger.warn('[EXECUTE][verify] gate errored (skipping):', err);
+      return 'skipped';
+    }
   }
 
   async exit(ctx: StateContext): Promise<void> {

--- a/apps/server/tests/unit/services/lead-engineer-verification-gate.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-verification-gate.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the EXECUTE-exit verifier-evidence gate (beads zg4).
+ *
+ * Verifies runVerificationGate: disabled → skip; enabled + command passes →
+ * 'pass' with evidence recorded; enabled + command fails → 'fail' with evidence;
+ * unresolvable worktree / no branch → skip. The processor's exit hook turns a
+ * 'fail' into a blocked transition (covered by the decision here).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+const { mockExec } = vi.hoisted(() => ({ mockExec: vi.fn() }));
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return { ...actual, exec: mockExec };
+});
+
+const { mockGetWorkflowSettings } = vi.hoisted(() => ({ mockGetWorkflowSettings: vi.fn() }));
+vi.mock('@/lib/settings-helpers.js', () => ({
+  getWorkflowSettings: mockGetWorkflowSettings,
+  getEffectivePrBaseBranch: vi.fn().mockResolvedValue('main'),
+}));
+
+import { ExecuteProcessor } from '@/services/lead-engineer-execute-processor.js';
+import type { ProcessorServiceContext, StateContext } from '@/services/lead-engineer-types.js';
+
+function makeCtx(overrides: Record<string, unknown> = {}): StateContext {
+  return {
+    feature: { id: 'feat-1', title: 'F', branchName: 'feature/x', ...overrides },
+    projectPath: '/proj',
+  } as unknown as StateContext;
+}
+
+function makeProc(settings: unknown, worktree: string | null = '/wt') {
+  const update = vi.fn().mockResolvedValue(undefined);
+  const svc = {
+    featureLoader: { update, get: vi.fn() },
+    settingsService: {},
+    events: { emit: vi.fn() },
+  } as unknown as ProcessorServiceContext;
+  mockGetWorkflowSettings.mockResolvedValue(settings);
+  const proc = new ExecuteProcessor(svc);
+  // resolveWorktreeDir is a private git helper — stub it for the unit.
+  (proc as unknown as { resolveWorktreeDir: unknown }).resolveWorktreeDir = vi
+    .fn()
+    .mockResolvedValue(worktree);
+  return { proc, update };
+}
+
+const passExec = (
+  _c: string,
+  _o: unknown,
+  cb: (e: null, r: { stdout: string; stderr: string }) => void
+) => cb(null, { stdout: '', stderr: '' });
+const failExec = (
+  _c: string,
+  _o: unknown,
+  cb: (e: Error & { stdout?: string; stderr?: string }) => void
+) => {
+  const err = new Error('tsc failed') as Error & { stdout?: string; stderr?: string };
+  err.stdout = 'src/x.ts(1,1): error TS2322';
+  cb(err);
+};
+
+describe('ExecuteProcessor.runVerificationGate (zg4)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('skips (no run, no evidence) when disabled', async () => {
+    const { proc, update } = makeProc({ requireVerificationEvidence: { enabled: false } });
+    const result = await (proc as any).runVerificationGate(makeCtx());
+    expect(result).toBe('skipped');
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("returns 'pass' and records passing evidence when the command succeeds", async () => {
+    mockExec.mockImplementation(passExec);
+    const { proc, update } = makeProc({
+      requireVerificationEvidence: { enabled: true, command: 'npm run typecheck' },
+    });
+    const result = await (proc as any).runVerificationGate(makeCtx());
+    expect(result).toBe('pass');
+    expect(update).toHaveBeenCalledWith(
+      '/proj',
+      'feat-1',
+      expect.objectContaining({
+        verificationEvidence: expect.objectContaining({
+          command: 'npm run typecheck',
+          passed: true,
+        }),
+      })
+    );
+  });
+
+  it("returns 'fail' and records failing evidence (with output) when the command fails", async () => {
+    mockExec.mockImplementation(failExec);
+    const { proc, update } = makeProc({ requireVerificationEvidence: { enabled: true } });
+    const result = await (proc as any).runVerificationGate(makeCtx());
+    expect(result).toBe('fail');
+    const evidence = update.mock.calls[0][2].verificationEvidence;
+    expect(evidence.passed).toBe(false);
+    expect(evidence.output).toContain('error TS2322');
+  });
+
+  it('skips when the feature has no branch', async () => {
+    const { proc } = makeProc({ requireVerificationEvidence: { enabled: true } });
+    const result = await (proc as any).runVerificationGate(makeCtx({ branchName: undefined }));
+    expect(result).toBe('skipped');
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('skips when the worktree cannot be resolved', async () => {
+    mockExec.mockImplementation(passExec);
+    const { proc } = makeProc({ requireVerificationEvidence: { enabled: true } }, null);
+    const result = await (proc as any).runVerificationGate(makeCtx());
+    expect(result).toBe('skipped');
+  });
+});

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -466,6 +466,20 @@ export interface Feature {
    */
   reviewAuditDismissCount?: number;
   /**
+   * Objective verification evidence captured at EXECUTE exit (beads zg4): which
+   * command ran against the diff and whether it passed. Recorded whenever the
+   * verifier gate runs; when `requireVerificationEvidence` is enabled a failing
+   * result blocks the REVIEW transition.
+   */
+  verificationEvidence?: {
+    command: string;
+    passed: boolean;
+    ranAt: string;
+    durationMs?: number;
+    /** Tail of the command output on failure (truncated). */
+    output?: string;
+  };
+  /**
    * Number of CI failure remediation cycles.
    * Tracks how many times the agent has fixed CI failures.
    */

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -471,6 +471,24 @@ export interface WorkflowSettings {
     model?: string;
   };
   /**
+   * Verifier evidence gate at EXECUTE exit (#3810→#3906 / beads zg4).
+   * When enabled, before transitioning EXECUTE→REVIEW the pipeline runs an
+   * objective verification command (typecheck/lint/test) in the worktree,
+   * records the result as `Feature.verificationEvidence`, and blocks the
+   * transition (escalates) if it fails — converting "agent says it works" into
+   * a measured pass/fail. Opt-in (default off) because the command adds latency
+   * and CI already covers it post-PR; turn on for hard pre-review verification.
+   * @default { enabled: false, command: 'npm run typecheck' }
+   */
+  requireVerificationEvidence?: {
+    /** Enable the EXECUTE-exit verification gate. @default false */
+    enabled: boolean;
+    /** Command run in the worktree as the objective check. @default 'npm run typecheck' */
+    command?: string;
+    /** Max milliseconds to wait for the command. @default 300000 */
+    timeoutMs?: number;
+  };
+  /**
    * Trajectory injection configuration.
    * When enabled, relevant past trajectories are injected into agent prompts
    * as a "Lessons from Similar Features" section. Omitting this field defaults


### PR DESCRIPTION
Sprint-1 `zg4`. Opt-in objective verification before `EXECUTE→REVIEW` — converts "the agent says it works" into a measured pass/fail (the Verifier-Layer pattern from #3906).

## What
- When `WorkflowSettings.requireVerificationEvidence.enabled`, `ExecuteProcessor.runVerificationGate` runs the configured command (default `npm run typecheck`) in the feature's worktree, records `Feature.verificationEvidence` (`{command, passed, ranAt, durationMs, output?}`), and **blocks** (escalates to a human) on failure. Default **off** — CI covers post-PR; turn on for hard pre-review verification. Never throws; unresolvable worktree/no-branch → skip.

## Also fixes a real bug in `getWorkflowSettings`
It rebuilt the workflow object from an explicit key list and **dropped newer fields** — so a project that set *any* workflow settings silently lost `freshEyesReview`, `reviewFeedbackAudit` (#3901), `trajectoryInjection`, and `requireVerificationEvidence` (all fell back to defaults regardless of config). Now propagated. (This is why #3901's audit setting would've been ignored for configured projects.)

## Tests
- 5 unit tests (pass / fail / disabled / no-branch / no-worktree).
- 3 eval scenarios (new `execute` domain in the harness), `baseline.json` minScenarios 6→9.
- `eval:harness` 9/9, `eval:gate` PASS, server typecheck clean, settings-helpers + execute-processor suites green.

Closes beads `zg4`. Refs #3906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a verification evidence gate that runs during code processing, executing configurable verification commands (e.g., typecheck) to validate code quality before progression.
  * Gate can be enabled/disabled and configured with custom commands and timeouts.
  * Blocks feature progression if verification fails; records verification results for audit purposes.

* **Tests**
  * Added comprehensive test coverage for the new verification gate functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3914?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->