### PR TITLE
feat(ops): quantified failure-mode taxonomy report (beads 2u4, #3905)

### DIFF
--- a/apps/server/src/routes/ops/index.ts
+++ b/apps/server/src/routes/ops/index.ts
@@ -25,6 +25,7 @@ import { createDeliveriesRoutes } from './routes/deliveries.js';
 import { createAuditRoutes } from './routes/audit.js';
 import { createConcurrencyRoutes } from './routes/concurrency.js';
 import { createEventsRoutes } from './routes/events.js';
+import { createFailureTaxonomyRoutes } from './routes/failure-taxonomy.js';
 import { createWorktreeCleanupRoutes } from './routes/worktree-cleanup.js';
 
 export function createOpsRoutes(
@@ -49,6 +50,7 @@ export function createOpsRoutes(
     '/worktree-cleanup',
     createWorktreeCleanupRoutes(worktreeLifecycleService, featureLoader, events, autoModeService)
   );
+  router.use('/failure-taxonomy', createFailureTaxonomyRoutes(featureLoader, autoModeService));
 
   return router;
 }

--- a/apps/server/src/routes/ops/routes/failure-taxonomy.ts
+++ b/apps/server/src/routes/ops/routes/failure-taxonomy.ts
@@ -1,0 +1,57 @@
+/**
+ * Failure-mode taxonomy API route (beads protomaker-2u4 / #3905).
+ *
+ * POST /   - Quantified breakdown of blocked/escalated features by failure
+ *            category (counts + %), classified from statusChangeReason.
+ *            Body: { projectPath?: string }  // omit → all active auto-loop projects
+ *            Returns: { success, taxonomy }
+ */
+
+import { Router } from 'express';
+import { createLogger } from '@protolabsai/utils';
+import type { Feature } from '@protolabsai/types';
+import type { FeatureLoader } from '../../../services/feature-loader.js';
+import type { AutoModeService } from '../../../services/auto-mode-service.js';
+import { createFailureClassifierService } from '../../../services/failure-classifier-service.js';
+import { buildFailureTaxonomy } from '../../../services/failure-taxonomy-service.js';
+
+const logger = createLogger('Routes:FailureTaxonomy');
+
+export function createFailureTaxonomyRoutes(
+  featureLoader: FeatureLoader,
+  autoModeService: AutoModeService
+): Router {
+  const router = Router();
+  const classifier = createFailureClassifierService();
+
+  router.post('/', async (req, res) => {
+    try {
+      const projectPath: string | undefined =
+        typeof req.body?.projectPath === 'string' && req.body.projectPath.trim()
+          ? req.body.projectPath
+          : undefined;
+
+      const projectPaths = projectPath
+        ? [projectPath]
+        : Array.from(new Set(autoModeService.getActiveAutoLoopProjects()));
+
+      const features: Feature[] = [];
+      for (const p of projectPaths) {
+        try {
+          features.push(...(await featureLoader.getAll(p)));
+        } catch (err) {
+          logger.warn(`Failed to load features for ${p}:`, err);
+        }
+      }
+
+      const taxonomy = buildFailureTaxonomy(features, classifier);
+      res.json({ success: true, projectCount: projectPaths.length, taxonomy });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error('Failure taxonomy request failed:', err);
+      res.status(500).json({ success: false, error: message });
+    }
+  });
+
+  return router;
+}

--- a/apps/server/src/services/failure-taxonomy-service.ts
+++ b/apps/server/src/services/failure-taxonomy-service.ts
@@ -1,0 +1,70 @@
+/**
+ * Failure-mode taxonomy (beads protomaker-2u4 / #3905).
+ *
+ * Aggregates blocked/escalated features into a quantified failure-mode
+ * breakdown (counts + %) by classifying each feature's statusChangeReason via
+ * the existing FailureClassifierService. This is the read-only analytics input
+ * to the self-improving harness loop (#3905): the proposer mines the top
+ * pattern, and operators see where the dark factory is actually failing.
+ *
+ * Pure: pass features + a classifier; no I/O.
+ */
+
+import type { Feature } from '@protolabsai/types';
+import type { FailureClassifierService } from './failure-classifier-service.js';
+
+/** Board statuses considered terminal failures for taxonomy purposes. */
+const FAILURE_STATUSES: ReadonlySet<string> = new Set(['blocked', 'escalated']);
+
+export interface FailureTaxonomyEntry {
+  /** FailureCategory from the classifier (e.g. merge_conflict, quota). */
+  category: string;
+  count: number;
+  /** Share of classified failures, 0–100 with one decimal. */
+  pct: number;
+  /** A few representative features for this category. */
+  examples: Array<{ featureId: string; title?: string; reason: string }>;
+}
+
+export interface FailureTaxonomy {
+  generatedAt: string;
+  /** Number of features scanned. */
+  scanned: number;
+  /** Number of those in a terminal failure state (the taxonomy denominator). */
+  failed: number;
+  /** Categories sorted by count desc. */
+  byCategory: FailureTaxonomyEntry[];
+}
+
+export function buildFailureTaxonomy(
+  features: Feature[],
+  classifier: Pick<FailureClassifierService, 'classify'>,
+  opts: { maxExamples?: number } = {}
+): FailureTaxonomy {
+  const maxExamples = opts.maxExamples ?? 3;
+  const failed = features.filter((f) => FAILURE_STATUSES.has(String(f.status)));
+
+  const buckets = new Map<string, FailureTaxonomyEntry>();
+  for (const f of failed) {
+    const reason = (f.statusChangeReason ?? '').trim() || 'unknown';
+    const category = reason === 'unknown' ? 'unknown' : classifier.classify(reason).category;
+    const entry = buckets.get(category) ?? { category, count: 0, pct: 0, examples: [] };
+    entry.count++;
+    if (entry.examples.length < maxExamples) {
+      entry.examples.push({ featureId: f.id, title: f.title, reason: reason.slice(0, 200) });
+    }
+    buckets.set(category, entry);
+  }
+
+  const failedCount = failed.length;
+  const byCategory = [...buckets.values()]
+    .map((e) => ({ ...e, pct: failedCount ? Math.round((e.count / failedCount) * 1000) / 10 : 0 }))
+    .sort((a, b) => b.count - a.count);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    scanned: features.length,
+    failed: failedCount,
+    byCategory,
+  };
+}

--- a/apps/server/tests/unit/services/failure-taxonomy-service.test.ts
+++ b/apps/server/tests/unit/services/failure-taxonomy-service.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { buildFailureTaxonomy } from '@/services/failure-taxonomy-service.js';
+import { createFailureClassifierService } from '@/services/failure-classifier-service.js';
+import type { Feature } from '@protolabsai/types';
+
+function feat(id: string, status: string, statusChangeReason?: string): Feature {
+  return {
+    id,
+    category: 'feature',
+    description: '',
+    status,
+    statusChangeReason,
+  } as unknown as Feature;
+}
+
+// Deterministic stub so the test asserts aggregation, not classifier regexes.
+const stub = {
+  classify: (reason: string) => ({
+    category: reason.includes('conflict')
+      ? 'merge_conflict'
+      : reason.includes('quota')
+        ? 'quota'
+        : 'tool_error',
+    confidence: 1,
+  }),
+} as any;
+
+describe('buildFailureTaxonomy', () => {
+  it('only counts blocked/escalated features', () => {
+    const features = [
+      feat('a', 'done', 'merged'),
+      feat('b', 'in_progress'),
+      feat('c', 'backlog'),
+      feat('d', 'blocked', 'merge conflict'),
+      feat('e', 'escalated', 'quota exceeded'),
+    ];
+    const t = buildFailureTaxonomy(features, stub);
+    expect(t.scanned).toBe(5);
+    expect(t.failed).toBe(2);
+  });
+
+  it('aggregates counts + pct by category, sorted desc', () => {
+    const features = [
+      feat('1', 'blocked', 'merge conflict A'),
+      feat('2', 'blocked', 'merge conflict B'),
+      feat('3', 'blocked', 'merge conflict C'),
+      feat('4', 'escalated', 'quota exceeded'),
+    ];
+    const t = buildFailureTaxonomy(features, stub);
+    expect(t.failed).toBe(4);
+    expect(t.byCategory[0]).toMatchObject({ category: 'merge_conflict', count: 3, pct: 75 });
+    expect(t.byCategory[1]).toMatchObject({ category: 'quota', count: 1, pct: 25 });
+  });
+
+  it('classifies missing reason as "unknown"', () => {
+    const t = buildFailureTaxonomy([feat('x', 'blocked')], stub);
+    expect(t.byCategory[0]).toMatchObject({ category: 'unknown', count: 1 });
+  });
+
+  it('caps examples per category', () => {
+    const features = Array.from({ length: 5 }, (_, i) => feat(`f${i}`, 'blocked', `conflict ${i}`));
+    const t = buildFailureTaxonomy(features, stub, { maxExamples: 2 });
+    expect(t.byCategory[0].count).toBe(5);
+    expect(t.byCategory[0].examples).toHaveLength(2);
+  });
+
+  it('returns an empty taxonomy when nothing failed', () => {
+    const t = buildFailureTaxonomy([feat('a', 'done')], stub);
+    expect(t.failed).toBe(0);
+    expect(t.byCategory).toEqual([]);
+  });
+
+  it('integrates with the real classifier (sanity)', () => {
+    const t = buildFailureTaxonomy(
+      [feat('a', 'blocked', 'Max agent retries exceeded: usage limit / quota reached')],
+      createFailureClassifierService()
+    );
+    expect(t.failed).toBe(1);
+    expect(t.byCategory[0].category).toBeTruthy();
+    expect(t.byCategory[0].count).toBe(1);
+  });
+});


### PR DESCRIPTION
Sprint-2 `2u4` — the analytics input the self-improving harness loop (#3905) mines, and the view operators use to see where the factory actually fails.

## What
- `buildFailureTaxonomy(features, classifier)` (pure) — filters blocked/escalated features, classifies each `statusChangeReason` via the existing `FailureClassifierService`, returns `{ scanned, failed, byCategory: [{category, count, pct, examples}] }` sorted by count desc.
- **`POST /api/ops/failure-taxonomy`** `{ projectPath? }` (defaults to active auto-loop projects) — mounted in ops routes.

## Tests
6 unit tests: failure-only filter, count/pct aggregation + sort, `unknown` reason, example cap, empty taxonomy, and a real-classifier integration sanity check. Typecheck clean; eval gate green (read-only analytics, no pipeline-decision change → no eval scenario needed).

Closes beads `2u4`. **Unblocks `2fq`** (harness-evolver proposer — it mines the top category from this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new failure-taxonomy API endpoint that analyzes and categorizes failure patterns in your projects. Returns a breakdown of failure types with counts, percentages, and representative examples. Supports analysis of individual projects or aggregated results across all active projects.

* **Tests**
  * Added unit tests for the failure taxonomy service.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3915?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->