### PR TITLE
feat(ops): harness-evolver proposer (beads 2fq, #3905)

### DIFF
--- a/apps/server/src/routes/ops/routes/failure-taxonomy.ts
+++ b/apps/server/src/routes/ops/routes/failure-taxonomy.ts
@@ -14,6 +14,7 @@ import type { FeatureLoader } from '../../../services/feature-loader.js';
 import type { AutoModeService } from '../../../services/auto-mode-service.js';
 import { createFailureClassifierService } from '../../../services/failure-classifier-service.js';
 import { buildFailureTaxonomy } from '../../../services/failure-taxonomy-service.js';
+import { proposeHarnessImprovement } from '../../../services/harness-evolver-service.js';
 
 const logger = createLogger('Routes:FailureTaxonomy');
 
@@ -24,31 +25,48 @@ export function createFailureTaxonomyRoutes(
   const router = Router();
   const classifier = createFailureClassifierService();
 
+  async function resolveTaxonomy(body: { projectPath?: unknown }) {
+    const projectPath =
+      typeof body?.projectPath === 'string' && body.projectPath.trim()
+        ? body.projectPath
+        : undefined;
+    const projectPaths = projectPath
+      ? [projectPath]
+      : Array.from(new Set(autoModeService.getActiveAutoLoopProjects()));
+    const features: Feature[] = [];
+    for (const p of projectPaths) {
+      try {
+        features.push(...(await featureLoader.getAll(p)));
+      } catch (err) {
+        logger.warn(`Failed to load features for ${p}:`, err);
+      }
+    }
+    return {
+      taxonomy: buildFailureTaxonomy(features, classifier),
+      projectCount: projectPaths.length,
+    };
+  }
+
   router.post('/', async (req, res) => {
     try {
-      const projectPath: string | undefined =
-        typeof req.body?.projectPath === 'string' && req.body.projectPath.trim()
-          ? req.body.projectPath
-          : undefined;
-
-      const projectPaths = projectPath
-        ? [projectPath]
-        : Array.from(new Set(autoModeService.getActiveAutoLoopProjects()));
-
-      const features: Feature[] = [];
-      for (const p of projectPaths) {
-        try {
-          features.push(...(await featureLoader.getAll(p)));
-        } catch (err) {
-          logger.warn(`Failed to load features for ${p}:`, err);
-        }
-      }
-
-      const taxonomy = buildFailureTaxonomy(features, classifier);
-      res.json({ success: true, projectCount: projectPaths.length, taxonomy });
+      const { taxonomy, projectCount } = await resolveTaxonomy(req.body ?? {});
+      res.json({ success: true, projectCount, taxonomy });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error('Failure taxonomy request failed:', err);
+      res.status(500).json({ success: false, error: message });
+    }
+  });
+
+  // Proposal: top failure mode → suggested harness improvement (beads 2fq).
+  router.post('/proposal', async (req, res) => {
+    try {
+      const { taxonomy, projectCount } = await resolveTaxonomy(req.body ?? {});
+      const proposal = proposeHarnessImprovement(taxonomy);
+      res.json({ success: true, projectCount, proposal, taxonomy });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error('Harness proposal request failed:', err);
       res.status(500).json({ success: false, error: message });
     }
   });

--- a/apps/server/src/services/harness-evolver-service.ts
+++ b/apps/server/src/services/harness-evolver-service.ts
@@ -1,0 +1,121 @@
+/**
+ * Harness-evolver proposer (beads protomaker-2fq / #3905).
+ *
+ * Reads the failure-mode taxonomy (2u4) and proposes a concrete harness/prompt/
+ * context improvement targeting the top recurring failure category. This is the
+ * *proposal* step only — it does NOT apply anything. The eval-gated auto-PR step
+ * (39l) consumes a proposal, applies the edit in a worktree, evals it against the
+ * harness, and opens a PR only if regression-clean.
+ *
+ * Pure: pass a taxonomy; no I/O.
+ */
+
+import type { FailureTaxonomy } from './failure-taxonomy-service.js';
+
+export interface HarnessProposal {
+  /** The failure category this proposal targets. */
+  category: string;
+  count: number;
+  pct: number;
+  /** Why this is happening (the leading hypothesis for the category). */
+  hypothesis: string;
+  /** Where a fix most likely lives (file/subsystem hint for the applier). */
+  suggestedTarget: string;
+  /** Human-readable rationale incl. the share of failures. */
+  rationale: string;
+  /** Representative failing features for the category. */
+  examples: Array<{ featureId: string; title?: string; reason: string }>;
+}
+
+/**
+ * Per-category remediation knowledge. Maps the classifier's failure categories
+ * to a leading hypothesis + the subsystem a fix most likely touches. Keep this
+ * the single place that encodes "what tends to fix category X".
+ */
+const REMEDIATION_MAP: Record<string, { hypothesis: string; target: string }> = {
+  merge_conflict: {
+    hypothesis:
+      'Feature worktrees drift behind origin/<base>, so the pre-flight/merge conflicts. Strengthen the pre-flight rebase / ensureCleanMergeState path.',
+    target: 'lead-engineer-execute-processor.ts pre-flight + libs/git-utils rebase',
+  },
+  quota: {
+    hypothesis:
+      'Model usage/budget limits are exhausted mid-run. Tune the model tier per complexity or the remediation/concurrency budget, and ensure clean pause-and-resume.',
+    target: 'model hierarchy (DEFAULT_MODELS) + RemediationBudgetEnforcer + concurrency',
+  },
+  rate_limit: {
+    hypothesis:
+      'Gateway/API throttling. Apply exponential backoff and stagger dispatch (workflow stagger setting).',
+    target: 'structured retry policy + FeatureScheduler dispatch stagger',
+  },
+  test_failure: {
+    hypothesis:
+      'Agents ship diffs whose tests fail. Enable requireVerificationEvidence (zg4) for this project so failing diffs are caught before REVIEW.',
+    target: 'WorkflowSettings.requireVerificationEvidence + EXECUTE verifier gate',
+  },
+  tool_error: {
+    hypothesis:
+      'Agents misuse tools (bad args / wrong tool). Tighten MCP tool schemas and per-role allowlists.',
+    target: 'packages/mcp-server/src/tools/*.ts schemas + per-role allowlists',
+  },
+  authentication: {
+    hypothesis:
+      'Gateway/credential failures (e.g. 401, key-not-allowed). Verify gateway routing + the API key wiring.',
+    target: 'providers/proto-provider gateway config + credential env',
+  },
+  dependency: {
+    hypothesis:
+      'Cross-repo or package dependencies block execution. Check externalDependencies gating and auto-install in pre-flight.',
+    target: 'dependency resolver + cross-repo dependency gating',
+  },
+  validation: {
+    hypothesis:
+      'Feature inputs are underspecified, so the agent flails. Strengthen INTAKE enrichment / acceptance-criteria generation.',
+    target: 'INTAKE phase description enrichment',
+  },
+  transient: {
+    hypothesis:
+      'Network/timeout flakiness. Increase retry backoff and timeouts for transient errors.',
+    target: 'structured retry policy / timeouts',
+  },
+  retry_exhausted: {
+    hypothesis:
+      'Agents burn all retries without converging — usually a deeper unaddressed cause. Inspect the example reasons; the real category may be mis-classified.',
+    target: 'FailureClassifierService patterns + the underlying category fix',
+  },
+  unknown: {
+    hypothesis:
+      'These failures are unclassified — the classifier has no pattern for them. Add patterns to FailureClassifierService so they bucket into an actionable category.',
+    target: 'failure-classifier-service.ts FAILURE_PATTERNS',
+  },
+};
+
+export interface ProposeOptions {
+  /** Minimum failures in the top category to propose (avoid acting on noise). @default 2 */
+  minCount?: number;
+}
+
+/**
+ * Propose a harness improvement for the top failure category, or null when
+ * there is nothing actionable (no failures, or the top category is below the
+ * noise threshold).
+ */
+export function proposeHarnessImprovement(
+  taxonomy: FailureTaxonomy,
+  opts: ProposeOptions = {}
+): HarnessProposal | null {
+  const minCount = opts.minCount ?? 2;
+  const top = taxonomy.byCategory[0];
+  if (!top || top.count < minCount) return null;
+
+  const remediation = REMEDIATION_MAP[top.category] ?? REMEDIATION_MAP.unknown;
+  return {
+    category: top.category,
+    count: top.count,
+    pct: top.pct,
+    hypothesis: remediation.hypothesis,
+    suggestedTarget: remediation.target,
+    rationale: `"${top.category}" is the top failure mode: ${top.count} of ${taxonomy.failed} failed features (${top.pct}%). ${remediation.hypothesis}`,
+    examples: top.examples,
+  };
+}

--- a/apps/server/tests/unit/services/harness-evolver-service.test.ts
+++ b/apps/server/tests/unit/services/harness-evolver-service.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { proposeHarnessImprovement } from '@/services/harness-evolver-service.js';
+import type { FailureTaxonomy } from '@/services/failure-taxonomy-service.js';
+
+function taxonomy(byCategory: FailureTaxonomy['byCategory'], failed?: number): FailureTaxonomy {
+  return {
+    generatedAt: '2026-05-27T00:00:00Z',
+    scanned: 10,
+    failed: failed ?? byCategory.reduce((n, c) => n + c.count, 0),
+    byCategory,
+  };
+}
+
+describe('proposeHarnessImprovement', () => {
+  it('proposes a fix for the top category with the mapped hypothesis + target', () => {
+    const p = proposeHarnessImprovement(
+      taxonomy([
+        {
+          category: 'merge_conflict',
+          count: 4,
+          pct: 66.7,
+          examples: [{ featureId: 'a', reason: 'conflict' }],
+        },
+        { category: 'quota', count: 2, pct: 33.3, examples: [] },
+      ])
+    );
+    expect(p).not.toBeNull();
+    expect(p!.category).toBe('merge_conflict');
+    expect(p!.count).toBe(4);
+    expect(p!.pct).toBe(66.7);
+    expect(p!.suggestedTarget).toMatch(/pre-flight|rebase/i);
+    expect(p!.rationale).toContain('top failure mode');
+    expect(p!.examples).toHaveLength(1);
+  });
+
+  it('returns null when the top category is below the noise threshold', () => {
+    const p = proposeHarnessImprovement(
+      taxonomy([{ category: 'tool_error', count: 1, pct: 100, examples: [] }])
+    );
+    expect(p).toBeNull();
+  });
+
+  it('respects a custom minCount', () => {
+    const t = taxonomy([{ category: 'tool_error', count: 1, pct: 100, examples: [] }]);
+    expect(proposeHarnessImprovement(t, { minCount: 1 })).not.toBeNull();
+  });
+
+  it('returns null on an empty taxonomy', () => {
+    expect(proposeHarnessImprovement(taxonomy([], 0))).toBeNull();
+  });
+
+  it('falls back to the unknown remediation for an unmapped category', () => {
+    const p = proposeHarnessImprovement(
+      taxonomy([{ category: 'something_new', count: 3, pct: 100, examples: [] }])
+    );
+    expect(p).not.toBeNull();
+    expect(p!.suggestedTarget).toMatch(/failure-classifier/i);
+  });
+
+  it('maps test_failure to the verifier gate (zg4) target', () => {
+    const p = proposeHarnessImprovement(
+      taxonomy([{ category: 'test_failure', count: 5, pct: 100, examples: [] }])
+    );
+    expect(p!.suggestedTarget).toMatch(/requireVerificationEvidence|verifier/i);
+  });
+});


### PR DESCRIPTION
Sprint-2 `2fq`. Reads the failure-mode taxonomy (2u4) and proposes a concrete harness improvement for the top recurring failure category — **proposal only** (applying + eval-gating + PR'ing is 39l).

- `proposeHarnessImprovement(taxonomy, opts)` (pure) → { category, count, pct, hypothesis, suggestedTarget, rationale, examples } or null below the noise threshold (minCount default 2). Per-category REMEDIATION_MAP encodes the leading fix per category.
- `POST /api/ops/failure-taxonomy/proposal` surfaces it.
- 6 unit tests; typecheck clean; eval gate green.

Closes `2fq`. Unblocks `39l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new API endpoint for generating harness improvement proposals based on analyzed test failure patterns.

* **Refactor**
  * Refactored taxonomy resolution logic for improved code reuse and consistency across endpoints.

* **Tests**
  * Added comprehensive unit tests for proposal generation functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->