### PR TITLE
feat(ops): harness auto-improvement — eval-gated improvement filing (beads 39l, #3905)

### DIFF
--- a/apps/server/src/routes/ops/routes/failure-taxonomy.ts
+++ b/apps/server/src/routes/ops/routes/failure-taxonomy.ts
@@ -15,6 +15,7 @@ import type { AutoModeService } from '../../../services/auto-mode-service.js';
 import { createFailureClassifierService } from '../../../services/failure-classifier-service.js';
 import { buildFailureTaxonomy } from '../../../services/failure-taxonomy-service.js';
 import { proposeHarnessImprovement } from '../../../services/harness-evolver-service.js';
+import { HarnessAutoImprovementService } from '../../../services/harness-auto-improvement-service.js';
 
 const logger = createLogger('Routes:FailureTaxonomy');
 
@@ -67,6 +68,30 @@ export function createFailureTaxonomyRoutes(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error('Harness proposal request failed:', err);
+      res.status(500).json({ success: false, error: message });
+    }
+  });
+
+  // Auto-improve: file a deduped improvement feature for the top failure mode
+  // (beads 39l). The filed feature flows through the eval-gated pipeline + review.
+  const autoImprove = new HarnessAutoImprovementService(featureLoader, classifier);
+  router.post('/auto-improve', async (req, res) => {
+    try {
+      const projectPath =
+        typeof req.body?.projectPath === 'string' && req.body.projectPath.trim()
+          ? req.body.projectPath
+          : undefined;
+      const projectPaths = projectPath
+        ? [projectPath]
+        : Array.from(new Set(autoModeService.getActiveAutoLoopProjects()));
+      const results = [];
+      for (const p of projectPaths) {
+        results.push({ projectPath: p, ...(await autoImprove.runOnce(p)) });
+      }
+      res.json({ success: true, results });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error('Harness auto-improve request failed:', err);
       res.status(500).json({ success: false, error: message });
     }
   });

--- a/apps/server/src/services/harness-auto-improvement-service.ts
+++ b/apps/server/src/services/harness-auto-improvement-service.ts
@@ -1,0 +1,98 @@
+/**
+ * Harness auto-improvement (beads protomaker-39l / #3905) — the flywheel payoff.
+ *
+ * Closes the self-improvement loop SAFELY: it turns the top failure-mode
+ * proposal (2fq) into a deduped, tracked improvement feature on the board. That
+ * feature then flows through the normal pipeline, where the harness-eval CI gate
+ * (#3904/#3908) enforces "regression-clean" on the resulting PR and a human
+ * reviews it — so the loop never blindly writes + merges harness changes.
+ *
+ * On-demand + dedup'd: it only files when there's an actionable top category and
+ * no equivalent improvement is already open (fingerprint marker in description).
+ */
+
+import { createLogger } from '@protolabsai/utils';
+import type { FeatureLoader } from './feature-loader.js';
+import {
+  createFailureClassifierService,
+  type FailureClassifierService,
+} from './failure-classifier-service.js';
+import { buildFailureTaxonomy } from './failure-taxonomy-service.js';
+import { proposeHarnessImprovement } from './harness-evolver-service.js';
+
+const logger = createLogger('HarnessAutoImprovement');
+
+/** Statuses where an open improvement counts as "already filed" (dedup). */
+const OPEN_STATUSES: ReadonlySet<string> = new Set(['backlog', 'in_progress', 'review']);
+
+export interface AutoImproveResult {
+  filed: boolean;
+  reason: string;
+  category?: string;
+  featureId?: string;
+}
+
+export class HarnessAutoImprovementService {
+  constructor(
+    private readonly featureLoader: Pick<FeatureLoader, 'getAll' | 'create'>,
+    private readonly classifier: Pick<
+      FailureClassifierService,
+      'classify'
+    > = createFailureClassifierService()
+  ) {}
+
+  /**
+   * Run one improvement cycle for a project: taxonomy → top-category proposal →
+   * file a deduped improvement feature. Never throws; returns what happened.
+   */
+  async runOnce(projectPath: string, opts: { minCount?: number } = {}): Promise<AutoImproveResult> {
+    try {
+      const features = await this.featureLoader.getAll(projectPath);
+      const taxonomy = buildFailureTaxonomy(features, this.classifier);
+      const proposal = proposeHarnessImprovement(taxonomy, { minCount: opts.minCount });
+      if (!proposal) return { filed: false, reason: 'no actionable proposal above threshold' };
+
+      // Dedup: skip if an improvement for this category is already open.
+      const marker = `harness-improve:${proposal.category}`;
+      const existing = features.find(
+        (f) =>
+          typeof f.description === 'string' &&
+          f.description.includes(marker) &&
+          OPEN_STATUSES.has(String(f.status))
+      );
+      if (existing) {
+        return {
+          filed: false,
+          reason: 'already filed',
+          category: proposal.category,
+          featureId: existing.id,
+        };
+      }
+
+      const examples = proposal.examples.map((e) => `- ${e.featureId}: ${e.reason}`).join('\n');
+      const description =
+        `Auto-filed by the harness self-improvement loop (#3905). ${proposal.rationale}\n\n` +
+        `**Hypothesis:** ${proposal.hypothesis}\n` +
+        `**Suggested target:** ${proposal.suggestedTarget}\n\n` +
+        `**Example failures (${proposal.category}):**\n${examples || '- (none captured)'}\n\n` +
+        `**Acceptance:** reduce \`${proposal.category}\` failures; the fix PR must pass the harness eval gate (no success-rate regression) and human review.\n\n` +
+        `<!-- ${marker} -->`;
+
+      const created = await this.featureLoader.create(projectPath, {
+        title: `Harness improvement: reduce ${proposal.category} failures`,
+        category: 'chore',
+        description,
+        priority: 2,
+      });
+
+      logger.info(`[harness-improve] filed improvement for "${proposal.category}"`, {
+        featureId: created.id,
+        count: proposal.count,
+      });
+      return { filed: true, reason: 'filed', category: proposal.category, featureId: created.id };
+    } catch (err) {
+      logger.warn('[harness-improve] runOnce failed (non-fatal):', err);
+      return { filed: false, reason: `error: ${err instanceof Error ? err.message : String(err)}` };
+    }
+  }
+}

--- a/apps/server/tests/unit/services/harness-auto-improvement-service.test.ts
+++ b/apps/server/tests/unit/services/harness-auto-improvement-service.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { HarnessAutoImprovementService } from '@/services/harness-auto-improvement-service.js';
+import type { Feature } from '@protolabsai/types';
+
+function feat(id: string, status: string, reason?: string, description?: string): Feature {
+  return {
+    id,
+    category: 'feature',
+    description: description ?? '',
+    status,
+    statusChangeReason: reason,
+  } as unknown as Feature;
+}
+
+// Deterministic classifier: every reason → 'merge_conflict'.
+const stub = { classify: () => ({ category: 'merge_conflict', confidence: 1 }) } as any;
+
+function svc(features: Feature[], createImpl?: any) {
+  const create =
+    createImpl ??
+    vi.fn(async (_p: string, f: Partial<Feature>) => ({ id: 'new-1', ...f }) as Feature);
+  const featureLoader = { getAll: vi.fn().mockResolvedValue(features), create } as any;
+  return { service: new HarnessAutoImprovementService(featureLoader, stub), create };
+}
+
+describe('HarnessAutoImprovementService.runOnce', () => {
+  it('files an improvement feature when there is an actionable top category', async () => {
+    const { service, create } = svc([
+      feat('a', 'blocked', 'conflict 1'),
+      feat('b', 'escalated', 'conflict 2'),
+    ]);
+    const r = await service.runOnce('/p');
+    expect(r.filed).toBe(true);
+    expect(r.category).toBe('merge_conflict');
+    expect(r.featureId).toBe('new-1');
+    expect(create).toHaveBeenCalledTimes(1);
+    const created = create.mock.calls[0][1];
+    expect(created.title).toMatch(/merge_conflict/);
+    expect(created.description).toContain('<!-- harness-improve:merge_conflict -->');
+  });
+
+  it('does not file when below the noise threshold (single failure)', async () => {
+    const { service, create } = svc([feat('a', 'blocked', 'conflict 1')]);
+    const r = await service.runOnce('/p');
+    expect(r.filed).toBe(false);
+    expect(r.reason).toMatch(/no actionable/);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('dedups: skips when an open improvement for the category already exists', async () => {
+    const existing = feat(
+      'imp-1',
+      'backlog',
+      undefined,
+      'prior <!-- harness-improve:merge_conflict -->'
+    );
+    const { service, create } = svc([
+      feat('a', 'blocked', 'conflict 1'),
+      feat('b', 'blocked', 'conflict 2'),
+      existing,
+    ]);
+    const r = await service.runOnce('/p');
+    expect(r.filed).toBe(false);
+    expect(r.reason).toBe('already filed');
+    expect(r.featureId).toBe('imp-1');
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('re-files if the prior improvement is already closed (done)', async () => {
+    const closed = feat('imp-old', 'done', undefined, '<!-- harness-improve:merge_conflict -->');
+    const { service, create } = svc([
+      feat('a', 'blocked', 'c1'),
+      feat('b', 'blocked', 'c2'),
+      closed,
+    ]);
+    const r = await service.runOnce('/p');
+    expect(r.filed).toBe(true);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('never throws — returns an error result if create fails', async () => {
+    const { service } = svc(
+      [feat('a', 'blocked', 'c1'), feat('b', 'blocked', 'c2')],
+      vi.fn().mockRejectedValue(new Error('disk full'))
+    );
+    const r = await service.runOnce('/p');
+    expect(r.filed).toBe(false);
+    expect(r.reason).toMatch(/error: disk full/);
+  });
+});


### PR DESCRIPTION
Sprint-2 `39l` — the flywheel payoff, done safely.

## What
Turns the top failure-mode proposal (2fq) into a **deduped improvement feature** on the board, which flows through the normal pipeline where the **harness-eval CI gate (#3904/#3908)** enforces regression-clean on the fix PR + a human reviews it. It deliberately does **not** auto-write+merge harness changes — the eval gate + review are the safety, not a blind code-writer.

- `HarnessAutoImprovementService.runOnce(projectPath)`: taxonomy → proposal → dedup (fingerprint marker; skip if an open improvement for the category exists; re-file once the prior closes) → `featureLoader.create`. Never throws.
- `POST /api/ops/failure-taxonomy/auto-improve` {projectPath?} — on-demand (calling it is the opt-in; no auto-loop in this MVP).

## Tests
5 unit tests (files / below-threshold / dedup-open / re-file-after-close / create-error). Typecheck clean; eval gate green.

Closes `39l` — completes the Sprint-2 flywheel: **2u4 taxonomy → 2fq proposer → 39l auto-file**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic improvement proposal generation for projects. The system analyzes failure patterns and creates detailed improvement recommendations with rationale, hypothesis, and acceptance criteria. Duplicate proposals are automatically prevented through intelligent tracking of existing recommendations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->