### PR TITLE
docs(bus): correct stale feature-lifecycle topic names in docstring

### DIFF
--- a/apps/server/src/services/feature-lifecycle-bus-publisher.ts
+++ b/apps/server/src/services/feature-lifecycle-bus-publisher.ts
@@ -5,9 +5,10 @@
  *
  * Subscribes to the existing `feature:status-changed` event (emitted by
  * FeatureLoader.update) and, when a feature transitions into a terminal state,
- * publishes `protomaker.feature.completed` (status -> done) or
- * `protomaker.feature.failed` (status -> blocked / escalated) to
- * protoWorkstacean's /publish endpoint. The payload echoes the originating
+ * publishes `feature.completed` (status -> done) or `feature.failed`
+ * (status -> blocked / escalated) to protoWorkstacean's /publish endpoint —
+ * the dotted, unprefixed topics workstacean's consumers subscribe to. The
+ * payload echoes the originating
  * signal metadata so a consumer (e.g. the Linear ↔ protoMaker bridge) can
  * reconstruct lineage and post a "feature done" comment on the source issue.
  * See protoLabsAI/protoMaker#3549 and the downstream consumer
@@ -72,8 +73,8 @@ export class FeatureLifecycleBusPublisher {
   }
 
   /**
-   * Publish `protomaker.feature.completed` when a feature reaches a terminal
-   * success state (done), or `protomaker.feature.failed` when it reaches a
+   * Publish `feature.completed` when a feature reaches a terminal
+   * success state (done), or `feature.failed` when it reaches a
    * terminal failure state (blocked / escalated). Loads the feature fresh to
    * echo its source signal metadata and PR tracking fields. Never throws — a
    * publish failure must not affect the board transition.


### PR DESCRIPTION
## Summary

The `FeatureLifecycleBusPublisher` docstrings still referenced the pre-#3913 prefixed topic names (`protomaker.feature.completed` / `protomaker.feature.failed`). The live `const topic` already emits the dotted, unprefixed `feature.completed` / `feature.failed` that workstacean's consumers subscribe to — only the comments lagged.

Comment-only; no behavior change. Found while verifying the close-the-loop end-to-end (workstacean #482, now closed — smoke-tested live).

## Test plan

- [x] No `protomaker.feature.*` references remain in `apps/server/src/`
- [x] `const topic` unchanged (still `feature.completed` / `feature.failed`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation to accurately reflect the feature event publishing semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3918?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->