### PR TITLE
feat(agent): get_run_telemetry self-query tool (beads 3um, #3906)

### DIFF
--- a/apps/server/src/routes/features/index.ts
+++ b/apps/server/src/routes/features/index.ts
@@ -11,6 +11,7 @@ import { validatePathParams } from '../../middleware/validate-paths.js';
 import { validateBody } from '../../middleware/validate-body.js';
 import { createListHandler } from './routes/list.js';
 import { createGetHandler } from './routes/get.js';
+import { createRunTelemetryHandler } from './routes/run-telemetry.js';
 import { createCreateHandler, CreateRequestSchema } from './routes/create.js';
 import { createUpdateHandler, UpdateRequestSchema } from './routes/update.js';
 import { createBulkUpdateHandler, BulkUpdateRequestSchema } from './routes/bulk-update.js';
@@ -51,6 +52,11 @@ export function createFeaturesRoutes(
 
   router.post('/list', validatePathParams('projectPath'), createListHandler(featureLoader));
   router.post('/get', validatePathParams('projectPath'), createGetHandler(featureLoader));
+  router.post(
+    '/run-telemetry',
+    validatePathParams('projectPath'),
+    createRunTelemetryHandler(featureLoader)
+  );
   router.post(
     '/create',
     validatePathParams('projectPath'),

--- a/apps/server/src/routes/features/routes/run-telemetry.ts
+++ b/apps/server/src/routes/features/routes/run-telemetry.ts
@@ -1,0 +1,43 @@
+/**
+ * POST /run-telemetry — agent self-query of a feature's run telemetry (beads 3um / #3906).
+ *
+ * Returns a structured digest (attempts, failures, repeated error, cost/turns,
+ * remediation cycles, and a looping/escalating signal + hint) so an agent can
+ * self-diagnose before declaring done.
+ */
+
+import { z } from 'zod';
+import type { Request, Response } from 'express';
+import { FeatureLoader } from '../../../services/feature-loader.js';
+import { getErrorMessage, logError } from '../common.js';
+import { projectPathSchema, featureIdSchema } from '../../../lib/validation.js';
+import { summarizeRunTelemetry } from '../../../services/run-telemetry-service.js';
+
+const bodySchema = z.object({
+  projectPath: projectPathSchema,
+  featureId: featureIdSchema,
+});
+
+export function createRunTelemetryHandler(featureLoader: FeatureLoader) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const parsed = bodySchema.safeParse(req.body);
+      if (!parsed.success) {
+        res
+          .status(400)
+          .json({ success: false, error: 'Validation failed', details: parsed.error.issues });
+        return;
+      }
+      const { projectPath, featureId } = parsed.data;
+      const feature = await featureLoader.get(projectPath, featureId);
+      if (!feature) {
+        res.status(404).json({ success: false, error: 'Feature not found' });
+        return;
+      }
+      res.json({ success: true, telemetry: summarizeRunTelemetry(feature) });
+    } catch (error) {
+      logError(error, 'Run telemetry failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/services/run-telemetry-service.ts
+++ b/apps/server/src/services/run-telemetry-service.ts
@@ -1,0 +1,93 @@
+/**
+ * Run telemetry self-query (beads protomaker-3um / #3906).
+ *
+ * Summarizes a feature's own execution history into a structured digest an
+ * agent can query to self-diagnose before declaring done — detecting the two
+ * failure shapes that waste cycles: looping (repeating the same error) and
+ * escalating (failures/remediations piling up). Pure over the feature; uses the
+ * locally-recorded executionHistory + remediation counters (no Langfuse needed).
+ */
+
+import type { Feature, ExecutionRecord } from '@protolabsai/types';
+
+export type RunSignal = 'ok' | 'looping' | 'escalating' | 'no-data';
+
+export interface RunTelemetry {
+  featureId: string;
+  status?: string;
+  attempts: number;
+  failures: number;
+  lastError?: string;
+  /** Same (normalized) error seen 2+ times — a strong "stop repeating" signal. */
+  repeatedError?: { message: string; count: number };
+  totalCostUsd: number;
+  totalTurns: number;
+  remediationCycles: number;
+  signal: RunSignal;
+  /** Plain-language self-diagnosis for the agent. */
+  hint: string;
+}
+
+/** Normalize an error to a stable key for repeat detection (drop digits/paths noise). */
+function errorKey(msg: string): string {
+  return msg.toLowerCase().replace(/\d+/g, '#').replace(/\s+/g, ' ').trim().slice(0, 120);
+}
+
+export function summarizeRunTelemetry(feature: Feature): RunTelemetry {
+  const history: ExecutionRecord[] = Array.isArray(feature.executionHistory)
+    ? feature.executionHistory
+    : [];
+  const attempts = history.length;
+  const failed = history.filter((r) => !r.success);
+  const lastError = [...failed].reverse().find((r) => r.error)?.error;
+
+  // Repeat detection over failed-run errors.
+  const counts = new Map<string, { message: string; count: number }>();
+  for (const r of failed) {
+    if (!r.error) continue;
+    const key = errorKey(r.error);
+    const e = counts.get(key) ?? { message: r.error, count: 0 };
+    e.count++;
+    counts.set(key, e);
+  }
+  const repeated = [...counts.values()]
+    .filter((e) => e.count >= 2)
+    .sort((a, b) => b.count - a.count)[0];
+
+  const totalCostUsd =
+    Math.round(history.reduce((n, r) => n + (r.costUsd ?? 0), 0) * 10000) / 10000;
+  const totalTurns = history.reduce((n, r) => n + (r.turnCount ?? 0), 0);
+  const remediationCycles =
+    ((feature.ciRemediationCount as number | undefined) ?? 0) +
+    ((feature.reviewRemediationCount as number | undefined) ?? 0);
+
+  let signal: RunSignal;
+  let hint: string;
+  if (attempts === 0) {
+    signal = 'no-data';
+    hint = 'No execution history yet.';
+  } else if (repeated) {
+    signal = 'looping';
+    hint = `You have hit the same error ${repeated.count}× ("${repeated.message.slice(0, 100)}"). Stop repeating the same approach — change strategy or escalate.`;
+  } else if (failed.length >= 2 || remediationCycles >= 2) {
+    signal = 'escalating';
+    hint = `${failed.length} failed attempt(s) and ${remediationCycles} remediation cycle(s). Confirm the root cause before another attempt; consider escalating.`;
+  } else {
+    signal = 'ok';
+    hint = 'No looping or escalation pattern detected.';
+  }
+
+  return {
+    featureId: feature.id,
+    status: feature.status ? String(feature.status) : undefined,
+    attempts,
+    failures: failed.length,
+    lastError,
+    repeatedError: repeated,
+    totalCostUsd,
+    totalTurns,
+    remediationCycles,
+    signal,
+    hint,
+  };
+}

--- a/apps/server/tests/unit/services/run-telemetry-service.test.ts
+++ b/apps/server/tests/unit/services/run-telemetry-service.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeRunTelemetry } from '@/services/run-telemetry-service.js';
+import type { Feature, ExecutionRecord } from '@protolabsai/types';
+
+function rec(success: boolean, over: Partial<ExecutionRecord> = {}): ExecutionRecord {
+  return {
+    id: Math.random().toString(36),
+    startedAt: '2026-05-27T00:00:00Z',
+    model: 'protolabs/smart',
+    success,
+    trigger: 'auto',
+    ...over,
+  } as ExecutionRecord;
+}
+
+function feat(over: Partial<Feature> = {}): Feature {
+  return {
+    id: 'f1',
+    category: 'feature',
+    description: '',
+    status: 'in_progress',
+    ...over,
+  } as unknown as Feature;
+}
+
+describe('summarizeRunTelemetry', () => {
+  it('returns no-data with no history', () => {
+    expect(summarizeRunTelemetry(feat()).signal).toBe('no-data');
+  });
+
+  it('detects looping when the same error repeats', () => {
+    const t = summarizeRunTelemetry(
+      feat({
+        executionHistory: [
+          // Same failure twice (differing only in a request id / digits) — the
+          // digit-normalizing key collapses them, which is the looping signal.
+          rec(false, { error: 'API Error: 401 key not allowed to access model (req 12)' }),
+          rec(false, { error: 'API Error: 401 key not allowed to access model (req 98)' }),
+        ],
+      })
+    );
+    expect(t.signal).toBe('looping');
+    expect(t.repeatedError?.count).toBe(2);
+    expect(t.hint).toMatch(/same error/i);
+  });
+
+  it('flags escalating on multiple distinct failures', () => {
+    const t = summarizeRunTelemetry(
+      feat({
+        executionHistory: [
+          rec(false, { error: 'merge conflict in foo.ts' }),
+          rec(false, { error: 'typecheck failed: TS2322' }),
+        ],
+      })
+    );
+    expect(t.signal).toBe('escalating');
+    expect(t.failures).toBe(2);
+    expect(t.lastError).toMatch(/typecheck/);
+  });
+
+  it('flags escalating on remediation cycles even with one failure', () => {
+    const t = summarizeRunTelemetry(
+      feat({
+        executionHistory: [rec(false, { error: 'x' })],
+        ciRemediationCount: 1,
+        reviewRemediationCount: 1,
+      } as Partial<Feature>)
+    );
+    expect(t.signal).toBe('escalating');
+    expect(t.remediationCycles).toBe(2);
+  });
+
+  it('returns ok for a single clean/in-progress run', () => {
+    const t = summarizeRunTelemetry(
+      feat({ executionHistory: [rec(true, { turnCount: 5, costUsd: 0.1 })] })
+    );
+    expect(t.signal).toBe('ok');
+    expect(t.attempts).toBe(1);
+    expect(t.failures).toBe(0);
+  });
+
+  it('aggregates cost + turns across runs', () => {
+    const t = summarizeRunTelemetry(
+      feat({
+        executionHistory: [
+          rec(true, { costUsd: 0.12, turnCount: 3 }),
+          rec(true, { costUsd: 0.08, turnCount: 4 }),
+        ],
+      })
+    );
+    expect(t.totalCostUsd).toBeCloseTo(0.2, 4);
+    expect(t.totalTurns).toBe(7);
+  });
+});

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -220,6 +220,12 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         compact: true, // Use compact mode to reduce response size
       });
 
+    case 'get_run_telemetry':
+      return apiCall('/features/run-telemetry', {
+        projectPath: args.projectPath,
+        featureId: args.featureId,
+      });
+
     case 'get_feature': {
       const featureResult = (await apiCall('/features/get', {
         projectPath: args.projectPath,

--- a/packages/mcp-server/src/tools/feature-tools.ts
+++ b/packages/mcp-server/src/tools/feature-tools.ts
@@ -69,6 +69,23 @@ export const featureTools: Tool[] = [
     },
   },
   {
+    name: 'get_run_telemetry',
+    description:
+      "Self-diagnose a feature's run: returns a structured digest of its execution history (attempts, failures, repeated error, cost, turns, remediation cycles) plus a signal (ok | looping | escalating) and a plain-language hint. Use before declaring work done to detect when you're repeating the same failing approach.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          minLength: 1,
+          description: 'Absolute path to the project directory',
+        },
+        featureId: { type: 'string', minLength: 1, description: 'The feature ID' },
+      },
+      required: ['projectPath', 'featureId'],
+    },
+  },
+  {
     name: 'create_feature',
     description:
       'Create a new feature on the Kanban board. Features start in the backlog by default.',


### PR DESCRIPTION
Sprint-1 `3um` — lets an agent self-diagnose its own run before declaring done (the Arize "agents query their telemetry" pattern), sourced from the locally-recorded `executionHistory` (no Langfuse dependency).

- `summarizeRunTelemetry(feature)` → attempts, failures, repeated-error detection, cost/turns, remediation cycles, and a **signal** (ok | looping | escalating) + a plain-language hint.
- `POST /api/features/run-telemetry` + MCP tool **`get_run_telemetry`**.
- 6 unit tests; server + mcp typecheck clean; eval gate green.

Closes `3um` — **completes Sprint 1** (eval substrate + zg4 verifier + 3um).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added feature run telemetry retrieval and analysis with execution metrics (failures, costs, turns, remediation cycles) and diagnostic signals to identify recurring errors and escalating issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->