### PR TITLE
fix(sitrep): settings-driven staging delta + git-settings docs (#3894, #3874)

### DIFF
--- a/apps/server/src/routes/sitrep/index.ts
+++ b/apps/server/src/routes/sitrep/index.ts
@@ -11,6 +11,7 @@ import { createLogger } from '@protolabsai/utils';
 import type { Feature } from '@protolabsai/types';
 import type { FeatureLoader } from '../../services/feature-loader.js';
 import type { AutoModeService } from '../../services/auto-mode-service.js';
+import type { SettingsService } from '../../services/settings-service.js';
 import { getEscalationRouter } from '../../services/escalation-router.js';
 import { open } from 'node:fs/promises';
 import { getServerLogPath } from '../../lib/server-log.js';
@@ -22,12 +23,14 @@ interface SitrepOptions {
   featureLoader: FeatureLoader;
   autoModeService: AutoModeService;
   repoRoot: string;
+  settingsService?: SettingsService;
 }
 
 export function createSitrepRoutes({
   featureLoader,
   autoModeService,
   repoRoot,
+  settingsService,
 }: SitrepOptions): Router {
   const router = Router();
 
@@ -39,6 +42,7 @@ export function createSitrepRoutes({
     }
 
     try {
+      const stagingDeltaBranches = await resolveStagingDeltaBranches(projectPath, settingsService);
       // Gather everything in parallel for speed
       const [
         allFeatures,
@@ -55,7 +59,7 @@ export function createSitrepRoutes({
         getRunningAgents(autoModeService),
         getOpenPRs(repoRoot),
         getRecentCommits(repoRoot),
-        getStagingDelta(repoRoot),
+        getStagingDelta(repoRoot, stagingDeltaBranches),
         getServerHealth(),
         getRecentLogErrors(10),
       ]);
@@ -237,17 +241,69 @@ async function getRecentCommits(repoRoot: string) {
   }
 }
 
-async function getStagingDelta(repoRoot: string) {
+export interface StagingDelta {
+  /**
+   * Whether the staging delta is tracked for this project. False when no
+   * `stagingDeltaBranches` are configured (the single-integration-branch flow)
+   * or when either branch doesn't exist on the remote — so consumers don't
+   * mistake a swallowed-error `0` for "in sync".
+   */
+  applicable: boolean;
+  commitsAhead: number;
+  commits: string[];
+}
+
+const NOT_APPLICABLE: StagingDelta = { applicable: false, commitsAhead: 0, commits: [] };
+
+/**
+ * Resolve the configured staging-delta branch pair for a project.
+ * Per-project `.automaker/settings.json` wins over global; unset = not tracked.
+ */
+export async function resolveStagingDeltaBranches(
+  projectPath: string,
+  settingsService?: SettingsService | null
+): Promise<{ from: string; to: string } | undefined> {
+  if (!settingsService) return undefined;
   try {
+    const projectSettings = await settingsService.getProjectSettings(projectPath);
+    const projectPair = projectSettings.workflow?.gitWorkflow?.stagingDeltaBranches;
+    if (projectPair?.from && projectPair?.to) return projectPair;
+    const globalSettings = await settingsService.getGlobalSettings();
+    const globalPair = globalSettings.gitWorkflow?.stagingDeltaBranches;
+    if (globalPair?.from && globalPair?.to) return globalPair;
+  } catch (err) {
+    logger.warn('Failed to read stagingDeltaBranches settings:', err);
+  }
+  return undefined;
+}
+
+/**
+ * Count commits on `to` not yet on `from` (commits queued to promote).
+ * Returns `applicable: false` when the branch pair is unconfigured or either
+ * ref is missing, rather than leaking a misleading `commitsAhead: 0`.
+ */
+export async function getStagingDelta(
+  repoRoot: string,
+  branches?: { from: string; to: string }
+): Promise<StagingDelta> {
+  if (!branches) return NOT_APPLICABLE;
+  try {
+    // Both refs must resolve, else the range query silently yields 0.
+    for (const ref of [branches.from, branches.to]) {
+      await execFileAsync('git', ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], {
+        cwd: repoRoot,
+        timeout: 5000,
+      });
+    }
     const { stdout } = await execFileAsync(
       'git',
-      ['log', '--oneline', 'origin/staging..origin/dev', '--format=%h %s'],
+      ['log', '--oneline', `${branches.from}..${branches.to}`, '--format=%h %s'],
       { cwd: repoRoot, timeout: 5000 }
     );
     const commits = stdout.trim().split('\n').filter(Boolean);
-    return { commitsAhead: commits.length, commits: commits.slice(0, 5) };
+    return { applicable: true, commitsAhead: commits.length, commits: commits.slice(0, 5) };
   } catch {
-    return { commitsAhead: 0, commits: [] };
+    return NOT_APPLICABLE;
   }
 }
 

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -374,7 +374,10 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
   app.use('/api/ai', createAIRoutes());
   app.use('/api/notes', createNotesRoutes(events));
   app.use('/api/beads', createBeadsRoutes(beadsService));
-  app.use('/api/sitrep', createSitrepRoutes({ featureLoader, autoModeService, repoRoot }));
+  app.use(
+    '/api/sitrep',
+    createSitrepRoutes({ featureLoader, autoModeService, repoRoot, settingsService })
+  );
   app.use('/api/portfolio/sitrep', createPortfolioSitrepRoutes({ settingsService }));
   app.use(
     '/api/portfolio/cross-repo-deps',

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -14,6 +14,7 @@ import { buildGitAddCommand } from '../lib/git-staging-utils.js';
 import type {
   Feature,
   GitWorkflowSettings,
+  ResolvedGitWorkflowSettings,
   GitWorkflowResult,
   GlobalSettings,
 } from '@protolabsai/types';
@@ -228,7 +229,7 @@ export class GitWorkflowService {
     feature: Feature,
     globalSettings: GlobalSettings,
     projectPrBaseBranch?: string
-  ): Required<GitWorkflowSettings> {
+  ): ResolvedGitWorkflowSettings {
     const global = globalSettings.gitWorkflow ?? DEFAULT_GIT_WORKFLOW_SETTINGS;
     const featureOverride = feature.gitWorkflow ?? {};
 
@@ -278,6 +279,7 @@ export class GitWorkflowService {
         featureOverride.syncLockfileOnManifestChange ??
         global.syncLockfileOnManifestChange ??
         DEFAULT_GIT_WORKFLOW_SETTINGS.syncLockfileOnManifestChange,
+      stagingDeltaBranches: featureOverride.stagingDeltaBranches ?? global.stagingDeltaBranches,
     };
   }
 

--- a/apps/server/src/services/portfolio-world-state-builder.ts
+++ b/apps/server/src/services/portfolio-world-state-builder.ts
@@ -48,6 +48,7 @@ interface ProjectSitrep {
     classification?: string;
   }>;
   stagingDelta: {
+    applicable: boolean;
     commitsAhead: number;
     commits: string[];
   };
@@ -162,7 +163,7 @@ export class PortfolioWorldStateBuilder {
         blockedCount: sitrep.board.blocked,
         errorBudgetStatus: this.calculateErrorBudgetStatus(sitrep),
         topReadyFeature: null,
-        stagingLagCommits: sitrep.stagingDelta.commitsAhead,
+        stagingLagCommits: sitrep.stagingDelta.applicable ? sitrep.stagingDelta.commitsAhead : 0,
         weeklyThroughput: sitrep.board.done,
       };
     });

--- a/apps/server/tests/unit/routes/sitrep-staging-delta.test.ts
+++ b/apps/server/tests/unit/routes/sitrep-staging-delta.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for the sitrep staging-delta signal (#3894).
+ *
+ * Guards the bug where getStagingDelta hardcoded `origin/staging..origin/dev`,
+ * so repos without those branches silently leaked `commitsAhead: 0` into world
+ * state. Now: unconfigured or missing-ref → `applicable: false`; configured +
+ * present refs → a real count.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { promisify } from 'node:util';
+
+const execFileMock = vi.fn();
+(execFileMock as unknown as Record<symbol, unknown>)[promisify.custom] = (
+  file: string,
+  args: string[],
+  opts?: unknown
+) =>
+  new Promise((resolve, reject) => {
+    execFileMock(file, args, opts, (err: Error | null, stdout: string, stderr: string) =>
+      err ? reject(err) : resolve({ stdout, stderr })
+    );
+  });
+
+vi.mock('node:child_process', () => ({ execFile: execFileMock }));
+
+const { getStagingDelta, resolveStagingDeltaBranches } = await import('@/routes/sitrep/index.js');
+
+type ExecCallback = (err: Error | null, stdout: string, stderr: string) => void;
+
+/** Queue one git response (by call order). `fail: true` rejects (missing ref). */
+function nextGit(opts: { stdout?: string; fail?: boolean }) {
+  execFileMock.mockImplementationOnce(
+    (_file: string, _args: string[], _o: unknown, cb: ExecCallback) => {
+      if (opts.fail) cb(Object.assign(new Error('git failed'), { code: 1 }), '', 'fatal');
+      else cb(null, opts.stdout ?? '', '');
+    }
+  );
+}
+
+const REPO = '/tmp/repo';
+const BRANCHES = { from: 'origin/staging', to: 'origin/dev' };
+
+describe('getStagingDelta', () => {
+  beforeEach(() => execFileMock.mockReset());
+
+  it('is not applicable when no branch pair is configured', async () => {
+    const result = await getStagingDelta(REPO, undefined);
+    expect(result).toEqual({ applicable: false, commitsAhead: 0, commits: [] });
+    expect(execFileMock).not.toHaveBeenCalled(); // no git when unconfigured
+  });
+
+  it('is not applicable when a configured ref does not exist', async () => {
+    nextGit({ fail: true }); // first rev-parse --verify fails for a missing ref
+    const result = await getStagingDelta(REPO, BRANCHES);
+    expect(result.applicable).toBe(false);
+    expect(result.commitsAhead).toBe(0);
+  });
+
+  it('counts commits when both refs exist', async () => {
+    nextGit({ stdout: 'deadbeef\n' }); // rev-parse from
+    nextGit({ stdout: 'cafef00d\n' }); // rev-parse to
+    nextGit({ stdout: 'aaa1111 feat: one\nbbb2222 fix: two\n' }); // log
+    const result = await getStagingDelta(REPO, BRANCHES);
+    expect(result.applicable).toBe(true);
+    expect(result.commitsAhead).toBe(2);
+    expect(result.commits).toEqual(['aaa1111 feat: one', 'bbb2222 fix: two']);
+    // the log range uses the configured branch pair, not hardcoded literals
+    const logCall = execFileMock.mock.calls.find((c) => c[1]?.[0] === 'log');
+    expect(logCall?.[1]).toContain('origin/staging..origin/dev');
+  });
+});
+
+describe('resolveStagingDeltaBranches', () => {
+  it('returns undefined without a settings service', async () => {
+    await expect(resolveStagingDeltaBranches(REPO, null)).resolves.toBeUndefined();
+  });
+
+  it('prefers the per-project pair over global', async () => {
+    const settingsService = {
+      getProjectSettings: vi.fn().mockResolvedValue({
+        workflow: { gitWorkflow: { stagingDeltaBranches: { from: 'origin/a', to: 'origin/b' } } },
+      }),
+      getGlobalSettings: vi.fn().mockResolvedValue({
+        gitWorkflow: { stagingDeltaBranches: { from: 'origin/x', to: 'origin/y' } },
+      }),
+    };
+    await expect(resolveStagingDeltaBranches(REPO, settingsService as never)).resolves.toEqual({
+      from: 'origin/a',
+      to: 'origin/b',
+    });
+    expect(settingsService.getGlobalSettings).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the global pair', async () => {
+    const settingsService = {
+      getProjectSettings: vi.fn().mockResolvedValue({ workflow: {} }),
+      getGlobalSettings: vi.fn().mockResolvedValue({
+        gitWorkflow: { stagingDeltaBranches: { from: 'origin/x', to: 'origin/y' } },
+      }),
+    };
+    await expect(resolveStagingDeltaBranches(REPO, settingsService as never)).resolves.toEqual({
+      from: 'origin/x',
+      to: 'origin/y',
+    });
+  });
+
+  it('returns undefined when neither level configures a pair', async () => {
+    const settingsService = {
+      getProjectSettings: vi.fn().mockResolvedValue({ workflow: {} }),
+      getGlobalSettings: vi.fn().mockResolvedValue({ gitWorkflow: {} }),
+    };
+    await expect(
+      resolveStagingDeltaBranches(REPO, settingsService as never)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/ui/src/components/views/board-view/board-settings-panel.tsx
+++ b/apps/ui/src/components/views/board-view/board-settings-panel.tsx
@@ -14,7 +14,11 @@ import { useAppStore } from '@/store/app-store';
 import { useGlobalSettings } from '@/hooks/queries';
 import { useUpdateGlobalSettings } from '@/hooks/mutations/use-settings-mutations';
 import { DEFAULT_GIT_WORKFLOW_SETTINGS } from '@protolabsai/types';
-import type { GitWorkflowSettings, PlanningMode } from '@protolabsai/types';
+import type {
+  GitWorkflowSettings,
+  ResolvedGitWorkflowSettings,
+  PlanningMode,
+} from '@protolabsai/types';
 
 interface BoardSettingsPanelProps {
   onClose: () => void;
@@ -41,7 +45,7 @@ export function BoardSettingsPanel({
   const { data: globalSettings } = useGlobalSettings();
   const updateGlobalSettings = useUpdateGlobalSettings({ showSuccessToast: false });
 
-  const gitWorkflow: Required<GitWorkflowSettings> = {
+  const gitWorkflow: ResolvedGitWorkflowSettings = {
     ...DEFAULT_GIT_WORKFLOW_SETTINGS,
     ...(globalSettings?.gitWorkflow ?? {}),
   };

--- a/apps/ui/src/components/views/settings-view/sections/git-workflow-defaults-section.tsx
+++ b/apps/ui/src/components/views/settings-view/sections/git-workflow-defaults-section.tsx
@@ -12,7 +12,11 @@ import { Button } from '@protolabsai/ui/atoms';
 import { Loader2, Save } from 'lucide-react';
 import { getHttpApiClient } from '@/lib/http-api-client';
 import { toast } from 'sonner';
-import type { GitWorkflowSettings, PRMergeStrategy } from '@protolabsai/types';
+import type {
+  GitWorkflowSettings,
+  ResolvedGitWorkflowSettings,
+  PRMergeStrategy,
+} from '@protolabsai/types';
 import { DEFAULT_GIT_WORKFLOW_SETTINGS } from '@protolabsai/types';
 
 function ToggleRow({
@@ -188,7 +192,7 @@ function SectionHeader({ title }: { title: string }) {
 
 export function GitWorkflowDefaultsSection() {
   const queryClient = useQueryClient();
-  const [localSettings, setLocalSettings] = useState<Required<GitWorkflowSettings>>(
+  const [localSettings, setLocalSettings] = useState<ResolvedGitWorkflowSettings>(
     DEFAULT_GIT_WORKFLOW_SETTINGS
   );
   const [isDirty, setIsDirty] = useState(false);

--- a/docs/reference/git-settings.md
+++ b/docs/reference/git-settings.md
@@ -28,19 +28,26 @@ Settings form a dependency chain: `autoCommit` > `autoPush` > `autoCreatePR` > `
 
 ### Pull Request
 
-| Setting             | Type   | Default    | Description                                              |
-| ------------------- | ------ | ---------- | -------------------------------------------------------- |
-| `prBaseBranch`      | string | `"dev"`    | Target branch for PR creation                            |
-| `prMergeStrategy`   | string | `"squash"` | How PRs are merged: `merge`, `squash`, or `rebase`       |
-| `maxPRLinesChanged` | number | `500`      | Flag PR as oversized above this line count. `0` disables |
-| `maxPRFilesTouched` | number | `20`       | Flag PR as oversized above this file count. `0` disables |
+| Setting             | Type   | Default                  | Description                                                                                                                                                  |
+| ------------------- | ------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `prBaseBranch`      | string | _auto-detected_ (`main`) | Target branch for PR creation. Set automatically at `/setup/project` time to the repo's detected default branch; falls back to `"main"` if setup didn't run. |
+| `prMergeStrategy`   | string | `"squash"`               | How PRs are merged: `merge`, `squash`, or `rebase`                                                                                                           |
+| `maxPRLinesChanged` | number | `500`                    | Flag PR as oversized above this line count. `0` disables                                                                                                     |
+| `maxPRFilesTouched` | number | `20`                     | Flag PR as oversized above this file count. `0` disables                                                                                                     |
+
+> **Repos without a `dev` branch (feature → main directly).** This is the default for fresh GitHub repos and the recommended single-integration-branch flow. `prBaseBranch` auto-detects to `main`, so no configuration is needed. Examples elsewhere that use `prBaseBranch: "dev"` apply only to repos running a `dev → main` staging flow.
+>
+> ```json
+> { "gitWorkflow": { "prBaseBranch": "main" } }
+> ```
 
 ### Staging
 
-| Setting              | Type     | Default | Description                                                        |
-| -------------------- | -------- | ------- | ------------------------------------------------------------------ |
-| `excludeFromStaging` | string[] | `[]`    | Directories to exclude from `git add`                              |
-| `softChecks`         | string[] | `[]`    | CI check names that don't block merge (case-insensitive substring) |
+| Setting                | Type     | Default | Description                                                                                                                                                                                                                                           |
+| ---------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `excludeFromStaging`   | string[] | `[]`    | Directories to exclude from `git add`                                                                                                                                                                                                                 |
+| `softChecks`           | string[] | `[]`    | CI check names that don't block merge (case-insensitive substring)                                                                                                                                                                                    |
+| `stagingDeltaBranches` | object   | _unset_ | `{ from, to }` branch pair for the sitrep "staging delta" signal (commits on `to` not yet on `from`). Only for multi-branch release flows; leave unset on feature → main (the delta is then reported as not-applicable rather than a misleading `0`). |
 
 ## skipGitHooks
 

--- a/libs/types/src/git-settings.ts
+++ b/libs/types/src/git-settings.ts
@@ -38,6 +38,14 @@ export interface GitWorkflowSettings {
   /** Base branch for PR creation (default: 'main') */
   prBaseBranch?: string;
   /**
+   * Branch pair for the "staging delta" sitrep signal — commits on `to` not yet
+   * on `from` (i.e. queued to promote). Only meaningful for multi-branch release
+   * flows (e.g. `{ from: 'origin/staging', to: 'origin/dev' }`). Leave UNSET on
+   * the single-integration-branch flow (feature → main): the sitrep then reports
+   * the delta as not-applicable instead of a misleading `0`.
+   */
+  stagingDeltaBranches?: { from: string; to: string };
+  /**
    * Maximum total lines changed (insertions + deletions) before flagging PR as oversized.
    * Oversized PRs receive an 'oversized-pr' label and an actionable item for human review.
    * Set to 0 to disable the check. (default: 500)
@@ -83,9 +91,19 @@ export interface GitWorkflowSettings {
 }
 
 /**
- * Default git workflow settings - commit/push/PR/auto-merge enabled by default
+ * Fully-resolved git workflow settings: every field present EXCEPT
+ * `stagingDeltaBranches`, which stays optional (unset = single-integration-branch
+ * flow, no staging delta tracked).
  */
-export const DEFAULT_GIT_WORKFLOW_SETTINGS: Required<GitWorkflowSettings> = {
+export type ResolvedGitWorkflowSettings = Required<
+  Omit<GitWorkflowSettings, 'stagingDeltaBranches'>
+> &
+  Pick<GitWorkflowSettings, 'stagingDeltaBranches'>;
+
+/**
+ * Default git workflow settings - commit/push/PR/auto-merge enabled by default.
+ */
+export const DEFAULT_GIT_WORKFLOW_SETTINGS: ResolvedGitWorkflowSettings = {
   autoCommit: true,
   autoPush: true,
   autoCreatePR: true,

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -310,6 +310,7 @@ export type {
   // Git workflow types
   PRMergeStrategy,
   GitWorkflowSettings,
+  ResolvedGitWorkflowSettings,
   GitWorkflowResult,
   // Discord integration types
   DiscordSettings,

--- a/libs/types/src/workflow-settings.ts
+++ b/libs/types/src/workflow-settings.ts
@@ -441,6 +441,8 @@ export interface WorkflowSettings {
   gitWorkflow?: {
     /** Base branch for PR creation (overrides global gitWorkflow.prBaseBranch) */
     prBaseBranch?: string;
+    /** Staging-delta branch pair (overrides global gitWorkflow.stagingDeltaBranches) */
+    stagingDeltaBranches?: { from: string; to: string };
   };
   /**
    * Fresh-eyes review configuration.


### PR DESCRIPTION
## #3894 — staging-delta leaked a misleading `0`

`getStagingDelta()` hardcoded `origin/staging..origin/dev` and ran it for every sitrep. On the single-integration-branch flow (no `dev`/`staging`), the range query failed, the error was swallowed, and `commitsAhead: 0` flowed into `stagingLagCommits` in portfolio world state as a real "in sync" signal.

**Fix**
- Branch pair is now configurable: new optional `GitWorkflowSettings.stagingDeltaBranches` (`{ from, to }`), resolved per-project → global. Unset (the default, including feature → main) means the delta isn't tracked.
- `getStagingDelta` verifies both refs exist (`git rev-parse --verify`) before counting and returns `applicable: false` when unconfigured or a ref is missing — a swallowed error can no longer masquerade as `0`.
- `StagingDelta` gains `applicable`; `portfolio-world-state-builder` only surfaces `stagingLagCommits` when applicable.
- New `ResolvedGitWorkflowSettings` type (`Required<…>` minus the optional `stagingDeltaBranches`) shared by `DEFAULT_GIT_WORKFLOW_SETTINGS`, the git-workflow resolver, and the two UI settings panels.

## #3874 — git-settings docs

- Corrected the stale `prBaseBranch` default (`"dev"` → auto-detected at setup, `main` fallback — matches `DEFAULT_GIT_WORKFLOW_SETTINGS`).
- Added a "feature → main, no dev branch" note + example.
- Documented the new `stagingDeltaBranches`.
- Gap 3 (`mainBranch`): verified it's a **local UI variable**, not a setting — nothing to document.

## Validation
- `npm run typecheck` — clean (22/22)
- `npm run test:server -- tests/unit/routes/sitrep-staging-delta.test.ts` — 7 passed
- Platform-first: no hardcoded branch literals in business logic; default experience (single-main) requires zero config and reports the delta as not-applicable.

Closes #3894, closes #3874.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Staging delta branches are now configurable per-project, overriding global defaults.
  * Pull request base branch now auto-detects target instead of using hardcoded defaults.

* **Bug Fixes**
  * Improved handling of missing or unconfigured branch pairs with clearer applicability status.

* **Documentation**
  * Updated git settings reference with staging delta configuration guidance and branch pair examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->