### PR TITLE
docs(ava): teach the Ava skill the /cli-control board fallback when MCP is down

### DIFF
--- a/packages/mcp-server/plugins/automaker/commands/ava.md
+++ b/packages/mcp-server/plugins/automaker/commands/ava.md
@@ -199,6 +199,10 @@ All code examples below use `projectPath` as a variable — substitute the resol
 - **File reads**: `Read({ file_path: projectPath + "/.automaker/spec.md" })`
 - **Auto-memory**: `~/.claude/projects/<sanitized>/memory/` where `<sanitized>` is projectPath with `/` replaced by `-`, prefixed with `-`
 
+## Board Control Without MCP — `/cli-control` Fallback
+
+The MCP tools above are your primary path. When the MCP server is **unavailable or unreachable** (a tool call errors with connection/transport failures, or you're operating in a shell-only / CI context), do not stall — fall back to the **`/cli-control`** skill, which drives the same server API over the `protomaker` CLI. It manages the entire board and crew (`protomaker board`, `feature list|get|create|update|move`, `agent start|list|stop`, `auto-mode start|stop|status`, `pr create|status|merge`, `queue …`), hits the same endpoints as the MCP tools, and is deterministic/scriptable. Use `--project <path>` to target any app and `--json` when parsing. Reach for it specifically when MCP is down so board management never blocks on transport.
+
 ## Prime Directive
 
 **Achieve full autonomy through orchestration.** See friction, route to the right specialist, monitor the outcome, intervene only if the specialist fails. Direct action is reserved for decisions that require your authority.


### PR DESCRIPTION
## Why

Asked whether Ava knows about the CLI skill for board management — it didn't. Both Ava surfaces drove the board purely through MCP tools, with no awareness of `/cli-control` (which ships in the **same plugin** for exactly the MCP-unavailable case). As the autonomous operator, if the MCP server drops, Ava had no documented fallback.

## Change

Added a **"Board Control Without MCP — `/cli-control` Fallback"** section to `commands/ava.md`, pointing Ava at the `/cli-control` skill + `protomaker` CLI (same server API, deterministic, `--project`/`--json`) as the path to use when MCP tool calls fail or in shell-only contexts.

## Scope

Only `ava.md` — the plugin skill, which has `Bash` in `allowed-tools` and can run the CLI.

**Deliberately NOT** `apps/server/src/routes/chat/ava-prompt.md`: the UI-chat Ava runs in-process with no shell access and already states *"Do not attempt MCP CLI tools — they are not available in this surface."* A CLI fallback there would be incorrect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing the fallback mechanism for board control operations when MCP tools are unavailable or unreachable. Explains how to use alternative CLI-based control to ensure board management continues without interruption.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->