### PR TITLE
fix(epic): complete epic when branch is 0 commits ahead of base, don't block (#3803)

### DIFF
--- a/apps/server/src/services/completion-detector-service.ts
+++ b/apps/server/src/services/completion-detector-service.ts
@@ -267,6 +267,74 @@ export class CompletionDetectorService {
   }
 
   /**
+   * Count commits on the epic branch not yet on the base branch
+   * (`origin/base..origin/epicBranch`). Fetches both refs first so the count
+   * reflects the remote, not a stale local mirror.
+   *
+   * Returns `null` when the count can't be determined (git/network error), so
+   * callers fall back to the normal PR path rather than guessing.
+   */
+  private async epicBranchCommitsAhead(
+    projectPath: string,
+    baseBranch: string,
+    epicBranch: string
+  ): Promise<number | null> {
+    try {
+      await execFileAsync('git', ['fetch', 'origin', baseBranch, epicBranch], {
+        cwd: projectPath,
+        timeout: 30000,
+      });
+      const { stdout } = await execFileAsync(
+        'git',
+        ['rev-list', '--count', `origin/${baseBranch}..origin/${epicBranch}`],
+        { cwd: projectPath, timeout: 15000 }
+      );
+      const count = parseInt(stdout.trim(), 10);
+      return Number.isNaN(count) ? null : count;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Mark an epic `done` without creating an epic→base PR — used when the work
+   * already landed on the base branch (epic branch absent on the remote, or
+   * present but 0 commits ahead of base). Claims dedup, updates ledger/counts,
+   * and emits the same completion events as the PR-merge path.
+   */
+  private async completeEpicDirectly(
+    projectPath: string,
+    epicId: string,
+    epic: Feature,
+    children: Feature[],
+    dedupeKey: string,
+    logMessage: string
+  ): Promise<void> {
+    this.emittedEpics.add(dedupeKey);
+    this.appendLedgerEntry('epic', dedupeKey);
+    this.completionCounts.epics++;
+    await this.featureLoader!.update(projectPath, epicId, { status: 'done' });
+    logger.info(logMessage);
+    this.emitter!.emit('feature:completed', {
+      projectPath,
+      featureId: epicId,
+      featureTitle: epic.title,
+      projectSlug: epic.projectSlug,
+      isEpic: true,
+    });
+    this.emitter!.emit('epic:auto-completed', {
+      projectPath,
+      epicId,
+      epicTitle: epic.title,
+      childrenIds: children.map((c) => c.id),
+      completedAt: new Date().toISOString(),
+    });
+    if (epic.projectSlug && epic.milestoneSlug) {
+      await this.checkMilestoneCompletion(projectPath, epic.projectSlug, epic.milestoneSlug);
+    }
+  }
+
+  /**
    * Check if all children of an epic are done. If the epic has a branch,
    * create a PR from the epic branch to the configured base branch and move
    * the epic to "review". The epic only reaches "done" when the GitHub
@@ -312,36 +380,48 @@ export class CompletionDetectorService {
       if (!branchExists) {
         // Children merged directly to the base branch — no epic branch to PR from.
         // Skip the PR step and mark the epic done immediately.
-        this.emittedEpics.add(dedupeKey);
-        this.appendLedgerEntry('epic', dedupeKey);
-        this.completionCounts.epics++;
-        await this.featureLoader!.update(projectPath, epicId, { status: 'done' });
-        logger.info(
-          `Epic "${epic.title}" completed — children merged directly to base, skipping epic PR (branch ${epic.branchName} not found on remote)`
-        );
-        this.emitter!.emit('feature:completed', {
-          projectPath,
-          featureId: epicId,
-          featureTitle: epic.title,
-          projectSlug: epic.projectSlug,
-          isEpic: true,
-        });
-        this.emitter!.emit('epic:auto-completed', {
+        await this.completeEpicDirectly(
           projectPath,
           epicId,
-          epicTitle: epic.title,
-          childrenIds: children.map((c) => c.id),
-          completedAt: new Date().toISOString(),
-        });
-        if (epic.projectSlug && epic.milestoneSlug) {
-          await this.checkMilestoneCompletion(projectPath, epic.projectSlug, epic.milestoneSlug);
-        }
+          epic,
+          children,
+          dedupeKey,
+          `Epic "${epic.title}" completed — children merged directly to base, skipping epic PR (branch ${epic.branchName} not found on remote)`
+        );
         return;
       }
 
-      // Branch exists on remote — create the epic-to-base PR as normal.
-      // Dedup is claimed only after a successful PR creation so that failures are retryable.
-      const result = await this.createEpicToBasePR(projectPath, epicId, epic);
+      // The epic branch exists but may be 0 commits ahead of base — this happens
+      // when child PRs targeted the base branch directly instead of the epic
+      // branch. A PR from a 0-ahead branch is empty, GitHub rejects it, and the
+      // epic is wrongly blocked even though all the work already landed. Detect
+      // that and complete the epic directly instead. (#3803)
+      const baseBranch = await getEffectivePrBaseBranch(
+        projectPath,
+        this.settingsService,
+        '[CompletionDetector]'
+      );
+      const commitsAhead = await this.epicBranchCommitsAhead(
+        projectPath,
+        baseBranch,
+        epic.branchName
+      );
+      if (commitsAhead === 0) {
+        await this.completeEpicDirectly(
+          projectPath,
+          epicId,
+          epic,
+          children,
+          dedupeKey,
+          `Epic "${epic.title}" completed — branch ${epic.branchName} is 0 commits ahead of ${baseBranch} (children merged directly to base); skipping empty epic PR`
+        );
+        return;
+      }
+
+      // Branch has commits ahead (or the count is indeterminate) — create the
+      // epic-to-base PR as normal. Dedup is claimed only after a successful PR
+      // creation so that failures are retryable.
+      const result = await this.createEpicToBasePR(projectPath, epicId, epic, baseBranch);
       if (result) {
         // PR created successfully — claim dedup and move epic to review
         this.emittedEpics.add(dedupeKey);
@@ -415,16 +495,10 @@ export class CompletionDetectorService {
   private async createEpicToBasePR(
     projectPath: string,
     epicId: string,
-    epic: Feature
+    epic: Feature,
+    baseBranch: string
   ): Promise<{ prNumber: number; prUrl: string } | null> {
     const epicBranch = epic.branchName!;
-
-    // Resolve the base branch: project settings > global settings > auto-detect > default
-    const baseBranch = await getEffectivePrBaseBranch(
-      projectPath,
-      this.settingsService,
-      '[CompletionDetector]'
-    );
 
     try {
       // Check if an open PR from this epic branch already exists

--- a/apps/server/tests/unit/services/completion-detector-service.test.ts
+++ b/apps/server/tests/unit/services/completion-detector-service.test.ts
@@ -1127,44 +1127,35 @@ describe('CompletionDetectorService', () => {
   });
 
   describe('git-backed epic regression', () => {
-    beforeEach(() => {
-      mockExecFile.mockReset();
-    });
+    type ExecFileCb = (err: null, result: { stdout: string; stderr: string }) => void;
 
-    it('should follow PR creation flow (not direct done) when epic branch exists on remote', async () => {
-      type ExecFileCb = (err: null, result: { stdout: string; stderr: string }) => void;
-
-      // git symbolic-ref (auto-detect default branch via getEffectivePrBaseBranch) → dev
-      mockExecFile.mockImplementationOnce(
-        (_cmd: string, _args: string[], _opts: object, cb: ExecFileCb) => {
-          cb(null, { stdout: 'refs/remotes/origin/dev', stderr: '' });
-        }
-      );
-      // git ls-remote → branch EXISTS on remote
-      mockExecFile.mockImplementationOnce(
-        (_cmd: string, _args: string[], _opts: object, cb: ExecFileCb) => {
-          cb(null, { stdout: 'abc123\trefs/heads/epic/m1-foundation', stderr: '' });
-        }
-      );
-      // gh pr list → no existing PR
-      mockExecFile.mockImplementationOnce(
-        (_cmd: string, _args: string[], _opts: object, cb: ExecFileCb) => {
-          cb(null, { stdout: '[]', stderr: '' });
-        }
-      );
-      // gh pr create → returns PR URL
-      mockExecFile.mockImplementationOnce(
-        (_cmd: string, _args: string[], _opts: object, cb: ExecFileCb) => {
-          cb(null, { stdout: 'https://github.com/org/repo/pull/99', stderr: '' });
-        }
-      );
-      // gh pr merge (auto-merge) → success
+    /**
+     * Command-aware git/gh mock (order-independent). `commitsAhead` controls the
+     * `git rev-list --count` response; `branchExists` controls `git ls-remote`.
+     */
+    function mockGitGh(opts: { commitsAhead: number; branchExists?: boolean }) {
       mockExecFile.mockImplementation(
-        (_cmd: string, _args: string[], _opts: object, cb: ExecFileCb) => {
-          cb(null, { stdout: '', stderr: '' });
+        (cmd: string, args: string[], _opts: object, cb: ExecFileCb) => {
+          const joined = args.join(' ');
+          let stdout = '';
+          if (cmd === 'git' && joined.includes('symbolic-ref')) {
+            stdout = 'refs/remotes/origin/main';
+          } else if (cmd === 'git' && joined.includes('ls-remote')) {
+            stdout = opts.branchExists === false ? '' : 'abc123\trefs/heads/epic/m1-foundation';
+          } else if (cmd === 'git' && joined.includes('rev-list')) {
+            stdout = String(opts.commitsAhead);
+          } else if (cmd === 'gh' && joined.includes('create')) {
+            stdout = 'https://github.com/org/repo/pull/99';
+          } else if (cmd === 'gh' && joined.includes('list')) {
+            stdout = '[]';
+          }
+          // git fetch, gh pr merge, etc. → ''
+          cb(null, { stdout, stderr: '' });
         }
       );
+    }
 
+    function makeEpicWithDoneChildren() {
       const epic = createTestFeature({
         id: 'epic-1',
         title: 'Git-Backed Epic',
@@ -1172,11 +1163,23 @@ describe('CompletionDetectorService', () => {
         isEpic: true,
         branchName: 'epic/m1-foundation',
       });
-      const child1 = createTestFeature({ id: 'child-1', epicId: 'epic-1', status: 'done' });
-      const child2 = createTestFeature({ id: 'child-2', epicId: 'epic-1', status: 'done' });
-      const child3 = createTestFeature({ id: 'child-3', epicId: 'epic-1', status: 'done' });
+      const children = [
+        createTestFeature({ id: 'child-1', epicId: 'epic-1', status: 'done' }),
+        createTestFeature({ id: 'child-2', epicId: 'epic-1', status: 'done' }),
+        createTestFeature({ id: 'child-3', epicId: 'epic-1', status: 'done' }),
+      ];
+      return { epic, children };
+    }
 
-      featureLoader = createMockFeatureLoader([epic, child1, child2, child3]);
+    beforeEach(() => {
+      mockExecFile.mockReset();
+    });
+
+    it('follows PR creation flow (not direct done) when the epic branch is ahead of base', async () => {
+      mockGitGh({ commitsAhead: 5, branchExists: true });
+
+      const { epic, children } = makeEpicWithDoneChildren();
+      featureLoader = createMockFeatureLoader([epic, ...children]);
       await service.initialize(events as any, featureLoader as any, projectService as any);
 
       events._fire('feature:status-changed', {
@@ -1194,11 +1197,7 @@ describe('CompletionDetectorService', () => {
         'epic-1',
         expect.objectContaining({ status: 'review', prNumber: 99 })
       );
-
-      // epic:auto-completed should NOT be emitted for git-backed epics
       expect(events.emit).not.toHaveBeenCalledWith('epic:auto-completed', expect.anything());
-
-      // epic:pr-created SHOULD be emitted
       expect(events.emit).toHaveBeenCalledWith(
         'epic:pr-created',
         expect.objectContaining({
@@ -1206,6 +1205,46 @@ describe('CompletionDetectorService', () => {
           epicBranchName: 'epic/m1-foundation',
           prNumber: 99,
         })
+      );
+    });
+
+    it('marks the epic done (no empty PR) when the branch exists but is 0 commits ahead of base (#3803)', async () => {
+      // Children PR'd to base directly → epic branch exists but is 0 ahead.
+      mockGitGh({ commitsAhead: 0, branchExists: true });
+
+      const { epic, children } = makeEpicWithDoneChildren();
+      featureLoader = createMockFeatureLoader([epic, ...children]);
+      await service.initialize(events as any, featureLoader as any, projectService as any);
+
+      events._fire('feature:status-changed', {
+        projectPath: '/test/path',
+        featureId: 'child-3',
+        previousStatus: 'review',
+        newStatus: 'done',
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Epic goes straight to 'done' — NOT 'review' and NOT 'blocked'.
+      expect(featureLoader.update).toHaveBeenCalledWith(
+        '/test/path',
+        'epic-1',
+        expect.objectContaining({ status: 'done' })
+      );
+      expect(featureLoader.update).not.toHaveBeenCalledWith(
+        '/test/path',
+        'epic-1',
+        expect.objectContaining({ status: 'blocked' })
+      );
+      // No empty epic PR is attempted.
+      const prCreateCall = mockExecFile.mock.calls.find(
+        (c) => c[0] === 'gh' && Array.isArray(c[1]) && c[1].includes('create')
+      );
+      expect(prCreateCall).toBeUndefined();
+      // Direct-completion events fire.
+      expect(events.emit).toHaveBeenCalledWith(
+        'epic:auto-completed',
+        expect.objectContaining({ epicId: 'epic-1' })
       );
     });
   });


### PR DESCRIPTION
## Problem

When an epic's child features merge their PRs to the **base branch directly** (rather than into the epic branch), the epic branch exists on the remote but is **0 commits ahead of base**. `CompletionDetectorService` still attempted an epic→base PR; GitHub rejected the empty PR and the epic flipped to **`blocked`** — even though all the work had already landed.

Observed on epic `feature-1779776804871-2s8hcs9rq` (children #3795/#3796/#3800 merged with `base=main`; `rev-list --count epic..main` = epic 0 ahead).

## Fix

After confirming the epic branch exists, count commits ahead of base (`git fetch` + `git rev-list --count origin/base..origin/epic`):
- **0 ahead** → mark the epic `done` directly (work already merged), no PR attempt.
- **>0 ahead** → create the epic→base PR as before.
- **indeterminate** (git/network error) → fall back to the PR path (prior behavior preserved).

Refactors:
- New `epicBranchCommitsAhead()` (fetches refs first → remote truth, not a stale local mirror).
- Extracted the duplicated "mark epic done directly" logic into `completeEpicDirectly()`, shared by the branch-absent and 0-ahead paths.
- `createEpicToBasePR()` now receives the already-resolved `baseBranch` (resolved once) instead of re-resolving.

## Tests

Rewrote the `git-backed epic regression` block with an order-independent, command-aware git/gh mock and added a case for the 0-ahead path:
- **>0 ahead** → epic → `review`, PR #99 created, `epic:pr-created` emitted.
- **0 ahead (#3803)** → epic → `done` (not `blocked`/`review`), **no `gh pr create` call**, `epic:auto-completed` emitted.

`npm run test:server -- …/completion-detector-service.test.ts` → 26 passed. `npm run typecheck` → clean (22/22).

## Acceptance (from #3803)

- [x] Epic whose children all merged to base directly is marked `done`, not `blocked`
- [x] No empty-PR creation attempt when epic branch is 0 commits ahead of base
- [x] Unit test covering the "0 commits ahead, all children done" path

Closes #3803.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Epic completion process now handles edge cases more efficiently, preventing unnecessary empty pull request creation when epic branches have no new commits ahead of the base branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->