### PR TITLE
ci(security): gate actionlint shellcheck on error severity only (#3819 follow-up)

### DIFF
--- a/.github/workflows/workflow-security-lint.yml
+++ b/.github/workflows/workflow-security-lint.yml
@@ -57,5 +57,11 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/62c50a97a146fe36a8951a2a365158c4a4795ba8/scripts/download-actionlint.bash -o /tmp/download-actionlint.bash
           bash /tmp/download-actionlint.bash 1.7.12
 
+      # SHELLCHECK_OPTS gates only on error-severity shell bugs. Pre-existing
+      # info/warning style findings (SC2086 unquoted vars, etc.) across the
+      # existing run: blocks are tracked for cleanup in #3935; tighten the
+      # severity once they're resolved.
       - name: Run actionlint
+        env:
+          SHELLCHECK_OPTS: --severity=error
         run: ./actionlint -color


### PR DESCRIPTION
**Fixes the red `workflow-security-lint` job on main.** #3936 added the gate but merged on `UNSTABLE` (the brand-new check isn't a *required* check yet) before its actionlint step was finalized.

CI has `shellcheck` installed (local runs don't), so actionlint surfaced **21 pre-existing info/warning** shell-style findings (SC2086 unquoted vars, SC2046, SC2011, SC2009) across existing `run:` blocks → job failed.

Sets `SHELLCHECK_OPTS=--severity=error` so the gate catches real shell **bugs** without blocking on pre-existing **style** debt. The info/warning cleanup + dropping the severity filter is tracked in #3935.

Verified locally with shellcheck 0.11 installed: `actionlint` and `zizmor --min-severity=high` both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality checks in the CI/CD pipeline to focus on critical issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->