### PR TITLE
feat(ava): file-read tools (read_file, list_directory) for the chat agent (#3791)

### DIFF
--- a/apps/server/src/routes/chat/ava-config.ts
+++ b/apps/server/src/routes/chat/ava-config.ts
@@ -86,6 +86,7 @@ export const DEFAULT_AVA_CONFIG: AvaConfig = {
     projects: true,
     scheduling: true,
     memory: true,
+    fileRead: true,
   },
   sitrepInjection: true,
   contextInjection: true,

--- a/apps/server/src/routes/chat/ava-prompt.md
+++ b/apps/server/src/routes/chat/ava-prompt.md
@@ -47,6 +47,7 @@ The following tool groups are available in the UI chat, gated by per-project `av
 | `settings`        | `get_global_settings`, `update_global_settings`, `get_project_settings`, `update_project_settings` |
 | `scheduling`      | `list_timers`, `pause_timer`, `resume_timer`                                                       |
 | `memory`          | `remember`, `recall`, `forget`                                                                     |
+| `fileRead`        | `read_file`, `list_directory` — read verbatim file contents within the project sandbox             |
 
 Use only tools that are enabled for the current project's tool group configuration. Do not attempt MCP CLI tools — they are not available in this surface.
 

--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -23,6 +23,7 @@ import {
   ensureNotesDir,
   getAutomakerDir,
   secureFs,
+  validatePath,
 } from '@protolabsai/platform';
 import type { FeatureLoader } from '../../services/feature-loader.js';
 import type { AutoModeService } from '../../services/auto-mode-service.js';
@@ -165,6 +166,8 @@ export interface AvaToolsConfig {
   scheduling?: boolean;
   /** Enable memory tools (remember, recall, forget) */
   memory?: boolean;
+  /** Enable filesystem read tools (read_file, list_directory) within the project */
+  fileRead?: boolean;
 }
 
 // Re-use the same status literals that the Feature type exposes
@@ -1298,6 +1301,84 @@ export function buildAvaTools(
         const filePath = path.join(contextDir, filename);
         await fs.writeFile(filePath, content, 'utf-8');
         return { success: true, filename, path: filePath };
+      },
+    });
+  }
+
+  // Filesystem read — lets Ava return verbatim file contents to the operator
+  // (#3791). Reads go through secureFs, which validates every path against
+  // ALLOWED_ROOT, so Ava can't escape the sandbox. Relative paths resolve
+  // against the current project.
+  if (config.fileRead) {
+    // Cap returned content so a giant file can't blow the context window.
+    const MAX_FILE_BYTES = 256 * 1024;
+
+    const resolveInProject = (p: string): string =>
+      path.isAbsolute(p) ? p : path.join(projectPath, p);
+
+    tools['read_file'] = makeTool({
+      description:
+        'Read a file and return its full contents as text. Use for inspecting source files, configs, or docs. Path may be absolute or relative to the project root. Files are read within the allowed sandbox only.',
+      inputSchema: z.object({
+        path: z
+          .string()
+          .min(1)
+          .describe(
+            'File path — absolute, or relative to the project root (e.g. "apps/server/src/index.ts")'
+          ),
+      }),
+      execute: async ({ path: filePath }) => {
+        const resolved = resolveInProject(filePath);
+        try {
+          const buf = (await secureFs.readFile(resolved)) as Buffer;
+          if (buf.length > MAX_FILE_BYTES) {
+            return {
+              path: resolved,
+              truncated: true,
+              bytes: buf.length,
+              content: buf.subarray(0, MAX_FILE_BYTES).toString('utf-8'),
+              note: `File is ${buf.length} bytes; returned the first ${MAX_FILE_BYTES}.`,
+            };
+          }
+          return { path: resolved, truncated: false, content: buf.toString('utf-8') };
+        } catch (err) {
+          return {
+            path: resolved,
+            error: err instanceof Error ? err.message : 'Failed to read file',
+          };
+        }
+      },
+    });
+
+    tools['list_directory'] = makeTool({
+      description:
+        'List the entries in a directory (names + whether each is a file or directory). Path may be absolute or relative to the project root.',
+      inputSchema: z.object({
+        path: z
+          .string()
+          .default('.')
+          .describe(
+            'Directory path — absolute or relative to the project root (default: project root)'
+          ),
+      }),
+      execute: async ({ path: dirPath }) => {
+        const resolved = resolveInProject(dirPath || '.');
+        try {
+          validatePath(resolved); // enforce sandbox before reading the dir
+          const entries = await fs.readdir(resolved, { withFileTypes: true });
+          return {
+            path: resolved,
+            entries: entries.map((e) => ({
+              name: e.name,
+              type: e.isDirectory() ? 'directory' : 'file',
+            })),
+          };
+        } catch (err) {
+          return {
+            path: resolved,
+            error: err instanceof Error ? err.message : 'Failed to list directory',
+          };
+        }
       },
     });
   }

--- a/apps/server/tests/unit/ava-file-read-tools.test.ts
+++ b/apps/server/tests/unit/ava-file-read-tools.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for Ava's filesystem-read tools (#3791) — registered in
+ * buildAvaTools() when config.fileRead is true:
+ *
+ *   read_file       – return a file's verbatim contents (size-capped)
+ *   list_directory  – list directory entries (name + file/directory)
+ *
+ * Verifies: content round-trip, large-file truncation, read-error handling,
+ * relative-path resolution against the project root, and that reads go through
+ * secureFs (ALLOWED_ROOT sandbox).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as path from 'path';
+import * as os from 'os';
+import * as fsSync from 'fs';
+
+// Controllable secureFs.readFile + pass-through validatePath.
+const { readFileMock } = vi.hoisted(() => ({ readFileMock: vi.fn() }));
+vi.mock('@protolabsai/platform', () => ({
+  getNotesWorkspacePath: vi.fn().mockReturnValue('/tmp/notes'),
+  ensureNotesDir: vi.fn().mockResolvedValue(undefined),
+  getAutomakerDir: vi.fn().mockReturnValue('/tmp/.automaker'),
+  secureFs: { readFile: readFileMock, writeFile: vi.fn(), mkdir: vi.fn() },
+  validatePath: vi.fn((p: string) => p),
+}));
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }),
+}));
+vi.mock('@protolabsai/git-utils', () => ({}));
+vi.mock('../../src/services/github-merge-service.js', () => ({
+  githubMergeService: { merge: vi.fn(), getPRStatus: vi.fn() },
+}));
+vi.mock('../../src/services/event-history-service.js', () => ({
+  getEventHistoryService: vi.fn().mockReturnValue(null),
+}));
+vi.mock('../../src/services/briefing-cursor-service.js', () => ({
+  getBriefingCursorService: vi.fn().mockReturnValue(null),
+}));
+vi.mock('../../src/routes/project-pm/pm-agent.js', () => ({
+  queryPm: vi.fn().mockResolvedValue({ text: '' }),
+}));
+vi.mock('../../src/providers/simple-query-service.js', () => ({
+  simpleQuery: vi.fn().mockResolvedValue({ text: '' }),
+}));
+
+import { buildAvaTools } from '../../src/routes/chat/ava-tools.js';
+
+type ExecutableTool = {
+  execute: (input: unknown, opts: { toolCallId: string }) => Promise<unknown>;
+};
+function getExecute(tools: Record<string, unknown>, name: string) {
+  const tool = tools[name] as ExecutableTool | undefined;
+  if (!tool) throw new Error(`Tool "${name}" not found`);
+  return (input: unknown) => tool.execute(input, { toolCallId: `test-${name}` });
+}
+
+describe('Ava file-read tools', () => {
+  let tempDir: string;
+  let tools: Record<string, unknown>;
+
+  beforeEach(() => {
+    readFileMock.mockReset();
+    tempDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'ava-fileread-'));
+    tools = buildAvaTools(tempDir, {}, { fileRead: true }) as Record<string, unknown>;
+  });
+
+  afterEach(() => {
+    fsSync.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('registers read_file and list_directory only when fileRead is enabled', () => {
+    expect(tools['read_file']).toBeDefined();
+    expect(tools['list_directory']).toBeDefined();
+    const without = buildAvaTools(tempDir, {}, {}) as Record<string, unknown>;
+    expect(without['read_file']).toBeUndefined();
+    expect(without['list_directory']).toBeUndefined();
+  });
+
+  it('read_file returns verbatim contents and resolves relative paths against the project', async () => {
+    readFileMock.mockResolvedValue(Buffer.from('hello world', 'utf-8'));
+    const res = (await getExecute(tools, 'read_file')({ path: 'src/x.ts' })) as {
+      content: string;
+      truncated: boolean;
+      path: string;
+    };
+    expect(res.content).toBe('hello world');
+    expect(res.truncated).toBe(false);
+    // relative path resolved against tempDir before hitting secureFs
+    expect(readFileMock).toHaveBeenCalledWith(path.join(tempDir, 'src/x.ts'));
+  });
+
+  it('read_file truncates files larger than the cap', async () => {
+    const big = Buffer.alloc(256 * 1024 + 100, 0x61); // 'a'
+    readFileMock.mockResolvedValue(big);
+    const res = (await getExecute(tools, 'read_file')({ path: 'big.txt' })) as {
+      truncated: boolean;
+      bytes: number;
+      content: string;
+    };
+    expect(res.truncated).toBe(true);
+    expect(res.bytes).toBe(256 * 1024 + 100);
+    expect(res.content.length).toBe(256 * 1024);
+  });
+
+  it('read_file returns an error object when the read fails (e.g. sandbox violation)', async () => {
+    readFileMock.mockRejectedValue(new Error('path escapes ALLOWED_ROOT'));
+    const res = (await getExecute(tools, 'read_file')({ path: '../../etc/passwd' })) as {
+      error: string;
+    };
+    expect(res.error).toMatch(/ALLOWED_ROOT/);
+  });
+
+  it('list_directory lists entries with their type', async () => {
+    fsSync.writeFileSync(path.join(tempDir, 'a.txt'), 'x');
+    fsSync.mkdirSync(path.join(tempDir, 'sub'));
+    const res = (await getExecute(tools, 'list_directory')({ path: '.' })) as {
+      entries: Array<{ name: string; type: string }>;
+    };
+    const byName = Object.fromEntries(res.entries.map((e) => [e.name, e.type]));
+    expect(byName['a.txt']).toBe('file');
+    expect(byName['sub']).toBe('directory');
+  });
+});


### PR DESCRIPTION
Ava (UI chat) lacked any filesystem-read capability — operator requests like *"read these files and return their contents"* came back empty (the gap #3791 reported).

## Changes
- New **`fileRead`** tool group with:
  - **`read_file(path)`** — verbatim file contents; relative paths resolve against the project root; **256 KB cap** with a truncation note.
  - **`list_directory(path)`** — entries with `file`/`directory` type; defaults to project root.
- Reads go through **`secureFs.readFile` / `validatePath`** (enforce `ALLOWED_ROOT`) — Ava can't escape the project sandbox.
- Enabled by default in `DEFAULT_AVA_CONFIG` (propagates to existing projects via the `toolGroups` spread); documented in the `ava-prompt.md` tool-groups table.

## Validation
- `tests/unit/ava-file-read-tools.test.ts` — 5 tests (content round-trip, relative-path resolution, truncation, sandbox-violation error, directory listing).
- Server typecheck clean; existing ava tool tests still pass (43 total).

Closes #3791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AVA autonomous chat assistant now includes file reading capabilities by default. The assistant can read project files and browse directory structures within your project sandbox, enabling it to provide more contextually aware responses and assistance.

* **Tests**
  * Added comprehensive unit tests for the new file reading functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->