### PR TITLE
ci(security): clear medium workflow findings + tighten zizmor gate to medium (#3935)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4  # zizmor: ignore[artipacked]  # pushes via git; needs persisted creds
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup project
         uses: ./.github/actions/setup-project

--- a/.github/workflows/create-protolab-test.yml
+++ b/.github/workflows/create-protolab-test.yml
@@ -15,6 +15,9 @@ on:
       - 'packages/create-protolab/**'
       - '.github/workflows/create-protolab-test.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test with Node ${{ matrix.node }} and ${{ matrix.package-manager }}
@@ -29,6 +32,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -39,6 +39,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup project
         uses: ./.github/actions/setup-project

--- a/.github/workflows/harness-eval.yml
+++ b/.github/workflows/harness-eval.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup project
         uses: ./.github/actions/setup-project

--- a/.github/workflows/langfuse-prompt-sync.yml
+++ b/.github/workflows/langfuse-prompt-sync.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup project

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,7 +14,8 @@ on:
       - '**.md'
       - '.automaker/**'
 
-permissions: read-all
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -30,6 +31,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Detect code changes
         id: changes

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3

--- a/.github/workflows/regenerate-site.yml
+++ b/.github/workflows/regenerate-site.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4  # zizmor: ignore[artipacked]  # pushes via git; needs persisted creds
         with:
           ref: dev
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Check for code changes

--- a/.github/workflows/workflow-security-lint.yml
+++ b/.github/workflows/workflow-security-lint.yml
@@ -40,14 +40,13 @@ jobs:
 
       # zizmor — GitHub Actions security linter. Installed from PyPI (no
       # third-party action to pin) at an exact version for reproducibility.
-      # --min-severity=high fails the build on script injection and unpinned
-      # actions; medium-severity hardening (artipacked, excessive-permissions)
-      # is tracked separately before tightening the gate.
+      # --min-severity=medium fails the build on script injection, unpinned
+      # actions, artipacked (persist-credentials), and token over-privilege.
       - name: Install zizmor
         run: pip install zizmor==1.25.2
 
       - name: Run zizmor
-        run: zizmor --min-severity=high .github/workflows/
+        run: zizmor --min-severity=medium .github/workflows/
 
       # actionlint — workflow syntax, expression typing, and shellcheck. Fetched
       # via the official download script pinned to an immutable commit SHA + an


### PR DESCRIPTION
Completes the #3819 follow-up: clears all **medium**-severity zizmor findings and raises the gate from `--min-severity=high` to `medium`.

## Changes
- **artipacked (12)** — `persist-credentials: false` added to checkout in the 10 read-only / deploy-via-token workflows. `auto-release` (`git tag`) and `regenerate-site` (`git commit`+`push`) genuinely need the persisted credential → justified `# zizmor: ignore[artipacked]` instead.
- **excessive-permissions (4)** — top-level `permissions: contents: read` on `create-protolab-test.yml`; narrowed `pr-check.yml` `read-all` → `contents: read`.
- **Gate** — `workflow-security-lint.yml` now runs zizmor at `--min-severity=medium`, so artipacked + token over-privilege gate on new workflows too.

## Verification (local)
- `zizmor --min-severity=medium .github/workflows/` → **No findings** (8 ignored, all justified)
- `actionlint` (SHELLCHECK_OPTS=--severity=error) → **0**

The shellcheck SC2086-style cleanup (quoting vars in `run:` blocks) remains a separate, larger pass.

Closes #3935.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline security by disabling credential persistence across checkout steps and restricting workflow token permissions to necessary scopes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->