### PR TITLE
docs(jon): remove dead content-pipeline tool refs from the skill body (#3929)

### DIFF
--- a/.claude/commands/jon.md
+++ b/.claude/commands/jon.md
@@ -169,12 +169,6 @@ mcp__plugin_protolabs_studio__list_projects({ projectPath })
 mcp__plugin_protolabs_studio__get_briefing({ projectPath })
 ```
 
-**Content pipeline:**
-
-```
-mcp__plugin_protolabs_studio__list_content({ projectPath })
-```
-
 **Notes tab (operator's direction):**
 
 ```
@@ -289,51 +283,24 @@ This is NOT a human org. AI agents generate, schedule, and distribute content at
 
 ## Cindi Coordination Protocol
 
-Jon provides strategy and briefs. Cindi executes content writing via the LangGraph content pipeline.
+Jon provides strategy and briefs; Cindi executes the content writing. Delegate
+to Cindi (via `/cindi`, the team delegation flow, or a written brief in the
+shared notes / Discord) rather than calling content tools directly.
 
-### How to brief Cindi (content pipeline)
+### How to brief Cindi
 
-**For blog posts / long-form:**
+Give Cindi a tight brief covering:
 
-```
-mcp__plugin_protolabs_studio__create_content({
-  projectPath,
-  topic: "Your topic here — be specific about angle and audience",
-  contentConfig: {
-    format: "guide",           // tutorial | reference | guide
-    audience: "intermediate",  // beginner | intermediate | expert
-    tone: "conversational",    // technical | conversational | formal
-    outputFormats: ["markdown", "frontmatter-md"]
-  }
-})
-```
+- **Topic + angle** — be specific about the thesis and what makes it worth reading.
+- **Audience** — beginner / intermediate / expert.
+- **Tone** — technical / conversational / formal (default conversational).
+- **Format + output** — tutorial / reference / guide; markdown or frontmatter-md.
+- **Review bar** — the quality gates you want enforced (research soundness,
+  outline structure, a final antagonistic pass for claims/voice).
 
-**For quality review of existing content:**
-
-```
-mcp__plugin_protolabs_studio__execute_antagonistic_review({
-  projectPath,
-  prdTitle: "Content title",
-  prdDescription: "Full content text to review"
-})
-```
-
-**Workflow:**
-
-1. Create the content flow with `create_content`
-2. Monitor with `get_content_status` (returns progress and HITL gates)
-3. Review at gates with `review_content` (approve/revise/reject)
-4. Export final with `export_content` (markdown, frontmatter-md, jsonl)
-
-### Content review gates
-
-The pipeline pauses at three HITL checkpoints:
-
-- `research_hitl` — After research phase. Review sources and angle.
-- `outline_hitl` — After outline generated. Review structure.
-- `final_review_hitl` — After antagonistic review. Final approval.
-
-At each gate, use `review_content` with decision: `approve`, `revise` (with feedback), or `reject`.
+> Note: the former in-app MCP content-pipeline tools were removed in #3911.
+> There is no content-generation tool to call from this skill — coordinate with
+> Cindi directly.
 
 ## Twitter/X Content Templates
 


### PR DESCRIPTION
#3911 removed the 6 content MCP tools; #3912/#3930 pruned them from jon.md's `allowed-tools` frontmatter — but jon's **body** still told it to *call* them (the mandatory-init "Content pipeline" step using `list_content`, and the entire "Cindi Coordination Protocol" built on `create_content`/`get_content_status`/`review_content`/`export_content`/`execute_antagonistic_review`). Those calls would fail at runtime.

Taking the **deprecated** reading (the content pipeline these tools fronted was removed as dead code): removed the init content-pipeline step and reframed Cindi coordination as a delegation brief (topic / angle / audience / tone / format / review-bar) with a note that the in-app content tools were removed.

**Acceptance met:** `grep -E 'list_content|create_content|get_content_status|review_content|export_content|execute_antagonistic_review' .claude/commands/jon.md` → 0.

Closes #3929.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI agent initialization and coordination procedures for improved system efficiency
  * Streamlined startup process by removing redundant status checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3942?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->