### PR TITLE
feat(models): route micro-tasks through the nano tier via phaseModels (#3859)

### DIFF
--- a/apps/server/src/providers/proto-provider.ts
+++ b/apps/server/src/providers/proto-provider.ts
@@ -346,6 +346,19 @@ export class ProtoProvider extends BaseProvider {
         supportsTools: true,
         tier: 'basic' as const,
       },
+      {
+        id: 'protolabs/nano',
+        name: 'protoLabs Nano',
+        modelString: 'protolabs/nano',
+        provider: 'protolabs',
+        description:
+          'Gateway-routed nano tier for trivial one-shot micro-tasks (branch names, titles, descriptions).',
+        contextWindow: 32000,
+        maxOutputTokens: 4192,
+        supportsVision: false,
+        supportsTools: false,
+        tier: 'basic' as const,
+      },
     ] satisfies ModelDefinition[];
   }
 

--- a/apps/server/src/routes/features/routes/generate-title.ts
+++ b/apps/server/src/routes/features/routes/generate-title.ts
@@ -7,10 +7,14 @@
 
 import type { Request, Response } from 'express';
 import { createLogger } from '@protolabsai/utils';
-import { CLAUDE_MODEL_MAP } from '@protolabsai/model-resolver';
+import { resolvePhaseModel } from '@protolabsai/model-resolver';
 import { simpleQuery } from '../../../providers/simple-query-service.js';
 import type { SettingsService } from '../../../services/settings-service.js';
-import { getPromptCustomization } from '../../../lib/settings-helpers.js';
+import {
+  getPromptCustomization,
+  getPhaseModelWithOverrides,
+} from '../../../lib/settings-helpers.js';
+import { captureTrainingRow } from '../../../services/training-capture.js';
 
 const logger = createLogger('GenerateTitle');
 
@@ -34,7 +38,7 @@ export function createGenerateTitleHandler(
 ): (req: Request, res: Response) => Promise<void> {
   return async (req: Request, res: Response): Promise<void> => {
     try {
-      const { description, projectPath: _projectPath } = req.body as GenerateTitleRequestBody;
+      const { description, projectPath } = req.body as GenerateTitleRequestBody;
 
       if (!description || typeof description !== 'string') {
         const response: GenerateTitleErrorResponse = {
@@ -66,10 +70,20 @@ export function createGenerateTitleHandler(
 
       const userPrompt = `Generate a concise title for this feature:\n\n${trimmedDescription}`;
 
-      // Use simpleQuery - provider abstraction handles all the streaming/extraction
+      // Model comes from the phase-model settings (Settings → AI Models →
+      // titleGenerationModel), not a hardcoded id — defaults to the nano tier.
+      const { phaseModel } = await getPhaseModelWithOverrides(
+        'titleGenerationModel',
+        settingsService,
+        projectPath,
+        '[GenerateTitle]'
+      );
+      const { model } = resolvePhaseModel(phaseModel);
+
+      // Use simpleQuery - provider abstraction handles all the streaming/extraction.
       const result = await simpleQuery({
         prompt: `${systemPrompt}\n\n${userPrompt}`,
-        model: CLAUDE_MODEL_MAP.haiku,
+        model,
         cwd: process.cwd(),
         maxTurns: 1,
         allowedTools: [],
@@ -77,6 +91,16 @@ export function createGenerateTitleHandler(
       });
 
       const title = result.text;
+
+      // Capture the input→output pair as training data (non-blocking; #3859).
+      if (projectPath && title && title.trim().length > 0) {
+        void captureTrainingRow(projectPath, {
+          task: 'feature-title',
+          model,
+          input: { description: trimmedDescription.slice(0, 500) },
+          output: title.trim(),
+        });
+      }
 
       if (!title || title.trim().length === 0) {
         logger.warn('Received empty response from AI');

--- a/apps/server/src/services/branch-name-generator.ts
+++ b/apps/server/src/services/branch-name-generator.ts
@@ -12,17 +12,14 @@
  * deterministic slug. It never throws.
  */
 
-import fs from 'node:fs';
-import path from 'node:path';
 import { createLogger } from '@protolabsai/utils';
+import { resolvePhaseModel } from '@protolabsai/model-resolver';
 import { simpleQuery } from '../providers/simple-query-service.js';
-import { getWorkflowSettings } from '../lib/settings-helpers.js';
+import { getWorkflowSettings, getPhaseModelWithOverrides } from '../lib/settings-helpers.js';
+import { captureTrainingRow } from './training-capture.js';
 import type { SettingsService } from './settings-service.js';
 
 const logger = createLogger('SmartBranchName');
-
-/** Fast tier alias — gateway-routed, NOT a hardcoded anthropic model id. */
-const FAST_MODEL = 'protolabs/fast';
 
 export interface SmartBranchInput {
   title?: string;
@@ -55,6 +52,16 @@ export function createSmartBranchNameGenerator(
       const prefix = branchPrefixForCategory(input.category);
       const shortId = (input.featureId ?? Date.now().toString(36)).slice(-7);
 
+      // Model comes from the phase-model settings (Settings → AI Models →
+      // branchNameModel), not a hardcoded id — defaults to the nano tier.
+      const { phaseModel } = await getPhaseModelWithOverrides(
+        'branchNameModel',
+        settingsService,
+        projectPath,
+        '[SmartBranchName]'
+      );
+      const { model } = resolvePhaseModel(phaseModel);
+
       let slug = '';
       let usedFallback = true;
       try {
@@ -63,7 +70,7 @@ export function createSmartBranchNameGenerator(
             `Generate a concise git branch slug for this work. ` +
             `Rules: 2-5 words, lowercase, hyphen-separated, no path prefix, no quotes, no trailing id. ` +
             `Return ONLY the slug.\n\nTitle: ${title}\nDescription: ${(input.description ?? '').slice(0, 300)}`,
-          model: FAST_MODEL,
+          model,
           cwd: projectPath,
           maxTurns: 1,
         });
@@ -85,7 +92,7 @@ export function createSmartBranchNameGenerator(
       // Capture the input→output pair as training data (non-blocking, fail-open).
       void captureTrainingRow(projectPath, {
         task: 'branch-name',
-        model: FAST_MODEL,
+        model,
         input: {
           title,
           description: (input.description ?? '').slice(0, 500),
@@ -101,25 +108,4 @@ export function createSmartBranchNameGenerator(
       return null;
     }
   };
-}
-
-/**
- * Append a training row to `.automaker/training/branch-names/captures.jsonl`.
- * Fail-open — capture must never break feature creation. See #3859.
- */
-async function captureTrainingRow(
-  projectPath: string,
-  row: Record<string, unknown>
-): Promise<void> {
-  try {
-    const dir = path.join(projectPath, '.automaker', 'training', 'branch-names');
-    await fs.promises.mkdir(dir, { recursive: true });
-    await fs.promises.appendFile(
-      path.join(dir, 'captures.jsonl'),
-      JSON.stringify({ ...row, timestamp: new Date().toISOString() }) + '\n',
-      'utf-8'
-    );
-  } catch {
-    // non-blocking
-  }
 }

--- a/apps/server/src/services/training-capture.ts
+++ b/apps/server/src/services/training-capture.ts
@@ -1,0 +1,48 @@
+/**
+ * Training-data capture for fast-tier micro-tasks (#3859).
+ *
+ * Several pipeline micro-tasks route to the fast model (branch names, feature
+ * titles, …). Each is narrow and high-volume — ideal to distill into a small
+ * purpose-built model later. This module captures input→output pairs as JSONL
+ * so that corpus accrues passively.
+ *
+ * Fail-open by design: capture must NEVER break the task it observes. Every
+ * function swallows its own errors.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/** Known fast-tier task kinds — one capture file per task under .automaker/training/. */
+export type FastTaskKind = 'branch-name' | 'feature-title';
+
+export interface TrainingRow {
+  /** The fast-task kind (also the capture sub-directory). */
+  task: FastTaskKind;
+  /** Model alias used (e.g. 'protolabs/fast', 'haiku'). */
+  model: string;
+  /** Task input (prompt-shaping fields). */
+  input: Record<string, unknown>;
+  /** The produced output, or a sentinel when the deterministic fallback was used. */
+  output: string;
+  /** True when the model output was rejected/unused and a fallback was taken. */
+  usedFallback?: boolean;
+}
+
+/**
+ * Append a training row to `.automaker/training/{task}/captures.jsonl`.
+ * Never throws — a capture failure must not affect the observed task.
+ */
+export async function captureTrainingRow(projectPath: string, row: TrainingRow): Promise<void> {
+  try {
+    const dir = path.join(projectPath, '.automaker', 'training', row.task);
+    await fs.promises.mkdir(dir, { recursive: true });
+    await fs.promises.appendFile(
+      path.join(dir, 'captures.jsonl'),
+      JSON.stringify({ ...row, timestamp: new Date().toISOString() }) + '\n',
+      'utf-8'
+    );
+  } catch {
+    // non-blocking — capture is best-effort
+  }
+}

--- a/apps/server/tests/unit/services/branch-name-generator.test.ts
+++ b/apps/server/tests/unit/services/branch-name-generator.test.ts
@@ -20,8 +20,10 @@ vi.mock('../../../src/providers/simple-query-service.js', () => ({
   simpleQuery: (...args: unknown[]) => simpleQuery(...args),
 }));
 const getWorkflowSettings = vi.fn();
+const getPhaseModelWithOverrides = vi.fn();
 vi.mock('../../../src/lib/settings-helpers.js', () => ({
   getWorkflowSettings: (...args: unknown[]) => getWorkflowSettings(...args),
+  getPhaseModelWithOverrides: (...args: unknown[]) => getPhaseModelWithOverrides(...args),
 }));
 
 import { createSmartBranchNameGenerator } from '../../../src/services/branch-name-generator.js';
@@ -36,7 +38,14 @@ const input = {
 };
 
 describe('createSmartBranchNameGenerator', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Branch-name model resolves from phaseModels.branchNameModel; default = nano.
+    getPhaseModelWithOverrides.mockResolvedValue({
+      phaseModel: { model: 'protolabs/nano' },
+      isProjectOverride: false,
+    });
+  });
 
   it('returns null when smartBranchNames is disabled (no model call)', async () => {
     getWorkflowSettings.mockResolvedValue({ smartBranchNames: false });
@@ -52,8 +61,8 @@ describe('createSmartBranchNameGenerator', () => {
     const gen = createSmartBranchNameGenerator(null, prefixFor);
     const result = await gen(input, '/proj');
     expect(result).toBe('feature/user-auth-flow-abc1234');
-    // routes through the fast tier
-    expect(simpleQuery).toHaveBeenCalledWith(expect.objectContaining({ model: 'protolabs/fast' }));
+    // routes through the nano tier (resolved from phaseModels.branchNameModel)
+    expect(simpleQuery).toHaveBeenCalledWith(expect.objectContaining({ model: 'protolabs/nano' }));
     // captured a training row
     expect(vi.mocked(fs.promises.appendFile)).toHaveBeenCalled();
   });

--- a/apps/server/tests/unit/services/settings-service.test.ts
+++ b/apps/server/tests/unit/services/settings-service.test.ts
@@ -758,7 +758,9 @@ describe('settings-service.ts', () => {
 
       // Should use DEFAULT_PHASE_MODELS (gateway-routed)
       expect(settings.phaseModels.enhancementModel).toEqual({ model: 'protolabs/smart' });
-      expect(settings.phaseModels.fileDescriptionModel).toEqual({ model: 'protolabs/fast' });
+      expect(settings.phaseModels.fileDescriptionModel).toEqual({ model: 'protolabs/nano' });
+      expect(settings.phaseModels.titleGenerationModel).toEqual({ model: 'protolabs/nano' });
+      expect(settings.phaseModels.branchNameModel).toEqual({ model: 'protolabs/nano' });
       expect(settings.phaseModels.specGenerationModel).toEqual({ model: 'protolabs/reasoning' });
     });
 

--- a/apps/server/tests/unit/services/training-capture.test.ts
+++ b/apps/server/tests/unit/services/training-capture.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the shared fast-tier training-data capture (#3859).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import * as fsSync from 'node:fs';
+import { captureTrainingRow } from '../../../src/services/training-capture.js';
+
+describe('captureTrainingRow', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'training-capture-'));
+  });
+  afterEach(() => {
+    fsSync.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('appends a JSONL row under .automaker/training/{task}/captures.jsonl', async () => {
+    await captureTrainingRow(tempDir, {
+      task: 'branch-name',
+      model: 'protolabs/nano',
+      input: { title: 'Add auth' },
+      output: 'feat/add-auth-abc1234',
+      usedFallback: false,
+    });
+
+    const file = path.join(tempDir, '.automaker', 'training', 'branch-name', 'captures.jsonl');
+    expect(fsSync.existsSync(file)).toBe(true);
+    const row = JSON.parse(fsSync.readFileSync(file, 'utf-8').trim());
+    expect(row).toMatchObject({
+      task: 'branch-name',
+      model: 'protolabs/nano',
+      output: 'feat/add-auth-abc1234',
+      usedFallback: false,
+    });
+    expect(typeof row.timestamp).toBe('string');
+  });
+
+  it('separates rows by task and appends (one line per call)', async () => {
+    await captureTrainingRow(tempDir, {
+      task: 'feature-title',
+      model: 'protolabs/nano',
+      input: { description: 'x' },
+      output: 'Title One',
+    });
+    await captureTrainingRow(tempDir, {
+      task: 'feature-title',
+      model: 'protolabs/nano',
+      input: { description: 'y' },
+      output: 'Title Two',
+    });
+
+    const file = path.join(tempDir, '.automaker', 'training', 'feature-title', 'captures.jsonl');
+    const lines = fsSync.readFileSync(file, 'utf-8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[1]).output).toBe('Title Two');
+    // branch-name dir must NOT exist (task isolation)
+    expect(fsSync.existsSync(path.join(tempDir, '.automaker', 'training', 'branch-name'))).toBe(
+      false
+    );
+  });
+
+  it('is fail-open — never throws on an unwritable path', async () => {
+    // A path under a file (not a dir) can't be mkdir'd → must swallow.
+    const filePath = path.join(tempDir, 'not-a-dir');
+    fsSync.writeFileSync(filePath, 'x');
+    await expect(
+      captureTrainingRow(filePath, {
+        task: 'branch-name',
+        model: 'protolabs/nano',
+        input: {},
+        output: 'x',
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/ui/src/components/views/project-settings-view/project-bulk-replace-dialog.tsx
+++ b/apps/ui/src/components/views/project-settings-view/project-bulk-replace-dialog.tsx
@@ -40,6 +40,7 @@ const PHASE_LABELS: Record<PhaseModelKey, string> = {
   fileDescriptionModel: 'File Descriptions',
   imageDescriptionModel: 'Image Descriptions',
   commitMessageModel: 'Commit Messages',
+  titleGenerationModel: 'Feature Titles',
   branchNameModel: 'Branch Names',
   validationModel: 'GitHub Issue Validation',
   specGenerationModel: 'App Specification',

--- a/apps/ui/src/components/views/project-settings-view/project-models-section.tsx
+++ b/apps/ui/src/components/views/project-settings-view/project-models-section.tsx
@@ -41,6 +41,11 @@ const QUICK_TASKS: PhaseConfig[] = [
     label: 'Commit Messages',
     description: 'Generates git commit messages from diffs',
   },
+  {
+    key: 'titleGenerationModel',
+    label: 'Feature Titles',
+    description: 'Generates a concise feature title from a description',
+  },
 ];
 
 const VALIDATION_TASKS: PhaseConfig[] = [

--- a/apps/ui/src/components/views/settings-view/model-defaults/bulk-replace-dialog.tsx
+++ b/apps/ui/src/components/views/settings-view/model-defaults/bulk-replace-dialog.tsx
@@ -37,6 +37,7 @@ const PHASE_LABELS: Record<PhaseModelKey, string> = {
   fileDescriptionModel: 'File Descriptions',
   imageDescriptionModel: 'Image Descriptions',
   commitMessageModel: 'Commit Messages',
+  titleGenerationModel: 'Feature Titles',
   branchNameModel: 'Branch Names',
   validationModel: 'GitHub Issue Validation',
   specGenerationModel: 'App Specification',

--- a/apps/ui/src/components/views/settings-view/model-defaults/model-defaults-section.tsx
+++ b/apps/ui/src/components/views/settings-view/model-defaults/model-defaults-section.tsx
@@ -66,6 +66,11 @@ const QUICK_TASKS: PhaseConfig[] = [
     label: 'Commit Messages',
     description: 'Generates git commit messages from diffs',
   },
+  {
+    key: 'titleGenerationModel',
+    label: 'Feature Titles',
+    description: 'Generates a concise feature title from a description',
+  },
 ];
 
 const VALIDATION_TASKS: PhaseConfig[] = [

--- a/apps/ui/src/hooks/use-settings-sync.ts
+++ b/apps/ui/src/hooks/use-settings-sync.ts
@@ -751,6 +751,9 @@ export async function refreshSettingsFromServer(): Promise<boolean> {
             serverSettings.phaseModels.memoryExtractionModel
           ),
           commitMessageModel: migratePhaseModelEntry(serverSettings.phaseModels.commitMessageModel),
+          titleGenerationModel: migratePhaseModelEntry(
+            serverSettings.phaseModels.titleGenerationModel
+          ),
           branchNameModel: migratePhaseModelEntry(serverSettings.phaseModels.branchNameModel),
           agentExecutionModel: migratePhaseModelEntry(
             serverSettings.phaseModels.agentExecutionModel

--- a/libs/types/src/agent-settings.ts
+++ b/libs/types/src/agent-settings.ts
@@ -193,6 +193,10 @@ export interface PhaseModelConfig {
   /** Model for generating git commit messages from diffs */
   commitMessageModel: PhaseModelEntry;
 
+  // Quick tasks - feature title generation
+  /** Model for generating a concise feature title from a description */
+  titleGenerationModel: PhaseModelEntry;
+
   // Quick tasks - branch name generation
   /** Model for generating git branch names from feature titles/descriptions */
   branchNameModel: PhaseModelEntry;
@@ -240,10 +244,10 @@ export type PhaseModelKey = Exclude<keyof PhaseModelConfig, 'flowModels'>;
  * of the box (the only key shipped on a fresh install).
  */
 export const DEFAULT_PHASE_MODELS: PhaseModelConfig = {
-  // Quick tasks — fast tier
+  // Quick tasks — nano tier (trivial one-shot micro-tasks)
   enhancementModel: { model: 'protolabs/smart' },
-  fileDescriptionModel: { model: 'protolabs/fast' },
-  imageDescriptionModel: { model: 'protolabs/fast' },
+  fileDescriptionModel: { model: 'protolabs/nano' },
+  imageDescriptionModel: { model: 'protolabs/nano' },
 
   // Validation — smart tier (accuracy matters)
   validationModel: { model: 'protolabs/smart' },
@@ -258,11 +262,14 @@ export const DEFAULT_PHASE_MODELS: PhaseModelConfig = {
   // Memory extraction — fast tier (cost-effective)
   memoryExtractionModel: { model: 'protolabs/fast' },
 
-  // Commit messages — fast tier
-  commitMessageModel: { model: 'protolabs/fast' },
+  // Commit messages — nano tier
+  commitMessageModel: { model: 'protolabs/nano' },
 
-  // Branch names — fast tier
-  branchNameModel: { model: 'protolabs/fast' },
+  // Feature titles — nano tier
+  titleGenerationModel: { model: 'protolabs/nano' },
+
+  // Branch names — nano tier
+  branchNameModel: { model: 'protolabs/nano' },
 
   // Agent execution — smart tier (reliable feature implementation)
   agentExecutionModel: { model: 'protolabs/smart' },


### PR DESCRIPTION
Per direction: switch the trivial one-shot **micro-tasks** to a cheaper **`protolabs/nano`** tier — done through the **phase-model settings system**, not hardcoded model strings.

## Changes
- **proto-provider**: register `protolabs/nano` (32k ctx / 4192 max out, basic tier, no tools/vision).
- **agent-settings**: new `titleGenerationModel` phase entry; defaults for the micro-task phases (`branchName`, `title`, `fileDescription`, `imageDescription`, `commitMessage`) → `protolabs/nano`. All remain user-overridable via **Settings → AI Models**.
- **branch-name-generator** + **generate-title**: resolve the model from `getPhaseModelWithOverrides(...)` + `resolvePhaseModel` — no hardcoded ids. (describe-file/image + commit-message already resolve via `phaseModels`, so they pick up nano from the new defaults automatically.)
- **training-capture**: extracted the fail-open capture helper into a shared service (#3859) and wired `feature-title` capture, so the micro-task corpus accrues for future distillation.
- **UI**: `titleGenerationModel` surfaced in the model-defaults / bulk-replace / settings-sync enumerations.

## Validation
- Full `npm run typecheck` clean (22/22); `training-capture.test.ts` (3) + updated branch-name-generator / settings-service assertions → green.

Advances #3859 (capture extension). The nano routing is settings-driven, addressing the "don't hardcode — we have a model settings system" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Feature Titles" as a configurable AI model phase in project and workspace settings.
  * Introduced nano-tier model support with protolabs/nano gateway model.

* **Improvements**
  * Feature title generation now dynamically selects from configured models instead of using a fixed default.
  * Updated default model tier configuration for improved efficiency across tasks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->