### PR TITLE
test(generate-title): cover phase-model resolution + fix stale comment

### DIFF
--- a/apps/server/src/routes/features/routes/generate-title.ts
+++ b/apps/server/src/routes/features/routes/generate-title.ts
@@ -65,13 +65,13 @@ export function createGenerateTitleHandler(
       const prompts = await getPromptCustomization(settingsService, '[GenerateTitle]');
       const systemPrompt = prompts.titleGeneration.systemPrompt;
 
-      // Get credentials for API calls (uses hardcoded haiku model, no phase setting)
-      const credentials = await settingsService?.getCredentials();
-
       const userPrompt = `Generate a concise title for this feature:\n\n${trimmedDescription}`;
 
-      // Model comes from the phase-model settings (Settings → AI Models →
-      // titleGenerationModel), not a hardcoded id — defaults to the nano tier.
+      // Resolve model via phase-model settings (titleGenerationModel) —
+      // defaults to protolabs/nano. Credentials are fetched alongside for the
+      // provider abstraction.
+      const credentials = await settingsService?.getCredentials();
+
       const { phaseModel } = await getPhaseModelWithOverrides(
         'titleGenerationModel',
         settingsService,

--- a/apps/server/tests/unit/routes/generate-title.test.ts
+++ b/apps/server/tests/unit/routes/generate-title.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for the generate-title route handler (#feature-1779913907802-36blk88h8).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: () => ({ info() {}, debug() {}, warn() {}, error() {} }),
+}));
+
+vi.mock('@protolabsai/model-resolver', () => ({
+  resolvePhaseModel: vi.fn((phaseModel) => phaseModel),
+}));
+
+const simpleQuery = vi.fn();
+vi.mock('../../../src/providers/simple-query-service.js', () => ({
+  simpleQuery: (...args: unknown[]) => simpleQuery(...args),
+}));
+
+const captureTrainingRow = vi.fn();
+vi.mock('../../../src/services/training-capture.js', () => ({
+  captureTrainingRow: (...args: unknown[]) => captureTrainingRow(...args),
+}));
+
+const getPromptCustomization = vi.fn();
+const getPhaseModelWithOverrides = vi.fn();
+vi.mock('../../../src/lib/settings-helpers.js', () => ({
+  getPromptCustomization: (...args: unknown[]) => getPromptCustomization(...args),
+  getPhaseModelWithOverrides: (...args: unknown[]) => getPhaseModelWithOverrides(...args),
+}));
+
+import { createGenerateTitleHandler } from '../../../src/routes/features/routes/generate-title.js';
+import { resolvePhaseModel } from '@protolabsai/model-resolver';
+
+// Mock settings service
+const mockSettingsService = {
+  getCredentials: vi.fn(),
+};
+
+describe('createGenerateTitleHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: phaseModel resolves to protolabs/nano
+    getPhaseModelWithOverrides.mockResolvedValue({
+      phaseModel: { model: 'protolabs/nano' },
+      isProjectOverride: false,
+    });
+
+    // resolvePhaseModel returns the phaseModel as-is (model: 'protolabs/nano')
+    vi.mocked(resolvePhaseModel).mockReturnValue({ model: 'protolabs/nano' });
+
+    // Default prompt customization
+    getPromptCustomization.mockResolvedValue({
+      titleGeneration: {
+        systemPrompt: 'You are a helpful assistant that generates concise titles.',
+      },
+    });
+
+    // Default credentials
+    mockSettingsService.getCredentials.mockResolvedValue({});
+  });
+
+  it('resolves model from getPhaseModelWithOverrides and passes to simpleQuery', async () => {
+    simpleQuery.mockResolvedValue({ text: 'Add user auth' });
+
+    const handler = createGenerateTitleHandler(mockSettingsService);
+    const req = { body: { description: 'Add user authentication' } };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await handler(req, res);
+
+    expect(getPhaseModelWithOverrides).toHaveBeenCalledWith(
+      'titleGenerationModel',
+      mockSettingsService,
+      undefined,
+      '[GenerateTitle]'
+    );
+    expect(simpleQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'protolabs/nano',
+      })
+    );
+  });
+
+  it('returns { success: true, title } with trimmed title from simpleQuery', async () => {
+    simpleQuery.mockResolvedValue({ text: '  Add User Auth  ' });
+
+    const handler = createGenerateTitleHandler(mockSettingsService);
+    const req = { body: { description: 'Add user authentication' } };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await handler(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      title: 'Add User Auth',
+    });
+  });
+
+  it('responds 400 with success: false on empty description', async () => {
+    const handler = createGenerateTitleHandler(mockSettingsService);
+    const req = { body: { description: '' } };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+  });
+
+  it('responds 400 with success: false on whitespace-only description', async () => {
+    const handler = createGenerateTitleHandler(mockSettingsService);
+    const req = { body: { description: '   ' } };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+  });
+
+  it('responds 400 when description is missing', async () => {
+    const handler = createGenerateTitleHandler(mockSettingsService);
+    const req = { body: {} };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await handler(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+  });
+});


### PR DESCRIPTION
Adds the missing unit test for the `generate-title` route (model resolves from `phaseModels.titleGenerationModel` → `simpleQuery`, default `protolabs/nano`; trimmed title on success; 400 on empty/whitespace/missing description) and fixes the stale "hardcoded haiku model" comment.

**Provenance:** produced by the auto-mode agent during a dogfood run (`feature-1779913907802-36blk88h8`). The EXECUTE phase failed to create the isolated worktree, so the agent edited `main` directly and never committed → feature blocked. The diff was verified (5 tests pass, typecheck clean) and salvaged here. The worktree-isolation failure is filed as a separate bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code organization improvements to the title generation functionality.

* **Tests**
  * Added comprehensive unit test coverage for the title generation feature, validating successful requests and proper error handling for edge cases including empty inputs, whitespace-only strings, and missing required parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3945?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->