### PR TITLE
fix(workflow): whole-word keyword matching so code features aren't downgraded to read-only (#3946)

### DIFF
--- a/apps/server/src/services/workflow-loader.ts
+++ b/apps/server/src/services/workflow-loader.ts
@@ -343,6 +343,18 @@ const BUILT_IN_WORKFLOWS = new Map<string, WorkflowDefinition>([
   ['signal', SIGNAL_WORKFLOW],
 ]);
 
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Whole-word (boundary-anchored) keyword match. Avoids substring false
+ * positives like "typecheck" matching the keyword "check" (#3946). Hyphens and
+ * spaces inside a keyword are treated literally; `\b` anchors the ends.
+ */
+function wordBoundaryMatch(haystack: string, keyword: string): boolean {
+  const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`\\b${escaped}\\b`, 'i').test(haystack);
+}
+
 // ─── Service ──────────────────────────────────────────────────────────────
 
 export class WorkflowLoader {
@@ -433,10 +445,13 @@ export class WorkflowLoader {
         }
       }
 
-      // Keyword matches in title/description
+      // Keyword matches in title/description — WHOLE WORD only. Substring
+      // matching falsely routed code features to read-only workflows (e.g.
+      // "typecheck" matched the audit keyword "check" → no-worktree run → block,
+      // #3946). Word boundaries keep "research" matching while "typecheck" does not.
       if (match.keywords) {
         for (const keyword of match.keywords) {
-          if (textToSearch.includes(keyword.toLowerCase())) {
+          if (wordBoundaryMatch(textToSearch, keyword.toLowerCase())) {
             score += 1;
           }
         }

--- a/apps/server/tests/unit/services/workflow-loader.test.ts
+++ b/apps/server/tests/unit/services/workflow-loader.test.ts
@@ -74,6 +74,22 @@ describe('WorkflowLoader', () => {
       expect(result.execution.useWorktrees).toBe(false);
     });
 
+    it('does NOT route a code feature to a read-only workflow on a substring keyword false-positive (#3946)', async () => {
+      // "typecheck" must not match the audit keyword "check"; a normal code
+      // feature with no real audit/research signal must stay on standard
+      // (worktree + commit + PR), not get silently downgraded to read-only.
+      const feature = createFeature({
+        category: 'test',
+        title: 'Add unit test for the title route + fix stale comment',
+        description: 'Add a unit test and ensure npm run typecheck is clean.',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('standard');
+      expect(result.execution.useWorktrees).toBe(true);
+    });
+
     it('explicit feature.workflow "standard" should override keyword match', async () => {
       const feature = createFeature({
         category: 'audit',


### PR DESCRIPTION
**Root cause of #3946** (found dogfooding). `WorkflowLoader.resolveForFeature` auto-matched keywords with **substring** matching, so a normal code feature whose description contained "type**check**" matched the `audit` workflow's keyword `check` and got routed to a read-only (no-worktree) workflow → agent ran in the main tree, no commits/PR → blocked.

**Fix:** whole-word (boundary-anchored) keyword matching. "research" in a title still matches; "typecheck" no longer matches "check". Regression test: a test/typecheck code feature resolves to `standard` (worktree + PR), not read-only.

19/19 workflow-loader tests pass; typecheck clean.

Addresses the primary cause of #3946. Secondary items remain tracked there (read-only → `done` completion semantics; CLI `feature create` `--execution-mode`/`--workflow` flags + the broken `--complexity` default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced keyword matching in workflow auto-assignment to recognize complete words only, eliminating false routing when keywords appear as substrings of larger words. For example, the keyword 'check' no longer incorrectly matches within 'typecheck', preventing workflows from being misassigned. Features are now accurately routed based on precise keyword detection with proper word boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->