### PR TITLE
Fix broken --complexity default in protomaker CLI feature create

### DIFF
--- a/packages/cli/src/feature.ts
+++ b/packages/cli/src/feature.ts
@@ -355,7 +355,7 @@ export function createCommand(parent: Command): void {
   cmd.requiredOption('--description <text>', 'Feature description');
   cmd.option('--title <text>', 'Feature title');
   cmd.option('--category <text>', 'Feature category', 'feature');
-  cmd.option('--complexity <level>', 'Complexity level', 'small|medium|large|architectural');
+  cmd.option('--complexity <level>', 'Complexity level (small|medium|large|architectural)');
   cmd.option('--priority <n>', 'Priority (1=urgent, 2=high, 3=normal, 4=low)');
   cmd.option('--epic-id <id>', 'Parent epic ID');
   cmd.option('--is-epic', 'Mark as epic container');
@@ -422,7 +422,7 @@ export function updateCommand(parent: Command): void {
   cmd.option('--title <text>', 'New title');
   cmd.option('--description <text>', 'New description');
   cmd.option('--category <text>', 'New category');
-  cmd.option('--complexity <level>', 'New complexity level', 'small|medium|large|architectural');
+  cmd.option('--complexity <level>', 'New complexity level (small|medium|large|architectural)');
   cmd.option('--priority <n>', 'New priority (1=urgent, 2=high, 3=normal, 4=low)');
 
   cmd.action(async (featureId: string, opts) => {


### PR DESCRIPTION
## Summary

In packages/cli/src/feature.ts, the 'create' command declares the complexity option as: cmd.option('--complexity <level>', 'Complexity level', 'small|medium|large|architectural'). The third argument to commander's .option() is the DEFAULT VALUE, so when --complexity is omitted the feature is created with the literal placeholder string 'small|medium|large|architectural' instead of a real complexity — an invalid value.

Fix: remove the bogus default so an omitted --complexity sends nothing (the se...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-77e4de6a team= created=2026-05-27T21:05:52.258Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help text for the `--complexity` option in feature commands to clearly display allowed values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->