### PR TITLE
fix(auto-mode): resume loops at saved concurrency after restart (#3949)

### DIFF
--- a/apps/server/src/server/startup.ts
+++ b/apps/server/src/server/startup.ts
@@ -305,7 +305,7 @@ export async function runStartup(
     // Candidate projects to inspect for persisted "was running" state: every
     // registered app plus any always-on project.
     const candidatePaths = [
-      ...settings.projects.map((p) => p.path),
+      ...(settings.projects?.map((p) => p.path) ?? []),
       ...(settings.autoModeAlwaysOn?.projects?.map((p) => p.projectPath) ?? []),
     ];
     const resumable = await autoModeService.listResumableLoops(candidatePaths);

--- a/apps/server/src/server/startup.ts
+++ b/apps/server/src/server/startup.ts
@@ -291,21 +291,73 @@ export async function runStartup(
     process.env.AUTO_MODE_STARTUP_DELAY_MS = crashDelayMs;
   }
 
-  // Auto-start auto-mode if enabled in settings
+  // Auto-start / auto-resume auto-mode. Two sources decide which loops run after boot:
+  //   1. Persisted execution state — any project whose loop was running at the last
+  //      shutdown (execution-state.json with autoLoopWasRunning) resumes at its SAVED
+  //      maxConcurrency. This delivers "set it and forget it": a deploy or crash
+  //      transparently resumes the crew at the configured concurrency (see #3949).
+  //   2. autoModeAlwaysOn config — projects explicitly configured to start on boot
+  //      even if they weren't running before (concurrency resolved from settings).
+  // Persisted-state entries win on overlap (they carry the configured concurrency).
   try {
     const settings = await settingsService.getGlobalSettings();
-    if (settings.autoModeAlwaysOn?.enabled && settings.autoModeAlwaysOn.projects.length > 0) {
-      logger.info(
-        `[AUTO-START] Auto-mode always-on enabled for ${settings.autoModeAlwaysOn.projects.length} project(s), starting auto-mode...`
-      );
 
-      // Start auto-mode for each configured project
+    // Candidate projects to inspect for persisted "was running" state: every
+    // registered app plus any always-on project.
+    const candidatePaths = [
+      ...settings.projects.map((p) => p.path),
+      ...(settings.autoModeAlwaysOn?.projects?.map((p) => p.projectPath) ?? []),
+    ];
+    const resumable = await autoModeService.listResumableLoops(candidatePaths);
+
+    // Unified start list, keyed per worktree. maxConcurrency === undefined means
+    // "resolve from settings" (always-on projects that weren't running before).
+    const keyOf = (projectPath: string, branchName: string | null): string =>
+      `${projectPath}::${branchName ?? '__main__'}`;
+    const targets = new Map<
+      string,
+      {
+        projectPath: string;
+        branchName: string | null;
+        maxConcurrency?: number;
+        reason: 'resume' | 'always-on';
+      }
+    >();
+
+    for (const loop of resumable) {
+      targets.set(keyOf(loop.projectPath, loop.branchName), {
+        projectPath: loop.projectPath,
+        branchName: loop.branchName,
+        maxConcurrency: loop.maxConcurrency,
+        reason: 'resume',
+      });
+    }
+
+    if (settings.autoModeAlwaysOn?.enabled) {
       for (const projectConfig of settings.autoModeAlwaysOn.projects) {
-        try {
-          const { projectPath, branchName } = projectConfig;
-          const worktreeDesc = branchName ? `worktree ${branchName}` : 'main worktree';
+        const branchName = projectConfig.branchName ?? null;
+        const key = keyOf(projectConfig.projectPath, branchName);
+        if (!targets.has(key)) {
+          targets.set(key, {
+            projectPath: projectConfig.projectPath,
+            branchName,
+            reason: 'always-on',
+          });
+        }
+      }
+    }
 
-          // Guard: skip auto-mode start if the project has no ready backlog features.
+    if (targets.size === 0) {
+      logger.info(
+        '[AUTO-START] No loops were running before restart and auto-mode always-on is off — nothing to start'
+      );
+    } else {
+      logger.info(`[AUTO-START] Resolving ${targets.size} auto-mode loop(s) to start...`);
+      for (const target of targets.values()) {
+        const { projectPath, branchName, maxConcurrency, reason } = target;
+        const worktreeDesc = branchName ? `worktree ${branchName}` : 'main worktree';
+        try {
+          // Guard: skip start if the project has no ready backlog features.
           // Starting loops for idle projects wastes memory and contributes to OOM on
           // restart when multiple apps are configured. The loop can be started later
           // when new work arrives via the normal start-auto-mode API call.
@@ -317,11 +369,15 @@ export async function runStartup(
             continue;
           }
 
-          logger.info(`[AUTO-START] Starting auto-mode for ${worktreeDesc} in ${projectPath}...`);
+          logger.info(
+            `[AUTO-START] Starting auto-mode (${reason}) for ${worktreeDesc} in ${projectPath}...`
+          );
 
           const resolvedMaxConcurrency = await autoModeService.startAutoLoopForProject(
             projectPath,
-            branchName ?? null
+            branchName,
+            false,
+            maxConcurrency
           );
 
           logger.info(
@@ -331,25 +387,14 @@ export async function runStartup(
           // If auto-mode is already running, that's OK (might have been restored from state)
           const errorMsg = err instanceof Error ? err.message : String(err);
           if (errorMsg.includes('already running')) {
-            logger.info(
-              `[AUTO-START] Auto-mode already running for ${projectConfig.projectPath}, skipping auto-start`
-            );
+            logger.info(`[AUTO-START] Auto-mode already running for ${projectPath}, skipping`);
           } else {
-            logger.error(
-              `[AUTO-START] Failed to start auto-mode for ${projectConfig.projectPath}:`,
-              err
-            );
+            logger.error(`[AUTO-START] Failed to start auto-mode for ${projectPath}:`, err);
           }
         }
       }
-    } else if (settings.autoModeAlwaysOn?.enabled) {
-      logger.info(
-        '[AUTO-START] Auto-mode always-on enabled but no projects configured, skipping auto-start'
-      );
-    } else {
-      logger.info('[AUTO-START] Auto-mode always-on disabled, skipping auto-start');
     }
   } catch (err) {
-    logger.warn('[AUTO-START] Failed to check auto-mode always-on setting:', err);
+    logger.warn('[AUTO-START] Failed to resolve auto-mode startup state:', err);
   }
 }

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -3703,19 +3703,36 @@ You can use the Read tool to view these images at any time during implementation
   // ============================================================================
 
   /**
-   * Save execution state to disk for recovery after server restart
+   * Refresh the persisted execution-state snapshot for a project after a feature
+   * finishes. This is a volatile-snapshot update only: it refreshes the running
+   * feature list and timestamp but MUST preserve the loop's configured
+   * `maxConcurrency`, `branchName`, and `autoLoopWasRunning` flag that
+   * {@link saveExecutionStateForProject} persisted at start. Previously this
+   * hardcoded `maxConcurrency` to the default (1) and `branchName` to null,
+   * which clobbered the real values on every completion — so restart resumed at
+   * the wrong concurrency (see #3949).
    */
   private async saveExecutionState(projectPath: string): Promise<void> {
     try {
       await ensureAutomakerDir(projectPath);
       const statePath = getExecutionStatePath(projectPath);
+      const runningFeatureIds = Array.from(this.runningFeatures.entries())
+        .filter(([, f]) => f.projectPath === projectPath)
+        .map(([id]) => id);
+
+      // Preserve the configured loop fields from the existing on-disk state.
+      // loadExecutionState() returns DEFAULT_EXECUTION_STATE (savedAt === '')
+      // when no file exists, which is our "no prior state" sentinel.
+      const existing = await this.loadExecutionState(projectPath);
+      const hasExisting = existing.savedAt !== '';
+
       const state: ExecutionState = {
         version: 1,
-        autoLoopWasRunning: this.autoLoopRunning,
-        maxConcurrency: DEFAULT_MAX_CONCURRENCY,
+        autoLoopWasRunning: hasExisting ? existing.autoLoopWasRunning : this.autoLoopRunning,
+        maxConcurrency: hasExisting ? existing.maxConcurrency : DEFAULT_MAX_CONCURRENCY,
         projectPath,
-        branchName: null, // Legacy global auto mode uses main worktree
-        runningFeatureIds: Array.from(this.runningFeatures.keys()),
+        branchName: hasExisting ? existing.branchName : null,
+        runningFeatureIds,
         savedAt: new Date().toISOString(),
       };
       await secureFs.writeFile(statePath, JSON.stringify(state, null, 2), 'utf-8');
@@ -3740,6 +3757,46 @@ You can use the Read tool to view these images at any time during implementation
       }
       return DEFAULT_EXECUTION_STATE;
     }
+  }
+
+  /**
+   * Inspect persisted execution state for the given candidate projects and
+   * return the auto-loops that were running at the last shutdown and should be
+   * resumed on boot.
+   *
+   * The "was running" signal is the presence of `execution-state.json` with
+   * `autoLoopWasRunning === true`. The file is written when a loop starts and
+   * deleted only on a clean auto-mode stop ({@link clearExecutionState}) — a
+   * graceful server shutdown does NOT delete it (see `shutdown()`), so any
+   * project running auto-mode at shutdown is correctly resumed across restarts.
+   *
+   * @param candidateProjectPaths - Project paths to inspect (deduped internally)
+   * @returns Loops to resume, each carrying its persisted `maxConcurrency` so
+   *   the configured concurrency is restored rather than reset to the default.
+   */
+  async listResumableLoops(
+    candidateProjectPaths: string[]
+  ): Promise<Array<{ projectPath: string; branchName: string | null; maxConcurrency: number }>> {
+    const resumable: Array<{
+      projectPath: string;
+      branchName: string | null;
+      maxConcurrency: number;
+    }> = [];
+    const seen = new Set<string>();
+    for (const projectPath of candidateProjectPaths) {
+      if (seen.has(projectPath)) continue;
+      seen.add(projectPath);
+      const state = await this.loadExecutionState(projectPath);
+      // savedAt === '' is the DEFAULT_EXECUTION_STATE sentinel for "no file".
+      if (state.savedAt !== '' && state.autoLoopWasRunning) {
+        resumable.push({
+          projectPath,
+          branchName: state.branchName,
+          maxConcurrency: state.maxConcurrency,
+        });
+      }
+    }
+    return resumable;
   }
 
   /**

--- a/apps/server/tests/unit/services/auto-mode-resume.test.ts
+++ b/apps/server/tests/unit/services/auto-mode-resume.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { ExecutionState } from '@protolabsai/types';
+
+// Keep platform real except for ensureAutomakerDir, which would mkdir on the real
+// filesystem. getExecutionStatePath stays real so spied reads/writes hit the same
+// path the service computes.
+vi.mock('@protolabsai/platform', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@protolabsai/platform')>();
+  return { ...actual, ensureAutomakerDir: vi.fn().mockResolvedValue(undefined) };
+});
+
+import { AutoModeService } from '@/services/auto-mode-service.js';
+import * as secureFs from '@/lib/secure-fs.js';
+import { getExecutionStatePath } from '@protolabsai/platform';
+
+const mockEvents = {
+  subscribe: vi.fn(),
+  emit: vi.fn(),
+  on: vi.fn().mockReturnValue({ unsubscribe: vi.fn() }),
+  setCorrelationContext: vi.fn(),
+  getCorrelationContext: vi.fn().mockReturnValue(undefined),
+  clearCorrelationContext: vi.fn(),
+};
+
+function makeState(overrides: Partial<ExecutionState>): ExecutionState {
+  return {
+    version: 1,
+    autoLoopWasRunning: true,
+    maxConcurrency: 8,
+    projectPath: '/proj',
+    branchName: null,
+    runningFeatureIds: [],
+    savedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function enoent(): NodeJS.ErrnoException {
+  const err = new Error('ENOENT: no such file') as NodeJS.ErrnoException;
+  err.code = 'ENOENT';
+  return err;
+}
+
+describe('auto-mode resume across restart (#3949)', () => {
+  let service: AutoModeService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEvents.on.mockReturnValue({ unsubscribe: vi.fn() });
+    service = new AutoModeService(mockEvents as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('listResumableLoops', () => {
+    it('resumes loops that were running, carrying the saved maxConcurrency', async () => {
+      const running = '/proj/running';
+      const branchRunning = '/proj/branch-running';
+      const stopped = '/proj/stopped';
+      const missing = '/proj/missing';
+
+      vi.spyOn(secureFs, 'readFile').mockImplementation(async (p: unknown) => {
+        if (p === getExecutionStatePath(running)) {
+          return JSON.stringify(makeState({ projectPath: running, maxConcurrency: 8 }));
+        }
+        if (p === getExecutionStatePath(branchRunning)) {
+          return JSON.stringify(
+            makeState({ projectPath: branchRunning, branchName: 'feature/x', maxConcurrency: 3 })
+          );
+        }
+        if (p === getExecutionStatePath(stopped)) {
+          // File present but loop was not running (e.g. cleanly stopped state shape).
+          return JSON.stringify(
+            makeState({ projectPath: stopped, autoLoopWasRunning: false, maxConcurrency: 5 })
+          );
+        }
+        throw enoent();
+      });
+
+      const result = await service.listResumableLoops([running, branchRunning, stopped, missing]);
+
+      expect(result).toEqual([
+        { projectPath: running, branchName: null, maxConcurrency: 8 },
+        { projectPath: branchRunning, branchName: 'feature/x', maxConcurrency: 3 },
+      ]);
+    });
+
+    it('dedupes repeated candidate paths and ignores missing state files', async () => {
+      const running = '/proj/running';
+      const readSpy = vi.spyOn(secureFs, 'readFile').mockImplementation(async (p: unknown) => {
+        if (p === getExecutionStatePath(running)) {
+          return JSON.stringify(makeState({ projectPath: running, maxConcurrency: 4 }));
+        }
+        throw enoent();
+      });
+
+      const result = await service.listResumableLoops([running, running, '/proj/none']);
+
+      expect(result).toEqual([{ projectPath: running, branchName: null, maxConcurrency: 4 }]);
+      // Deduped: the repeated path is read at most once.
+      expect(readSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns nothing when no project has persisted state', async () => {
+      vi.spyOn(secureFs, 'readFile').mockRejectedValue(enoent());
+      const result = await service.listResumableLoops(['/a', '/b']);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('saveExecutionState snapshot refresh', () => {
+    it('preserves configured maxConcurrency, branchName, and running flag from disk', async () => {
+      const projectPath = '/proj/keep';
+      const existing = makeState({
+        projectPath,
+        branchName: 'feature/keep',
+        maxConcurrency: 8,
+        autoLoopWasRunning: true,
+        runningFeatureIds: ['old'],
+        savedAt: '2026-01-01T00:00:00.000Z',
+      });
+
+      vi.spyOn(secureFs, 'readFile').mockResolvedValue(JSON.stringify(existing) as never);
+      const writeSpy = vi.spyOn(secureFs, 'writeFile').mockResolvedValue(undefined as never);
+
+      // Private snapshot-refresh hook invoked via the post-execution callback path.
+      await (
+        service as unknown as { saveExecutionState(p: string): Promise<void> }
+      ).saveExecutionState(projectPath);
+
+      expect(writeSpy).toHaveBeenCalledTimes(1);
+      const written = JSON.parse(writeSpy.mock.calls[0][1] as string) as ExecutionState;
+      expect(written.maxConcurrency).toBe(8);
+      expect(written.branchName).toBe('feature/keep');
+      expect(written.autoLoopWasRunning).toBe(true);
+      // The volatile timestamp is refreshed, not preserved.
+      expect(written.savedAt).not.toBe(existing.savedAt);
+    });
+
+    it('falls back to defaults when no prior state file exists', async () => {
+      vi.spyOn(secureFs, 'readFile').mockRejectedValue(enoent());
+      const writeSpy = vi.spyOn(secureFs, 'writeFile').mockResolvedValue(undefined as never);
+
+      await (
+        service as unknown as { saveExecutionState(p: string): Promise<void> }
+      ).saveExecutionState('/proj/fresh');
+
+      const written = JSON.parse(writeSpy.mock.calls[0][1] as string) as ExecutionState;
+      expect(written.branchName).toBeNull();
+      expect(written.maxConcurrency).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/docs/reference/auto-mode.md
+++ b/docs/reference/auto-mode.md
@@ -179,6 +179,14 @@ interface ExecutionState {
 
 Call `resumeInterruptedFeatures(projectPath)` on startup to re-queue any `in-progress` features that survived a crash.
 
+### Loop resume on restart
+
+`execution-state.json` is written when a loop starts and deleted only on a clean auto-mode **stop** (`stopAutoLoopForProject`). A graceful server shutdown does **not** delete it, so the file's presence with `autoLoopWasRunning: true` is the "was running at shutdown" signal.
+
+On boot, `listResumableLoops(candidateProjectPaths)` inspects every registered app (plus any `autoModeAlwaysOn` project) and resumes each loop that was running — at its **saved `maxConcurrency`**, not the default. This makes a deploy or crash transparent: the crew resumes at the configured concurrency without manual re-start. `autoModeAlwaysOn` still force-starts its configured projects even if they weren't running before; the idle-project guard (`hasReadyBacklogFeatures`) applies to both paths.
+
+The post-execution snapshot refresh preserves the loop's configured `maxConcurrency` / `branchName` from disk — it only updates the volatile running-feature list, so the configured concurrency is never reset to the default mid-run.
+
 ## Multi-Project Support
 
 Auto-loops are keyed by `projectPath::branchName`. Multiple projects can run loops simultaneously. The key function:


### PR DESCRIPTION
## Problem

Fixes #3949. Found dogfooding: auto-mode was running (`maxConcurrency: 8`), the server was restarted to pick up a code change, and afterward `GET /api/auto-mode/status` reported `isRunning: false, maxConcurrency: 1`. A backlog feature then sat unprocessed indefinitely — the autonomous crew was silently off. This breaks the core "set it and forget it" promise: every prod deploy restarts the server and silently halts the crew.

## Root cause (two bugs)

1. **`maxConcurrency` reset to 1.** The legacy post-execution snapshot refresh `saveExecutionState()` runs after *every* feature completion (wired via the execution-service / post-execution-middleware callbacks). It overwrote `execution-state.json` with a **hardcoded `maxConcurrency: DEFAULT_MAX_CONCURRENCY` (1)** and `branchName: null` (and `autoLoopWasRunning` from the dead legacy global flag), clobbering the correct values `saveExecutionStateForProject()` persisted at loop start.

2. **Running-state not restored.** Graceful `shutdown()` stops loops in memory but does **not** delete `execution-state.json` (it's deleted only on a clean auto-mode *stop*). So the file — with `autoLoopWasRunning: true` and the saved `maxConcurrency` — survives any restart and is a ready-made "was running" signal. But nothing on boot read it to restart the loop; only `autoModeAlwaysOn`-configured projects restarted, and even those passed no `maxConcurrency` override (→ resolved to 1).

## Fix

- **`saveExecutionState()`** now preserves the configured `maxConcurrency`, `branchName`, and `autoLoopWasRunning` from the existing on-disk state and only refreshes the volatile running-feature list + timestamp. The configured concurrency is never reset mid-run.
- **`AutoModeService.listResumableLoops(candidateProjectPaths)`** (new) inspects persisted state and returns the loops that were running, each carrying its saved `maxConcurrency`.
- **Startup** (`server/startup.ts`) now resumes every registered app (`settings.projects`) plus any always-on project that was running at shutdown — at its **saved** concurrency — unified with the existing `autoModeAlwaysOn` force-start. The idle-project guard (`hasReadyBacklogFeatures`) still applies, so idle projects don't wake on boot (OOM protection).

Behavior chosen per maintainer decision: **auto-resume if it was running** (vs. gating on `autoModeAlwaysOn` only).

## Acceptance (from #3949)

- [x] Auto-mode running-state + maxConcurrency persist across restart.
- [x] On restart, the configured maxConcurrency is restored (not reset to 1).

## Tests

New isolated suite `auto-mode-resume.test.ts` (5 tests): resume selection carries saved concurrency, dedupes candidates, ignores missing state, and the snapshot refresh preserves configured fields / falls back to defaults when no prior file exists. Full `typecheck` + existing `auto-mode-service` suite (26) green.

## Docs

`docs/reference/auto-mode.md` → new "Loop resume on restart" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-mode now inspects persisted state and configured always-on projects on boot to resume previously running loops, preserving configured concurrency and branch settings.
  * Backlog check prevents idle projects from being started unnecessarily.

* **Bug Fixes / Reliability**
  * Improved startup handling and logging for already-running loops and start failures.

* **Tests**
  * Added unit tests covering resumable-loop discovery and execution-state snapshot behavior.

* **Documentation**
  * Clarified execution-state persistence and resumption behavior across shutdowns and restarts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->