### PR TITLE
fix(pipeline): read-only features complete at done, not blocked; CLI execution-mode/workflow flags (#3946)

### DIFF
--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -924,6 +924,29 @@ export class ExecuteProcessor implements StateProcessor {
       }
     }
 
+    // ── Read-only / audit short-circuit ──────────────────────────────────────
+    // Read-only features (audit, research, postmortem, …) run against the main
+    // tree with no worktree and no git ops, so by design they produce no commits
+    // and no PR. The PR/commits guard below would wrongly block them with
+    // "no commits ahead of base"; instead they terminate at `done` (#3946).
+    // Returning DONE lets the state machine stop cleanly (REVIEW/MERGE are
+    // disabled for these workflows anyway — see resolveNextState skipping).
+    if (ctx.feature.executionMode === 'read-only') {
+      logger.info('[EXECUTE] Read-only feature completed — no PR expected, moving to done', {
+        featureId: ctx.feature.id,
+      });
+      await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+        status: 'done',
+        completedAt: new Date().toISOString(),
+        statusChangeReason: 'Read-only execution completed — no PR expected for read-only mode',
+      });
+      return {
+        nextState: 'DONE',
+        shouldContinue: false,
+        reason: 'Read-only execution completed',
+      };
+    }
+
     // ── Guard: require a PR and commits before transitioning to REVIEW ────────
     // Without this guard, an agent that hard-fails on turn 1 (e.g. 401 from the
     // model gateway) can still reach REVIEW with no PR and no commits — leaving

--- a/apps/server/tests/unit/services/lead-engineer-execute-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-execute-processor.test.ts
@@ -585,4 +585,42 @@ describe('ExecuteProcessor — EXECUTE→REVIEW guard (no PR or no commits)', ()
     expect(result.shouldContinue).toBe(true);
     expect(result.reason).toMatch(/Execution completed, moving to review/i);
   });
+
+  it('completes a read-only feature at done instead of blocking on no-PR (#3946)', async () => {
+    // Read-only / audit features run against the main tree with no git ops, so
+    // they produce no PR and no commits by design. The no-PR guard must NOT
+    // block them — they terminate at `done`.
+    const { ctx, featureLoader } = makeServiceContext({
+      maxCostUsdPerFeature: 100,
+    });
+
+    const readOnlyFeature = makeFeature({
+      costUsd: 1,
+      prNumber: undefined,
+      executionMode: 'read-only',
+    });
+    (featureLoader.get as ReturnType<typeof vi.fn>).mockResolvedValue(readOnlyFeature);
+
+    const processor = new ExecuteProcessor(ctx);
+    const stateCtx = makeCtx({ feature: readOnlyFeature, prNumber: undefined });
+    const result = await processor.process(stateCtx);
+
+    expect(result.nextState).toBe('DONE');
+    expect(result.shouldContinue).toBe(false);
+
+    // Marked done — never blocked.
+    expect(featureLoader.update).toHaveBeenCalledWith(
+      '/test/project',
+      'feat-001',
+      expect.objectContaining({
+        status: 'done',
+        statusChangeReason: expect.stringMatching(/read-only execution completed/i),
+      })
+    );
+    expect(featureLoader.update).not.toHaveBeenCalledWith(
+      '/test/project',
+      'feat-001',
+      expect.objectContaining({ status: 'blocked' })
+    );
+  });
 });

--- a/handoffs/001-backlog-triage-cli-beads-ava.md
+++ b/handoffs/001-backlog-triage-cli-beads-ava.md
@@ -1,0 +1,90 @@
+# Handoff: Sprint close-out + backlog triage (CLI fixes, beads UI init, Ava CLI fallback)
+
+**Date**: 2026-05-27
+**Handoff Number**: 001
+
+---
+
+## Overview/Summary
+
+This session drove the entire `protomaker-*` beads board to **done** (both harness-eval sprints + operator tooling), then worked the GitHub issue backlog: closed everything already-resolved, and shipped fixes for the clean, well-scoped items. The beads board is now empty (0 open / 0 in-progress). 14 GitHub issues remain open — all genuine backlog that is either larger feature work or needs a product/infra decision (none are stale).
+
+Net this session: **6 fix/feature PRs merged** + the prior sprint PRs, **12 issues closed**, **3 follow-ups filed**, board cleared.
+
+## Background/Context
+
+- Triggered by validating the `/cli-control` skill (bead `3do`) after a Claude restart made the plugin MCP live. Exercising the CLI surfaced five real bugs that made most of the `protomaker` CLI unusable — fixed in #3924.
+- The user then asked to triage and close out the GitHub backlog "as needed," and finally whether the Ava persona knew about the CLI skill (it didn't — fixed in #3932).
+- Standing constraints (still apply): never push to `main` directly (PR only); never use `--admin`/`--auto`; never `cd` into worktrees (use `git -C`/absolute paths); do not start/stop the dev server (the `ai.protolabs.protomaker` LaunchAgent is the exception and auto-reloads); no Anthropic keys — gateway only; no emojis except ✅/❌; verify `gh pr create` returns an `https://` URL before closing a bead/issue.
+- PR merge pattern used all session: background gh-only watcher polling `mergeStateStatus`, squash-merge on `CLEAN`/`UNSTABLE`. Never merge on pending/failing CI.
+
+## Current State
+
+Completed (merged to `main`):
+
+- [x] **Harness-eval program** — both sprints (substrate, eval gate, verifier gate, run-telemetry, failure-taxonomy → proposer → eval-gated auto-improve flywheel). PRs #3908/#3913–#3919.
+- [x] **CLAUDE.md decomposition** (#3920) + **best-of-N spike** (#3922) + **operator runbook** (#3921).
+- [x] **CLI repair (#3924)** — 5 bugs: positional-arg commands unreachable (`new Command('x <a>')` doesn't parse args in Commander v14 → use `.arguments()`), `feature` group never registered, stale `(program, flags)` signatures, global flags read from local opts (→ `optsWithGlobals()`), `feature list` missing `projectPath`. + `feature-wiring.test.ts`.
+- [x] **Beads UI init (#3927, bead `gyd`)** — `BeadsService.status()`/`.init()`, `POST /api/beads/{status,init}`, UI "Initialize beads" empty state. `br` errors land on **stderr** (key detail).
+- [x] **Cleanup (#3930)** — pruned dead content-tool refs from cindi/jon `allowed-tools` (#3912); deleted orphaned `create-protolab/templates/cicd/github-actions/` (#3898).
+- [x] **Sitrep staging-delta (#3931)** — settings-driven `stagingDeltaBranches` + ref-existence guard + `applicable` flag; new `ResolvedGitWorkflowSettings` type; git-settings docs (#3874).
+- [x] **Ava CLI fallback (#3932)** — taught the `ava.md` plugin skill to fall back to `/cli-control` when MCP is down (NOT the UI-chat persona — it has no shell).
+
+Remaining (open GitHub issues — see table below):
+
+- [ ] 14 open issues; **#3803** is the next clean autonomous bug-fix.
+
+## Technical Approach
+
+- **Greenfield-first** (per CLAUDE.md): no compat shims; delete dead code; touch all consumers when changing a type (e.g. `ResolvedGitWorkflowSettings` propagated to DEFAULT, the resolver, and both UI settings panels).
+- **Platform-first**: no hardcoded workflow values — the staging-delta branch pair became the optional `GitWorkflowSettings.stagingDeltaBranches` setting (unset = not tracked, the single-main default).
+- **Test pattern for shelling-out services**: mock `node:child_process` with the `promisify.custom` symbol (see `tests/unit/lib/gh-pr-create.test.ts`). For sequenced calls, use ordered `mockImplementationOnce` and DON'T read `args` inside a persistent `mockImplementation` (a rejection triggers a spurious 2nd call with `undefined` args — burned ~20 min on this).
+- **`br` (beads) behavior**: structured `{error:{code}}` JSON (`NOT_INITIALIZED`, `ALREADY_INITIALIZED`) goes to **stderr**, exit 2 — even with `--json`. `br` auto-discovers `.beads/` by walking up parent dirs (so status detection on a nested dir finds the parent store).
+- **Doc-as-you-build**: new settings documented in `docs/reference/git-settings.md`; CLAUDE.md beads section notes the new endpoints.
+
+## Key Files and Documentation
+
+| File                                                                                   | Purpose                                                               |
+| -------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `packages/cli/src/cli.ts`, `feature.ts`, `agent.ts`, `pr.ts`, `queue.ts`, `context.ts` | CLI command wiring + `optsWithGlobals()` fix (#3924)                  |
+| `packages/cli/test/feature-wiring.test.ts`                                             | CLI wiring/flag regression test                                       |
+| `apps/server/src/services/beads-service.ts`                                            | `status()`/`init()` + `runAllowFail()`/`errorCode()`                  |
+| `apps/server/src/routes/beads/index.ts`                                                | `/status`, `/init` routes                                             |
+| `apps/ui/src/components/views/beads-view/beads-view.tsx`                               | "Initialize beads" empty state                                        |
+| `apps/server/src/routes/sitrep/index.ts`                                               | `getStagingDelta()` settings-driven + `resolveStagingDeltaBranches()` |
+| `libs/types/src/git-settings.ts`                                                       | `stagingDeltaBranches`, `ResolvedGitWorkflowSettings`                 |
+| `packages/mcp-server/plugins/automaker/commands/ava.md`                                | Ava `/cli-control` fallback section                                   |
+| `docs/reference/git-settings.md`                                                       | git settings reference (updated)                                      |
+| `docs/internal/dev/best-of-n-spike.md`                                                 | best-of-N spike (recommendation: Option A, PLAN sampling)             |
+
+## Acceptance Criteria
+
+This handoff's scope (sprint close-out + clean backlog) is **complete**:
+
+- [x] All `protomaker-*` beads closed; board empty
+- [x] All already-resolved GitHub issues closed with references
+- [x] All clean/well-scoped issues fixed, tested, merged
+- [x] Remaining issues are genuine open work (not stale), triaged below
+
+## Open Questions/Considerations
+
+- **#3798 / #3801 (review gating)** need a **branch-protection ruleset decision** (required approving reviews / `required_conversation_resolution` on `main`). Can't be fully fixed in code alone — partly a GitHub admin action.
+- **#3893 (per-project FS isolation)** is a security design task + a prod-env change (`ALLOWED_ROOT_DIRECTORY` unset in prod). Needs scoping with the owner.
+- **#3815 / #3819 (fleet CI security)** are cross-repo / fleet-wide rollouts.
+- Quinn-related issues (#3900) are cross-repo behavior tuning (Quinn's handler lives in protoWorkstacean).
+- Follow-ups filed this session: **#3929** (jon.md body still uses removed content tools — needs a product call on jon's content path), **#3925** (extend CLI wiring tests to all groups), **#3923** (implement best-of-N PLAN from the spike).
+
+## Next Steps
+
+1. **#3803 — Epic blocks on completion when children PR to main directly** (next clean autonomous fix). `CompletionDetectorService` opens an epic→base PR from the epic branch, which is 0 commits ahead when children merged to `main` directly → epic flips to `blocked`. Fix: detect the empty-epic-branch case and mark the epic `done` (children already merged) instead of attempting a PR. Self-contained in the server; add a unit test.
+2. Decide the **review-gating** direction (#3798/#3801): enable the rulesets + build the REVIEW-phase thread-resolution loop, or defer.
+3. Triage the feature requests (#3865 ACP, #3791 Ava file tool, #3794 haiku branch names, #3859 distillation) into beads when prioritized.
+4. Address **#3929** (jon.md content workflow) once the content-pipeline replacement path is decided.
+
+### Reproduce the board/PR state
+
+```bash
+RUST_LOG=error br list --json            # 0 open / 0 in-progress
+gh issue list --repo protoLabsAI/protoMaker --state open   # 14, all genuine backlog
+gh pr list --repo protoLabsAI/protoMaker --author "@me" --state open   # none
+```

--- a/packages/cli/src/feature.ts
+++ b/packages/cli/src/feature.ts
@@ -359,6 +359,8 @@ export function createCommand(parent: Command): void {
   cmd.option('--priority <n>', 'Priority (1=urgent, 2=high, 3=normal, 4=low)');
   cmd.option('--epic-id <id>', 'Parent epic ID');
   cmd.option('--is-epic', 'Mark as epic container');
+  cmd.option('--execution-mode <mode>', 'Execution mode (standard|read-only)');
+  cmd.option('--workflow <name>', 'Workflow name (e.g. standard, audit, research, postmortem)');
 
   cmd.action(async (opts) => {
     const flags = getGlobalFlags(cmd.optsWithGlobals());
@@ -380,6 +382,13 @@ export function createCommand(parent: Command): void {
     }
     if (opts.epicId) feature.epicId = opts.epicId;
     if (opts.isEpic) feature.isEpic = true;
+    if (opts.executionMode) {
+      if (!['standard', 'read-only'].includes(opts.executionMode)) {
+        usageError("Execution mode must be 'standard' or 'read-only'");
+      }
+      feature.executionMode = opts.executionMode;
+    }
+    if (opts.workflow) feature.workflow = opts.workflow;
 
     const result = await client.post<CreateResponse>('/features/create', {
       projectPath: flags.project,

--- a/packages/cli/test/cli-wiring.test.ts
+++ b/packages/cli/test/cli-wiring.test.ts
@@ -33,6 +33,7 @@ beforeEach(() => {
         JSON.stringify({
           success: true,
           features: [],
+          feature: { id: 'feat-created' },
           issues: [],
           files: [],
           runningFeatures: [],
@@ -103,5 +104,30 @@ describe('global flag propagation (--project / --json) reaches the request body'
     ]);
     expect(lastBody, `${_label} made no request`).toBeDefined();
     expect(lastBody!.projectPath).toBe('/custom/project');
+  });
+});
+
+describe('feature create maps --execution-mode / --workflow into the payload (#3946)', () => {
+  it('sends executionMode and workflow on the created feature', async () => {
+    await buildProgram().parseAsync([
+      'node',
+      'protomaker',
+      '--project',
+      '/custom/project',
+      '--json',
+      'feature',
+      'create',
+      '--description',
+      'Audit the auth module',
+      '--execution-mode',
+      'read-only',
+      '--workflow',
+      'audit',
+    ]);
+    expect(lastUrl).toMatch(/\/features\/create$/);
+    expect(lastBody!.projectPath).toBe('/custom/project');
+    const feature = lastBody!.feature as Record<string, unknown>;
+    expect(feature.executionMode).toBe('read-only');
+    expect(feature.workflow).toBe('audit');
   });
 });


### PR DESCRIPTION
## Problem

Part 2 of #3946. (Part 1 — the keyword-match downgrade that wrongly set `executionMode: read-only` — was fixed in #3947; the broken `--complexity` default in #3950.)

A read-only / audit feature runs the agent against the **main tree with no worktree and no git ops** — so by design it produces **no commits and no PR**. But the EXECUTE→REVIEW guard blocks any feature with "no PR created, no commits ahead of base". Result: a read-only feature whose agent did its work correctly ended up **`blocked`** with nowhere for the work to go.

## Fix

**1. Read-only short-circuit in `ExecuteProcessor`** (`lead-engineer-execute-processor.ts`): before the PR/commits guard, if `feature.executionMode === 'read-only'`, mark the feature `done` and return `nextState: 'DONE'`. REVIEW/MERGE are disabled for read-only workflows anyway, so the state machine's `resolveNextState` would skip to DONE regardless — but terminating explicitly is robust and mirrors the existing blocked-path pattern of setting status directly. This covers both audit-style workflows (which set `executionMode` via `useWorktrees: false`) and features created directly with `executionMode: 'read-only'`.

**2. CLI flags** (`packages/cli/src/feature.ts`): `protomaker feature create` gains `--execution-mode <standard|read-only>` (validated) and `--workflow <name>`, mapped into the create payload (acceptance item 3).

## Acceptance (from #3946)

- [x] A code feature created without an explicit executionMode runs `standard` — fixed in #3947.
- [x] Read-only/audit features terminate at `done`, not `blocked`, when they produce no PR.
- [x] `feature create` CLI gains `--execution-mode`/`--workflow` and a correct `--complexity` default (default fixed in #3950).

## Tests

- `lead-engineer-execute-processor.test.ts`: read-only feature completes at `done` (not blocked) in the no-PR guard suite (17 tests pass).
- `cli-wiring.test.ts`: asserts `--execution-mode` / `--workflow` reach the `/features/create` payload (49 CLI tests pass).
- Full `typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `feature create` command now supports `--execution-mode` (standard or read-only) and `--workflow` options for enhanced feature configuration.

* **Bug Fixes**
  * Read-only features now automatically transition to completion without requiring pull requests.

* **Tests**
  * Added verification for read-only feature handling and CLI option mapping.

* **Documentation**
  * Updated sprint closeout and backlog triage documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->