### PR TITLE
feat(settings): persist ProjectRef github/defaultBranch at setup (#3948)

### DIFF
--- a/apps/server/src/routes/settings/routes/enrich-projects.ts
+++ b/apps/server/src/routes/settings/routes/enrich-projects.ts
@@ -31,36 +31,50 @@ export async function resolveDefaultBranch(projectPath: string): Promise<string 
 }
 
 /**
- * Enrich a list of ProjectRef entries with github owner/repo and defaultBranch.
- * Each project is enriched independently — failures on one project don't affect others.
- * Within each project, github and defaultBranch are resolved in parallel.
+ * Backfill `github` owner/repo and `defaultBranch` onto ProjectRef entries that
+ * are missing them. This is a fallback/refresh path only — the source of truth is
+ * the values persisted at project setup (see setup/routes/project.ts). A project
+ * that already carries BOTH fields is returned untouched, so it incurs no `.git`
+ * inspection and its values survive even when the project repo is not on disk
+ * (the mount-drop goal in #3948).
+ *
+ * Each project is backfilled independently — failures on one don't affect others.
  */
 export async function enrichProjects(projects: ProjectRef[]): Promise<ProjectRef[]> {
   return Promise.all(
     projects.map(async (project) => {
-      const enriched = { ...project };
-
-      // Resolve github owner/repo (best-effort)
-      try {
-        const remoteStatus = await checkGitHubRemote(project.path);
-        if (remoteStatus.owner && remoteStatus.repo) {
-          enriched.github = {
-            owner: remoteStatus.owner,
-            repo: remoteStatus.repo,
-          };
-        }
-      } catch {
-        // Omit github on failure
+      // Already persisted — serve as-is, no git inspection.
+      if (project.github && project.defaultBranch) {
+        return project;
       }
 
-      // Resolve defaultBranch (best-effort)
-      try {
-        const defaultBranch = await resolveDefaultBranch(project.path);
-        if (defaultBranch) {
-          enriched.defaultBranch = defaultBranch;
+      const enriched = { ...project };
+
+      // Resolve github owner/repo (best-effort) only if missing.
+      if (!enriched.github) {
+        try {
+          const remoteStatus = await checkGitHubRemote(project.path);
+          if (remoteStatus.owner && remoteStatus.repo) {
+            enriched.github = {
+              owner: remoteStatus.owner,
+              repo: remoteStatus.repo,
+            };
+          }
+        } catch {
+          // Omit github on failure
         }
-      } catch {
-        // Omit defaultBranch on failure
+      }
+
+      // Resolve defaultBranch (best-effort) only if missing.
+      if (!enriched.defaultBranch) {
+        try {
+          const defaultBranch = await resolveDefaultBranch(project.path);
+          if (defaultBranch) {
+            enriched.defaultBranch = defaultBranch;
+          }
+        } catch {
+          // Omit defaultBranch on failure
+        }
       }
 
       return enriched;

--- a/apps/server/src/routes/settings/routes/get-global.ts
+++ b/apps/server/src/routes/settings/routes/get-global.ts
@@ -23,9 +23,29 @@ export function createGetGlobalHandler(settingsService: SettingsService) {
     try {
       const settings = await settingsService.getGlobalSettings();
 
-      // Enrich projects[] with github owner/repo and defaultBranch (best-effort)
+      // Serve persisted github/defaultBranch directly. enrichProjects only backfills
+      // entries still missing them (projects added before they were persisted at
+      // setup). When it does backfill, persist the result once so future reads —
+      // and a dropped source mount (#3948) — serve the values without `.git`.
       if (settings.projects && settings.projects.length > 0) {
-        settings.projects = await enrichProjects(settings.projects);
+        const original = settings.projects;
+        const enriched = await enrichProjects(original);
+        settings.projects = enriched;
+
+        const backfilled = enriched.some((p, i) => {
+          const before = original[i];
+          return (
+            p.github?.owner !== before.github?.owner ||
+            p.github?.repo !== before.github?.repo ||
+            p.defaultBranch !== before.defaultBranch
+          );
+        });
+        if (backfilled) {
+          // One-time lazy migration. Best-effort: a write failure must not fail the read.
+          await settingsService
+            .updateGlobalSettings({ projects: enriched })
+            .catch((err) => logError(err, 'Failed to persist backfilled project github metadata'));
+        }
       }
 
       res.json({

--- a/apps/server/src/routes/setup/routes/project.ts
+++ b/apps/server/src/routes/setup/routes/project.ts
@@ -10,6 +10,7 @@ import { SettingsService } from '../../../services/settings-service.js';
 import type { RepoResearchResult, ProjectSettings } from '@protolabsai/types';
 import { DEFAULT_GIT_WORKFLOW_SETTINGS } from '@protolabsai/types';
 import { generateSpecMd, researchRepo } from '../../../services/repo-research-service.js';
+import { checkGitHubRemote } from '../../github/routes/check-github-remote.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -232,9 +233,9 @@ export function createSetupProjectHandler(
       // 4. Detect and persist the repo's default branch as prBaseBranch.
       //    Resolution: research.git.defaultBranch → git symbolic-ref → skip (auto-detect at runtime).
       //    This ensures feature PRs target the correct branch for this project, not the global default.
+      //    detectedBranch is hoisted so step 5 can persist it onto the ProjectRef (#3948).
+      let detectedBranch: string | undefined = research?.git?.defaultBranch;
       try {
-        let detectedBranch: string | undefined = research?.git?.defaultBranch;
-
         if (!detectedBranch) {
           try {
             const { stdout } = await execFileAsync(
@@ -274,10 +275,25 @@ export function createSetupProjectHandler(
         // Non-fatal — runtime auto-detect in getEffectivePrBaseBranch will still work
       }
 
-      // 5. Add project to Automaker settings if not already present
+      // 5. Add project to Automaker settings if not already present.
+      //    Persist github owner/repo + defaultBranch onto the ProjectRef now (#3948)
+      //    so GET /api/settings/global serves them without inspecting `.git` — and the
+      //    source mount can later be dropped without losing the fields. enrich-projects
+      //    is only a backfill for projects added before this was persisted.
       let projectAdded = false;
 
       try {
+        // Resolve github owner/repo (best-effort — omitted on failure).
+        let github: { owner: string; repo: string } | undefined;
+        try {
+          const remoteStatus = await checkGitHubRemote(realPath);
+          if (remoteStatus.owner && remoteStatus.repo) {
+            github = { owner: remoteStatus.owner, repo: remoteStatus.repo };
+          }
+        } catch {
+          // Omit github on failure
+        }
+
         // Check if project already exists
         const existingSettings = await settingsService.getGlobalSettings();
         const projectExists = existingSettings.projects?.some((p) => p.path === realPath);
@@ -292,11 +308,17 @@ export function createSetupProjectHandler(
                 path: realPath,
                 name: projectName,
                 lastOpened: new Date().toISOString(),
+                ...(github ? { github } : {}),
+                ...(detectedBranch ? { defaultBranch: detectedBranch } : {}),
               },
             ],
           });
           projectAdded = true;
-          logger.info('Added project to settings', { projectPath: realPath });
+          logger.info('Added project to settings', {
+            projectPath: realPath,
+            github,
+            defaultBranch: detectedBranch,
+          });
         } else {
           logger.info('Project already exists in settings', { projectPath: realPath });
         }

--- a/apps/server/tests/unit/routes/get-global-enrichment.test.ts
+++ b/apps/server/tests/unit/routes/get-global-enrichment.test.ts
@@ -147,6 +147,36 @@ describe('enrichProjects()', () => {
     expect(result).toEqual([]);
   });
 
+  it('serves a fully-persisted project untouched, with no git inspection (#3948)', async () => {
+    // No mock results are queued. If enrichProjects tried to inspect git/github,
+    // the call indices would advance — asserting they stay 0 proves the persisted
+    // values are served without touching `.git` (so the source mount can be dropped).
+    const persisted = makeProject({
+      github: { owner: 'protolabs', repo: 'protomaker' },
+      defaultBranch: 'main',
+    });
+
+    const result = await enrichProjects([persisted]);
+
+    expect(result[0]).toBe(persisted); // same reference — untouched
+    expect(result[0].github).toEqual({ owner: 'protolabs', repo: 'protomaker' });
+    expect(result[0].defaultBranch).toBe('main');
+    expect(h.checkGitHubRemoteIdx).toBe(0);
+    expect(h.execFileAsyncIdx).toBe(0);
+  });
+
+  it('backfills only the missing field, preserving the persisted one (#3948)', async () => {
+    // github is already persisted; only defaultBranch is missing → only git is hit.
+    h.execFileAsyncResults = [{ stdout: 'refs/remotes/origin/main\n' }];
+    const partial = makeProject({ github: { owner: 'acme', repo: 'widgets' } });
+
+    const result = await enrichProjects([partial]);
+
+    expect(result[0].github).toEqual({ owner: 'acme', repo: 'widgets' });
+    expect(result[0].defaultBranch).toBe('main');
+    expect(h.checkGitHubRemoteIdx).toBe(0); // persisted github was not re-derived
+  });
+
   it('enriches multiple projects independently', async () => {
     h.checkGitHubRemoteResults = [
       { hasGitHubRemote: true, owner: 'org1', repo: 'repo1' },


### PR DESCRIPTION
## Problem

Fixes #3948. #3883 (PR #3899) added `ProjectRef.github { owner, repo }` + `defaultBranch`, but `enrich-projects.ts` **re-derives them at read time** from each project's local `.git` (`checkGitHubRemote` + `git symbolic-ref`, both `cwd: project.path`). So the fields depend on the project repo being present on disk. The cross-repo goal (protoWorkstacean) is to **drop the source mounts** once protoMaker exposes native project metadata — but with read-time derivation, dropping the mounts makes the fields silently go empty. The mount-drop is currently blocked.

## Change

- **`setup/routes/project.ts`** now captures `github` (via `checkGitHubRemote`) and `defaultBranch` (already detected for `prBaseBranch`) and **persists them onto the `ProjectRef`** at project-create time — the source of truth (#3883's original acceptance item).
- **`enrich-projects.ts`** is now a **backfill only**: a project that already carries both fields is returned untouched with **no `.git` inspection**, so its values survive a dropped mount. It still backfills only the missing field for older entries.
- **`get-global.ts`** serves persisted values directly and **lazily persists any backfilled values once** (one-time migration for projects added before this change), best-effort so a write failure never fails the read.

## Acceptance (from #3948)

- [x] `github`/`defaultBranch` written to `ProjectRef` on project setup, persisted in `data/settings.json`.
- [x] `GET /api/settings/global` returns them without inspecting `project.path/.git` (a fully-persisted project is served untouched — verified by a test asserting zero git calls).
- [x] `enrich-projects` retained only as a refresh/backfill, not the primary populator.

## Tests

`get-global-enrichment.test.ts` gains coverage that a fully-persisted project is served untouched with zero git/github calls, and that only the missing field is backfilled (persisted `github` is not re-derived). Existing 7 enrichment tests still pass. Full `typecheck` green.

## References

- #3883 / PR #3899 (native fields, read-time enrichment)
- protoWorkstacean #631 (registry plugin); the mount-drop goal that depends on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects now automatically enrich and backfill missing GitHub repository information and default branch details during setup and settings retrieval as a best-effort operation.

* **Tests**
  * Added unit tests to verify metadata enrichment behavior for previously-persisted and partially-persisted projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3953?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->