### PR TITLE
fix(cli): resolve argv[1] symlink so the global `protomaker` bin actually runs

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -22,6 +22,7 @@
 
 import { createRequire } from 'node:module';
 import { pathToFileURL } from 'node:url';
+import { realpathSync } from 'node:fs';
 import { Command } from 'commander';
 import { type GlobalFlags, usageError, exitError } from './output.js';
 import { listCommand, getCommand, createCommand, updateCommand, moveCommand } from './feature.js';
@@ -244,11 +245,29 @@ async function main(): Promise<void> {
   process.exit(0);
 }
 
-// Only run the CLI when this module is invoked directly (e.g. `node dist/cli.js …`),
-// NOT when it's imported — tests import `buildProgram` and must not trigger a parse
-// of the test runner's argv (which would call process.exit during the test run).
-const invokedDirectly =
-  process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href;
+/**
+ * Whether the CLI was invoked directly (so it should parse argv and run), versus
+ * imported (tests import `buildProgram` and must not trigger a parse of the test
+ * runner's argv, which would call process.exit mid-test).
+ *
+ * `argv1` MUST be resolved through realpath before comparing: when the CLI runs via
+ * an npm bin symlink (global install / `npm link`), argv1 is the symlink path
+ * (…/bin/protomaker) while `moduleHref` is the real dist/cli.js. Comparing the raw
+ * paths makes the guard fail and the CLI silently no-ops as a global command — the
+ * only way Ava and `/cli-control` invoke it. realpathSync collapses the symlink so
+ * the linked-bin and `node dist/cli.js` forms both match; a test runner's argv1
+ * resolves to the runner path and still won't match, preserving import-safety.
+ */
+export function isInvokedDirectly(argv1: string | undefined, moduleHref: string): boolean {
+  if (argv1 == null) return false;
+  try {
+    return moduleHref === pathToFileURL(realpathSync(argv1)).href;
+  } catch {
+    return false;
+  }
+}
+
+const invokedDirectly = isInvokedDirectly(process.argv[1], import.meta.url);
 
 if (invokedDirectly) {
   main().catch((err: any) => {

--- a/packages/cli/test/cli-entry.test.ts
+++ b/packages/cli/test/cli-entry.test.ts
@@ -20,13 +20,16 @@ describe('isInvokedDirectly() — entry guard (symlinked bin)', () => {
   let dir: string;
   let realFile: string;
   let symlink: string;
+  let otherFile: string;
   let realHref: string;
 
   beforeAll(() => {
     dir = mkdtempSync(join(tmpdir(), 'pm-cli-entry-'));
     realFile = join(dir, 'cli.js');
     symlink = join(dir, 'protomaker'); // mimics …/bin/protomaker → ../dist/cli.js
+    otherFile = join(dir, 'runner.js'); // a real but different file (e.g. a test runner)
     writeFileSync(realFile, '// stub\n');
+    writeFileSync(otherFile, '// runner\n');
     symlinkSync(realFile, symlink);
     // Resolve through realpath: on macOS tmpdir() itself is a symlink
     // (/var → /private/var), and the guard realpath-resolves argv[1], so the
@@ -47,8 +50,10 @@ describe('isInvokedDirectly() — entry guard (symlinked bin)', () => {
     expect(isInvokedDirectly(realFile, realHref)).toBe(true);
   });
 
-  it('returns false for an unrelated argv[1] (e.g. a test runner — import safety)', () => {
-    expect(isInvokedDirectly(join(dir, 'vitest-runner.js'), realHref)).toBe(false);
+  it('returns false for a real but different argv[1] (e.g. a test runner — import safety)', () => {
+    // otherFile exists, so realpathSync succeeds — this exercises the genuine
+    // path-mismatch branch, not the realpathSync-throws branch below.
+    expect(isInvokedDirectly(otherFile, realHref)).toBe(false);
   });
 
   it('returns false when argv[1] is undefined', () => {

--- a/packages/cli/test/cli-entry.test.ts
+++ b/packages/cli/test/cli-entry.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression test for the CLI entry-point guard (isInvokedDirectly).
+ *
+ * The bug: the guard compared `process.argv[1]` to `import.meta.url` WITHOUT
+ * resolving symlinks. When `protomaker` runs as an npm bin symlink (global install
+ * / `npm link`), argv[1] is the symlink path (…/bin/protomaker) while import.meta.url
+ * is the real dist/cli.js — so the guard failed and the CLI silently no-op'd as a
+ * global command (the only way Ava and `/cli-control` invoke it). The fix resolves
+ * argv[1] through realpath before comparing.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdtempSync, writeFileSync, symlinkSync, rmSync, realpathSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { isInvokedDirectly } from '../src/cli.js';
+
+describe('isInvokedDirectly() — entry guard (symlinked bin)', () => {
+  let dir: string;
+  let realFile: string;
+  let symlink: string;
+  let realHref: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pm-cli-entry-'));
+    realFile = join(dir, 'cli.js');
+    symlink = join(dir, 'protomaker'); // mimics …/bin/protomaker → ../dist/cli.js
+    writeFileSync(realFile, '// stub\n');
+    symlinkSync(realFile, symlink);
+    // Resolve through realpath: on macOS tmpdir() itself is a symlink
+    // (/var → /private/var), and the guard realpath-resolves argv[1], so the
+    // expected module href must be the realpath'd one too.
+    realHref = pathToFileURL(realpathSync(realFile)).href;
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns true when invoked via a symlinked bin (the global-install path)', () => {
+    // This is the case the bug missed: argv[1] is the symlink, module is the real file.
+    expect(isInvokedDirectly(symlink, realHref)).toBe(true);
+  });
+
+  it('returns true when invoked directly as the real file (node dist/cli.js)', () => {
+    expect(isInvokedDirectly(realFile, realHref)).toBe(true);
+  });
+
+  it('returns false for an unrelated argv[1] (e.g. a test runner — import safety)', () => {
+    expect(isInvokedDirectly(join(dir, 'vitest-runner.js'), realHref)).toBe(false);
+  });
+
+  it('returns false when argv[1] is undefined', () => {
+    expect(isInvokedDirectly(undefined, realHref)).toBe(false);
+  });
+
+  it('returns false (never throws) when argv[1] does not exist on disk', () => {
+    expect(isInvokedDirectly('/no/such/path/protomaker', realHref)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem (found dogfooding the /cli-control fallback as Ava)

The `protomaker` CLI silently does nothing when invoked as a globally-installed / `npm link`ed bin:

```
$ protomaker --help        # exit 0, ZERO output
$ protomaker auto-mode status   # exit 0, ZERO output
$ node packages/cli/dist/cli.js --help   # works fine
```

Same file (`readlink -f` confirms the bin symlink resolves to `dist/cli.js`), totally different behavior. **The CLI has never worked as a globally-installed command** — which is the only way Ava and the `/cli-control` skill invoke it (bare `protomaker`).

## Root cause

The entry-point guard in `packages/cli/src/cli.ts`:

```js
const invokedDirectly =
  process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href;
```

When run via an npm bin symlink, `process.argv[1]` is the **symlink** path (`…/bin/protomaker`) while `import.meta.url` is the **real** `dist/cli.js`. The raw-path comparison fails → `invokedDirectly` is `false` → `main()` never runs → silent exit 0. (`node dist/cli.js` works only because there argv[1] already *is* the real path.)

## Fix

Resolve `argv[1]` through `realpathSync` before comparing, so the symlinked-bin and `node dist/cli.js` forms both match. A test runner's `argv[1]` resolves to the runner path and still won't match `import.meta.url`, so importing `buildProgram` in tests stays side-effect-free (the guard's original purpose). Extracted the logic into an exported `isInvokedDirectly()` helper.

## Verification

```
$ protomaker --help              # now prints usage, exit 0
$ protomaker --project … auto-mode status --json   # now returns live JSON
```

## Tests

New `cli-entry.test.ts` (5 tests): symlinked-bin path resolves to `true`, direct path resolves to `true`, unrelated/test-runner path is `false`, `undefined` argv is `false`, and a non-existent path returns `false` (never throws). Full CLI suite: 53 pass. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI entry-point detection so running the tool via symlinked npm bin paths is recognized correctly, while preserving correct behavior when imported by tests; errors still map to appropriate exit codes.

* **Tests**
  * Added regression tests covering symlinked and real-file invocations, undefined or unrelated argv values, and non-existent paths to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->