### PR TITLE
fix(a2a): keep Tailscale callback URLs on http so the agent card is reachable (#3956)

### DIFF
--- a/apps/server/tests/unit/callback-url.test.ts
+++ b/apps/server/tests/unit/callback-url.test.ts
@@ -269,9 +269,35 @@ describe('resolveCallbackUrl', () => {
     expect(url).toBe('http://ava.ts.net');
   });
 
-  it('uses https protocol when specified', () => {
+  it('keeps a Tailscale URL on http even when protocol:"https" is requested (#3956)', () => {
+    // Tailscale secures transport via WireGuard and the app terminates no TLS on
+    // its port, so forcing https would advertise an unreachable endpoint. The
+    // protocol override must be ignored for Tailscale-derived URLs.
     setHostname('ava.ts.net');
-    const url = resolveCallbackUrl({ port: 443, protocol: 'https' });
-    expect(url).toBe('https://ava.ts.net:443');
+    const url = resolveCallbackUrl({ port: 3008, protocol: 'https' });
+    expect(url).toBe('http://ava.ts.net:3008');
+  });
+
+  it('keeps a force-on Tailscale URL on http even when protocol:"https" is requested (#3956)', () => {
+    setHostname('some-host');
+    const url = resolveCallbackUrl({
+      port: 3008,
+      protocol: 'https',
+      tailscaleDetection: 'force-on',
+    });
+    expect(url).toBe('http://some-host:3008');
+  });
+
+  it('applies protocol:"https" to an explicit non-Tailscale HOSTNAME', () => {
+    // A real public hostname (with a TLS ingress) legitimately uses https.
+    setHostname('localhost');
+    setNetworkInterfaces({});
+    process.env['HOSTNAME'] = 'ava.proto-labs.ai';
+    const url = resolveCallbackUrl({
+      port: 443,
+      protocol: 'https',
+      tailscaleDetection: 'force-off',
+    });
+    expect(url).toBe('https://ava.proto-labs.ai:443');
   });
 });

--- a/libs/platform/src/callback-url.ts
+++ b/libs/platform/src/callback-url.ts
@@ -188,17 +188,21 @@ export function resolveCallbackUrl(options: ResolveCallbackUrlOptions = {}): str
   }
 
   // ── 2. Tailscale detection ────────────────────────────────────────────────
+  // Tailscale endpoints are ALWAYS http: WireGuard secures the transport at the
+  // network layer and the app does not terminate TLS on its port. Forcing https
+  // here (e.g. under NODE_ENV=production) advertises a URL with no TLS listener —
+  // the handshake fails and peers can't reach the agent (#3956). The `protocol`
+  // option therefore applies only to an explicit public HOSTNAME (step 3); a real
+  // TLS ingress must be supplied via PUBLIC_CALLBACK_URL, which wins in step 1.
   if (tailscaleDetection !== 'force-off') {
     if (tailscaleDetection === 'force-on') {
       const host = hostname ?? os.hostname();
-      return `${protocol}://${host}${portSuffix}`;
+      return `http://${host}${portSuffix}`;
     }
 
     const detection = detectTailscale(hostname);
     if (detection.isTailscale && detection.tailscaleUrl) {
-      const base = detection.tailscaleUrl
-        .replace(/\/$/, '')
-        .replace(/^http:\/\//, `${protocol}://`);
+      const base = detection.tailscaleUrl.replace(/\/$/, '');
       return port != null ? `${base}${portSuffix}` : base;
     }
   }


### PR DESCRIPTION
## Problem

Fixes #3956. Found testing the A2A agent end-to-end. The agent card (`GET /.well-known/agent.json`) advertised an unreachable URL under `NODE_ENV=production`:

```
url: https://100.119.239.8:3008/a2a          # from the live card
curl https://100.119.239.8:3008/...  → TLS handshake fails (curl exit 35)
curl http://100.119.239.8:3008/...   → 200 OK
```

:3008 serves plain http; there is no TLS terminator. Any external A2A peer (e.g. protoWorkstacean) that reads the card and POSTs to the advertised `url` gets a TLS failure — inbound A2A delegation to this instance is broken.

## Root cause

`buildAgentCard()` forces `protocol: 'https'` when `NODE_ENV=production`. With `PUBLIC_CALLBACK_URL` unset, `resolveCallbackUrl` falls to Tailscale detection — `detectTailscale()` correctly returns `http://100.119.239.8` — then **rewrites the scheme to https** (`libs/platform/src/callback-url.ts`):

```js
const base = detection.tailscaleUrl.replace(/^http:\/\//, `${protocol}://`);
```

Tailscale endpoints terminate no TLS on the app port (WireGuard secures the transport at the network layer), so the rewrite produces a URL with no TLS listener behind it.

## Fix

Tailscale-derived callback URLs (both auto-detected and `force-on`) now stay `http` regardless of the `protocol` option. The `protocol` override applies only to an explicit public `HOSTNAME` (step 3) — a real TLS ingress is supplied via `PUBLIC_CALLBACK_URL`, which still wins in step 1 and is used verbatim.

**Config follow-up (per #3956):** deployments with a public https ingress should set `PUBLIC_CALLBACK_URL` (e.g. `https://ava.proto-labs.ai`); it is unaffected by this change and takes priority over Tailscale detection.

## Tests

`callback-url.test.ts`: replaced the test that encoded the old https-rewrite with one asserting a Tailscale URL stays http under `protocol:'https'`; added coverage for the `force-on` case and for a genuine public-`HOSTNAME` https case. Platform suite 142/142, full `typecheck` green.

Note: the live card on this LaunchAgent won't change until the server process restarts (the resolver is evaluated per request but the module is loaded in-process); unit tests verify the corrected logic.

## A2A surface otherwise healthy

Verified live during testing: card discovery, X-API-Key auth (401), skill-allowlist (-32601), unknown-method (-32601), `message/send` (sitrep), `message/stream` SSE, default chat. Only the advertised card scheme was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed callback URL protocol handling for Tailscale environments. URLs derived from Tailscale detection now consistently use HTTP protocol regardless of configuration settings.

* **Tests**
  * Enhanced protocol-handling test coverage for callback URL resolution in Tailscale scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3957?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->