### PR TITLE
fix(plugin): SessionStart hook resolves project from session cwd, not stale AUTOMAKER_ROOT

### DIFF
--- a/packages/mcp-server/plugins/automaker/hooks/pre-compact-save-state.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/pre-compact-save-state.sh
@@ -7,7 +7,15 @@
 
 set -euo pipefail
 
-PROJECT_ROOT="${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+# Resolve project path: session cwd (from stdin JSON) > git toplevel > AUTOMAKER_ROOT
+if [ -t 0 ]; then
+  INPUT=""
+else
+  INPUT="$(cat 2>/dev/null || true)"
+fi
+HOOK_CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)"
+PROJECT_ROOT="${HOOK_CWD:-$(git -C "${HOOK_CWD:-.}" rev-parse --show-toplevel 2>/dev/null)}"
+PROJECT_ROOT="${PROJECT_ROOT:-${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}}"
 FEATURES_DIR="$PROJECT_ROOT/.automaker/features"
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DATA_DIR="${PLUGIN_DIR}/data"

--- a/packages/mcp-server/plugins/automaker/hooks/session-context.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/session-context.sh
@@ -3,7 +3,15 @@
 # Injects board summary so Ava/Claude starts with awareness of current state.
 # Output goes to stdout and is added to Claude's context.
 
-PROJECT_ROOT="${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+# Resolve project path: session cwd (from stdin JSON) > git toplevel > AUTOMAKER_ROOT
+if [ -t 0 ]; then
+  INPUT=""
+else
+  INPUT="$(cat 2>/dev/null || true)"
+fi
+HOOK_CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)"
+PROJECT_ROOT="${HOOK_CWD:-$(git -C "${HOOK_CWD:-.}" rev-parse --show-toplevel 2>/dev/null)}"
+PROJECT_ROOT="${PROJECT_ROOT:-${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}}"
 FEATURES_DIR="$PROJECT_ROOT/.automaker/features"
 
 # Get the plugin directory to access saved state

--- a/packages/mcp-server/plugins/automaker/hooks/session-end-save.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/session-end-save.sh
@@ -6,7 +6,15 @@
 
 set -euo pipefail
 
-PROJECT_ROOT="${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+# Resolve project path: session cwd (from stdin JSON) > git toplevel > AUTOMAKER_ROOT
+if [ -t 0 ]; then
+  INPUT=""
+else
+  INPUT="$(cat 2>/dev/null || true)"
+fi
+HOOK_CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)"
+PROJECT_ROOT="${HOOK_CWD:-$(git -C "${HOOK_CWD:-.}" rev-parse --show-toplevel 2>/dev/null)}"
+PROJECT_ROOT="${PROJECT_ROOT:-${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}}"
 FEATURES_DIR="$PROJECT_ROOT/.automaker/features"
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DATA_DIR="${PLUGIN_DIR}/data"


### PR DESCRIPTION
## Summary

Implements GitHub issue protoLabsAI/protoMaker#3959. Read full context first: `gh issue view 3959 --repo protoLabsAI/protoMaker`.

## Bug
The protoLabs plugin SessionStart hook resolves the project path from the ambient AUTOMAKER_ROOT env var instead of the session's real cwd (which Claude Code passes as JSON on stdin). When a claude process carries a stale AUTOMAKER_ROOT (e.g. a pre-rename /Users/kj/dev/automaker), the hook reports the wrong project and wrong board counts even though the sessio...

Closes #3959

---
*Created automatically by Automaker*

<!-- automaker:owner instance=transient-20572056 team= created=2026-05-28T00:28:51.382Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved project root detection to accept working directory context from external inputs.
  * Enhanced fallback mechanisms for path resolution, ensuring more reliable project identification across session management processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->