### PR TITLE
feat(server): auto-generate feature title server-side so CLI/MCP/API features get names like the UI

### DIFF
--- a/apps/server/src/routes/features/index.ts
+++ b/apps/server/src/routes/features/index.ts
@@ -61,7 +61,7 @@ export function createFeaturesRoutes(
     '/create',
     validatePathParams('projectPath'),
     validateBody(CreateRequestSchema),
-    createCreateHandler(featureLoader, trustTierService, events)
+    createCreateHandler(featureLoader, trustTierService, events, settingsService)
   );
   router.post(
     '/update',

--- a/apps/server/src/routes/features/routes/create.ts
+++ b/apps/server/src/routes/features/routes/create.ts
@@ -12,6 +12,8 @@ import { TrustTierService } from '../../../services/trust-tier-service.js';
 import { QuarantineService } from '../../../services/quarantine-service.js';
 import type { QuarantineStage, SanitizationViolation } from '@protolabsai/types';
 import { createLogger } from '@protolabsai/utils';
+import type { SettingsService } from '../../../services/settings-service.js';
+import { generateFeatureTitle } from '../../../services/title-generator.js';
 
 const logger = createLogger('CreateFeature');
 
@@ -51,7 +53,8 @@ function determineSource(req: Request): Feature['source'] {
 export function createCreateHandler(
   featureLoader: FeatureLoader,
   trustTierService: TrustTierService,
-  events?: EventEmitter
+  events?: EventEmitter,
+  settingsService?: SettingsService
 ) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
@@ -123,9 +126,35 @@ export function createCreateHandler(
 
       // Use sanitized title and description from quarantine outcome
       // Preserve original empty title so the UI can auto-generate it client-side
+      let resolvedTitle = feature.title?.trim() ? outcome.sanitizedTitle : (feature.title ?? '');
+
+      // Auto-generate title when empty and a description is available.
+      // If generation fails or returns empty, fall back to empty title (no 500).
+      if (!resolvedTitle && feature.description) {
+        const generated = await generateFeatureTitle(
+          feature.description,
+          settingsService,
+          projectPath
+        );
+        if (generated) {
+          // Run the generated title through the same sanitization path.
+          // Re-run quarantine with the generated title to get a sanitized version.
+          const titleQuarantine = await quarantineService.process({
+            title: generated,
+            description: feature.description,
+            source,
+            trustTier,
+          });
+          if (titleQuarantine.approved) {
+            resolvedTitle = titleQuarantine.sanitizedTitle;
+            logger.info(`Auto-generated feature title: ${resolvedTitle}`);
+          }
+        }
+      }
+
       const sanitizedFeature: Partial<Feature> = {
         ...feature,
-        title: feature.title?.trim() ? outcome.sanitizedTitle : (feature.title ?? ''),
+        title: resolvedTitle,
         description: outcome.sanitizedDescription,
         source,
         trustTier,

--- a/apps/server/src/routes/features/routes/generate-title.ts
+++ b/apps/server/src/routes/features/routes/generate-title.ts
@@ -1,20 +1,14 @@
 /**
  * POST /features/generate-title endpoint - Generate a concise title from description
  *
- * Uses the provider abstraction to generate a short, descriptive title
- * from a feature description. Works with any configured provider (Claude, Cursor, etc.).
+ * Delegates to the shared title-generator service so both this route and
+ * the feature create handler use the same logic.
  */
 
 import type { Request, Response } from 'express';
 import { createLogger } from '@protolabsai/utils';
-import { resolvePhaseModel } from '@protolabsai/model-resolver';
-import { simpleQuery } from '../../../providers/simple-query-service.js';
 import type { SettingsService } from '../../../services/settings-service.js';
-import {
-  getPromptCustomization,
-  getPhaseModelWithOverrides,
-} from '../../../lib/settings-helpers.js';
-import { captureTrainingRow } from '../../../services/training-capture.js';
+import { generateFeatureTitle } from '../../../services/title-generator.js';
 
 const logger = createLogger('GenerateTitle');
 
@@ -61,48 +55,9 @@ export function createGenerateTitleHandler(
 
       logger.info(`Generating title for description: ${trimmedDescription.substring(0, 50)}...`);
 
-      // Get customized prompts from settings
-      const prompts = await getPromptCustomization(settingsService, '[GenerateTitle]');
-      const systemPrompt = prompts.titleGeneration.systemPrompt;
+      const title = await generateFeatureTitle(trimmedDescription, settingsService, projectPath);
 
-      const userPrompt = `Generate a concise title for this feature:\n\n${trimmedDescription}`;
-
-      // Resolve model via phase-model settings (titleGenerationModel) —
-      // defaults to protolabs/nano. Credentials are fetched alongside for the
-      // provider abstraction.
-      const credentials = await settingsService?.getCredentials();
-
-      const { phaseModel } = await getPhaseModelWithOverrides(
-        'titleGenerationModel',
-        settingsService,
-        projectPath,
-        '[GenerateTitle]'
-      );
-      const { model } = resolvePhaseModel(phaseModel);
-
-      // Use simpleQuery - provider abstraction handles all the streaming/extraction.
-      const result = await simpleQuery({
-        prompt: `${systemPrompt}\n\n${userPrompt}`,
-        model,
-        cwd: process.cwd(),
-        maxTurns: 1,
-        allowedTools: [],
-        credentials, // Pass credentials for resolving 'credentials' apiKeySource
-      });
-
-      const title = result.text;
-
-      // Capture the input→output pair as training data (non-blocking; #3859).
-      if (projectPath && title && title.trim().length > 0) {
-        void captureTrainingRow(projectPath, {
-          task: 'feature-title',
-          model,
-          input: { description: trimmedDescription.slice(0, 500) },
-          output: title.trim(),
-        });
-      }
-
-      if (!title || title.trim().length === 0) {
+      if (!title) {
         logger.warn('Received empty response from AI');
         const response: GenerateTitleErrorResponse = {
           success: false,
@@ -112,11 +67,9 @@ export function createGenerateTitleHandler(
         return;
       }
 
-      logger.info(`Generated title: ${title.trim()}`);
-
       const response: GenerateTitleSuccessResponse = {
         success: true,
-        title: title.trim(),
+        title,
       };
       res.json(response);
     } catch (error) {

--- a/apps/server/src/services/title-generator.ts
+++ b/apps/server/src/services/title-generator.ts
@@ -1,0 +1,82 @@
+/**
+ * Feature title generator service.
+ *
+ * Produces a concise, human-readable feature title from a description using
+ * the fast model tier (titleGenerationModel) and captures every input→output
+ * pair as training data so a small purpose-built model can be distilled later.
+ *
+ * Returns `null` when it cannot produce a title (no description, model failure,
+ * or empty result) so the caller falls back to deterministic behavior. Never throws.
+ */
+
+import { createLogger } from '@protolabsai/utils';
+import { resolvePhaseModel } from '@protolabsai/model-resolver';
+import { simpleQuery } from '../providers/simple-query-service.js';
+import { getPromptCustomization, getPhaseModelWithOverrides } from '../lib/settings-helpers.js';
+import { captureTrainingRow } from './training-capture.js';
+import type { SettingsService } from './settings-service.js';
+
+const logger = createLogger('TitleGenerator');
+
+/**
+ * Generate a concise feature title from a description using the configured
+ * title-generation model and prompts.
+ *
+ * @returns The generated title string, or `null` on failure / empty input.
+ */
+export async function generateFeatureTitle(
+  description: string,
+  settingsService?: SettingsService | null,
+  projectPath?: string
+): Promise<string | null> {
+  try {
+    const trimmed = description.trim();
+    if (!trimmed) return null;
+
+    // Get customized prompts from settings
+    const prompts = await getPromptCustomization(settingsService, '[TitleGenerator]');
+    const systemPrompt = prompts.titleGeneration.systemPrompt;
+
+    const userPrompt = `Generate a concise title for this feature:\n\n${trimmed}`;
+
+    // Resolve model via phase-model settings (titleGenerationModel)
+    const credentials = await settingsService?.getCredentials();
+
+    const { phaseModel } = await getPhaseModelWithOverrides(
+      'titleGenerationModel',
+      settingsService,
+      projectPath,
+      '[TitleGenerator]'
+    );
+    const { model } = resolvePhaseModel(phaseModel);
+
+    const result = await simpleQuery({
+      prompt: `${systemPrompt}\n\n${userPrompt}`,
+      model,
+      cwd: process.cwd(),
+      maxTurns: 1,
+      allowedTools: [],
+      credentials,
+    });
+
+    const title = (result.text ?? '').trim();
+
+    // Capture the input→output pair as training data (non-blocking; #3859).
+    if (projectPath && title) {
+      void captureTrainingRow(projectPath, {
+        task: 'feature-title',
+        model,
+        input: { description: trimmed.slice(0, 500) },
+        output: title,
+      });
+    }
+
+    if (!title) return null;
+
+    logger.info(`Generated title: ${title}`);
+    return title;
+  } catch (err) {
+    logger.debug('Title generation failed; returning null for fallback', err);
+    return null;
+  }
+}

--- a/apps/server/tests/unit/routes/create-auto-title.test.ts
+++ b/apps/server/tests/unit/routes/create-auto-title.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Unit tests for auto-generated feature titles in the create handler.
+ *
+ * Verifies:
+ * - Empty title + description -> generated non-empty title
+ * - Provided title -> unchanged (no regression)
+ * - Generation failure -> graceful fallback (no 500)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: () => ({ info() {}, debug() {}, warn() {}, error() {} }),
+}));
+
+// Mock the title generator
+const generateFeatureTitle = vi.fn();
+vi.mock('../../../src/services/title-generator.js', () => ({
+  generateFeatureTitle: (...args: unknown[]) => generateFeatureTitle(...args),
+}));
+
+// Mock quarantine service - spy on the constructor
+const quarantineProcessSpy = vi.fn();
+vi.mock('../../../src/services/quarantine-service.js', () => ({
+  QuarantineService: class {
+    constructor() {}
+    process = quarantineProcessSpy;
+  },
+}));
+
+// Mock trust tier service
+vi.mock('../../../src/services/trust-tier-service.js', () => ({
+  TrustTierService: class {
+    classifyTrust = vi.fn().mockReturnValue('trusted');
+  },
+}));
+
+// Mock feature loader methods at module level
+const findDuplicateTitleMock = vi.fn();
+const findCandidateEpicMock = vi.fn();
+const createMock = vi.fn();
+vi.mock('../../../src/services/feature-loader.js', () => ({
+  FeatureLoader: {
+    findDuplicateTitle: (...args: unknown[]) => findDuplicateTitleMock(...args),
+    findCandidateEpicForTitle: (...args: unknown[]) => findCandidateEpicMock(...args),
+    create: (...args: unknown[]) => createMock(...args),
+  },
+}));
+
+vi.mock('../common.js', () => ({
+  getErrorMessage: vi.fn((err) => (err instanceof Error ? err.message : 'Unknown error')),
+  logError: vi.fn(),
+}));
+
+import { createCreateHandler } from '../../../src/routes/features/routes/create.js';
+
+const mockQuarantineOutcome = {
+  approved: true,
+  sanitizedTitle: 'Sanitized Title',
+  sanitizedDescription: 'Sanitized description',
+  entry: {
+    id: 'quarantine-1',
+    result: 'approved',
+    stage: 'passed',
+    violations: [],
+  },
+};
+
+const mockFeatureLoader = {
+  findDuplicateTitle: findDuplicateTitleMock,
+  findCandidateEpicForTitle: findCandidateEpicMock,
+  create: createMock,
+};
+
+const mockTrustTierService = {
+  classifyTrust: vi.fn().mockReturnValue('trusted'),
+};
+
+describe('createCreateHandler - auto-generate title', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    generateFeatureTitle.mockResolvedValue('Generated Title');
+    findDuplicateTitleMock.mockResolvedValue(null);
+    findCandidateEpicMock.mockResolvedValue(null);
+    quarantineProcessSpy.mockResolvedValue(mockQuarantineOutcome);
+    createMock.mockImplementation((_projectPath, feature) =>
+      Promise.resolve({ id: 'feat-1', projectPath: '/test/project', ...feature })
+    );
+    mockTrustTierService.classifyTrust.mockReturnValue('trusted');
+  });
+
+  it('generates a title when title is empty and description is provided', async () => {
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any,
+      undefined,
+      {} as any
+    );
+
+    const req = {
+      body: {
+        projectPath: '/test/project',
+        feature: {
+          title: '',
+          description: 'Add a dark-mode toggle to settings',
+        },
+      },
+      headers: {},
+      cookies: {},
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await handler(req, res);
+
+    // Should call the title generator
+    expect(generateFeatureTitle).toHaveBeenCalledWith(
+      'Add a dark-mode toggle to settings',
+      {},
+      '/test/project'
+    );
+
+    // The created feature should have the generated title (sanitized)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        feature: expect.objectContaining({
+          title: 'Sanitized Title',
+        }),
+      })
+    );
+  });
+
+  it('uses provided title verbatim when title is given', async () => {
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any,
+      undefined,
+      {} as any
+    );
+
+    const req = {
+      body: {
+        projectPath: '/test/project',
+        feature: {
+          title: 'My Explicit Title',
+          description: 'Some description',
+        },
+      },
+      headers: {},
+      cookies: {},
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await handler(req, res);
+
+    // Should NOT call the title generator
+    expect(generateFeatureTitle).not.toHaveBeenCalled();
+
+    // The created feature should have the explicit title (sanitized)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        feature: expect.objectContaining({
+          title: 'Sanitized Title',
+        }),
+      })
+    );
+  });
+
+  it('falls back gracefully when title generation returns null', async () => {
+    generateFeatureTitle.mockResolvedValue(null);
+
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any,
+      undefined,
+      {} as any
+    );
+
+    const req = {
+      body: {
+        projectPath: '/test/project',
+        feature: {
+          title: '',
+          description: 'Add a dark-mode toggle',
+        },
+      },
+      headers: {},
+      cookies: {},
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await handler(req, res);
+
+    // Should attempt generation
+    expect(generateFeatureTitle).toHaveBeenCalled();
+
+    // Should NOT return 500 - should create with empty title
+    expect(res.status).not.toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        feature: expect.objectContaining({
+          title: '',
+        }),
+      })
+    );
+  });
+
+  it('falls back gracefully when title generation throws', async () => {
+    generateFeatureTitle.mockRejectedValue(new Error('Model timeout'));
+
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any,
+      undefined,
+      {} as any
+    );
+
+    const req = {
+      body: {
+        projectPath: '/test/project',
+        feature: {
+          title: '',
+          description: 'Add a dark-mode toggle',
+        },
+      },
+      headers: {},
+      cookies: {},
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await handler(req, res);
+
+    // Should attempt generation
+    expect(generateFeatureTitle).toHaveBeenCalled();
+
+    // Should return 500 error (outer catch handles the throw)
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it('does not generate title when no description is provided', async () => {
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any,
+      undefined,
+      {} as any
+    );
+
+    const req = {
+      body: {
+        projectPath: '/test/project',
+        feature: {
+          title: '',
+          description: '',
+        },
+      },
+      headers: {},
+      cookies: {},
+    };
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn(),
+    };
+
+    await handler(req, res);
+
+    // Should NOT call the title generator when description is empty
+    expect(generateFeatureTitle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/tests/unit/routes/generate-title.test.ts
+++ b/apps/server/tests/unit/routes/generate-title.test.ts
@@ -77,7 +77,7 @@ describe('createGenerateTitleHandler', () => {
       'titleGenerationModel',
       mockSettingsService,
       undefined,
-      '[GenerateTitle]'
+      '[TitleGenerator]'
     );
     expect(simpleQuery).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
## Summary

## Problem
Feature title generation currently lives only in the UI. When a feature is created via the CLI (`protomaker feature create`), MCP (`create_feature`), or the API without an explicit title, it lands with an EMPTY title — unlike the UI, which calls `/features/generate-title` (an AI model call) before `/features/create`.

Evidence:
- `apps/server/src/routes/features/routes/create.ts:125-128` deliberately preserves an empty title: `title: feature.title?.trim() ? outcome.sanitizedTitle : (f...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-c4afe7c8 team= created=2026-05-28T00:37:24.211Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature titles are now automatically generated from descriptions when no title is explicitly provided during feature creation.

* **Refactor**
  * Title generation logic has been consolidated into a shared service for consistency across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->