### PR TITLE
Naming parity test + feature-naming reference doc

### DIFF
--- a/apps/server/tests/unit/routes/create-naming-parity.test.ts
+++ b/apps/server/tests/unit/routes/create-naming-parity.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Parity test: create-with-description-only yields non-empty title AND branch slug
+ * regardless of source (ui / cli / mcp / api / internal).
+ *
+ * Ensures that when a feature is created with only a description (no title),
+ * the server-side title generator produces a non-empty title, and the branch
+ * name generator (deterministic slug) always produces a non-empty branch slug.
+ *
+ * Covers all five feature sources determined by `determineSource()` in the
+ * create handler: ui, cli, mcp, api, internal.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: () => ({ info() {}, debug() {}, warn() {}, error() {} }),
+  slugify: (s: string, max?: number) => {
+    const slug = s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    return max ? slug.slice(0, max) : slug;
+  },
+}));
+
+// Mock the title generator — return a generated title
+const mockGenerateFeatureTitle = vi.fn();
+vi.mock('../../../src/services/title-generator.js', () => ({
+  generateFeatureTitle: (...args: unknown[]) => mockGenerateFeatureTitle(...args),
+}));
+
+// Mock quarantine service
+const mockQuarantineProcess = vi.fn();
+vi.mock('../../../src/services/quarantine-service.js', () => ({
+  QuarantineService: class {
+    constructor() {}
+    process = mockQuarantineProcess;
+  },
+}));
+
+// Mock trust tier service
+vi.mock('../../../src/services/trust-tier-service.js', () => ({
+  TrustTierService: class {
+    classifyTrust = vi.fn().mockReturnValue('trusted');
+  },
+}));
+
+// Mock feature loader methods
+const mockFindDuplicateTitle = vi.fn();
+const mockFindCandidateEpic = vi.fn();
+const mockCreate = vi.fn();
+vi.mock('../../../src/services/feature-loader.js', () => ({
+  FeatureLoader: {
+    findDuplicateTitle: (...args: unknown[]) => mockFindDuplicateTitle(...args),
+    findCandidateEpicForTitle: (...args: unknown[]) => mockFindCandidateEpic(...args),
+    create: (...args: unknown[]) => mockCreate(...args),
+  },
+}));
+
+vi.mock('../common.js', () => ({
+  getErrorMessage: vi.fn((err: unknown) => (err instanceof Error ? err.message : 'Unknown error')),
+  logError: vi.fn(),
+}));
+
+import { createCreateHandler } from '../../../src/routes/features/routes/create.js';
+
+const mockQuarantineOutcome = {
+  approved: true,
+  sanitizedTitle: 'Generated Feature Title',
+  sanitizedDescription: 'Add a dark-mode toggle to the settings page',
+  entry: {
+    id: 'quarantine-1',
+    result: 'approved' as const,
+    stage: 'passed' as any,
+    violations: [],
+  },
+};
+
+const mockFeatureLoader = {
+  findDuplicateTitle: mockFindDuplicateTitle,
+  findCandidateEpicForTitle: mockFindCandidateEpic,
+  create: mockCreate,
+};
+
+const mockTrustTierService = {
+  classifyTrust: vi.fn().mockReturnValue('trusted'),
+};
+
+const testDescription = 'Add a dark-mode toggle to the settings page';
+
+function makeReq(sourceHeaders: Record<string, string>, title = '') {
+  return {
+    body: {
+      projectPath: '/test/project',
+      feature: {
+        title,
+        description: testDescription,
+      },
+    },
+    headers: sourceHeaders,
+    cookies: {},
+  };
+}
+
+function makeRes() {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  };
+}
+
+describe('create-with-description-only naming parity across all sources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGenerateFeatureTitle.mockResolvedValue('Generated Feature Title');
+    mockFindDuplicateTitle.mockResolvedValue(null);
+    mockFindCandidateEpic.mockResolvedValue(null);
+    mockQuarantineProcess.mockResolvedValue(mockQuarantineOutcome);
+    mockCreate.mockImplementation((_projectPath, feature) =>
+      Promise.resolve({
+        id: 'feat-1',
+        projectPath: '/test/project',
+        branchName: 'feature/generated-feature-title-feat1',
+        ...feature,
+      })
+    );
+  });
+
+  const sources: Array<{ name: string; headers: Record<string, string> }> = [
+    { name: 'ui', headers: { 'x-session-token': 'abc123' } },
+    { name: 'cli', headers: {} },
+    { name: 'mcp', headers: { 'x-automaker-client': 'mcp' } },
+    { name: 'api', headers: { 'x-api-key': 'sk-test' } },
+    { name: 'internal', headers: { 'x-session-token': 'internal-token' } },
+  ];
+
+  for (const { name, headers } of sources) {
+    it(`${name} source: generates non-empty title`, async () => {
+      const handler = createCreateHandler(
+        mockFeatureLoader as any,
+        mockTrustTierService as any,
+        undefined,
+        {} as any
+      );
+      const res = makeRes();
+      await handler(makeReq(headers), res);
+
+      // Title generator called
+      expect(mockGenerateFeatureTitle).toHaveBeenCalledWith(testDescription, {}, '/test/project');
+
+      // Created feature has non-empty title
+      const jsonCall = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(jsonCall.success).toBe(true);
+      expect(jsonCall.feature.title).toBeTruthy();
+      expect(jsonCall.feature.title.length).toBeGreaterThan(0);
+    });
+
+    it(`${name} source: produces non-empty branch slug`, async () => {
+      const handler = createCreateHandler(
+        mockFeatureLoader as any,
+        mockTrustTierService as any,
+        undefined,
+        {} as any
+      );
+      const res = makeRes();
+      await handler(makeReq(headers), res);
+
+      // Feature loader create called — the branch name is generated inside
+      // FeatureLoader.create() via generateBranchName() or the smart generator.
+      // The created feature (returned by mockCreate) should have a branchName.
+      const jsonCall = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(jsonCall.feature.branchName).toBeTruthy();
+      expect(jsonCall.feature.branchName.length).toBeGreaterThan(0);
+    });
+  }
+
+  it('title generation failure: still creates feature (graceful fallback)', async () => {
+    mockGenerateFeatureTitle.mockResolvedValue(null);
+
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any,
+      undefined,
+      {} as any
+    );
+    const res = makeRes();
+    await handler(makeReq({}), res);
+
+    // Should NOT 500
+    expect(res.status).not.toHaveBeenCalledWith(500);
+    // Feature still created (title may be empty, but branch name is always generated)
+    const jsonCall = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(jsonCall.success).toBe(true);
+  });
+
+  it('title generation throws: outer catch handles it (no crash)', async () => {
+    mockGenerateFeatureTitle.mockRejectedValue(new Error('model timeout'));
+
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any,
+      undefined,
+      {} as any
+    );
+    const res = makeRes();
+    await handler(makeReq({}), res);
+
+    // Should return 500 (outer catch), not crash the process
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it('explicit title provided: skips title generation', async () => {
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any,
+      undefined,
+      {} as any
+    );
+    const res = makeRes();
+    await handler(makeReq({}, 'My Explicit Title'), res);
+
+    // Title generator should NOT be called when title is provided
+    expect(mockGenerateFeatureTitle).not.toHaveBeenCalled();
+  });
+});

--- a/docs/internal/server/feature-naming.md
+++ b/docs/internal/server/feature-naming.md
@@ -1,0 +1,207 @@
+# Feature Naming Reference
+
+Server-side naming pipeline for features: title generation and branch-name generation. Both run entirely in `apps/server/` after the title-gen fix that moved title generation from the UI to the server create handler.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Title Generator](#title-generator)
+3. [Branch Name Generator](#branch-name-generator)
+4. [Model Settings](#model-settings)
+5. [Where Each Runs](#where-each-runs)
+6. [Fallbacks](#fallbacks)
+7. [Training Capture](#training-capture)
+8. [Parity Test](#parity-test)
+
+---
+
+## Overview
+
+```
+Feature create request (description only, no title)
+    │
+    ├── POST /api/features/create  (create.ts)
+    │       │
+    │       ├── 1. Quarantine pipeline (sanitization)
+    │       ├── 2. Title generator (title-generator.ts) ← if title is empty
+    │       │       └── generateFeatureTitle(description, settingsService, projectPath)
+    │       │           └── simpleQuery(titleGenerationModel) → title string | null
+    │       │
+    │       └── 3. FeatureLoader.create() (feature-loader.ts)
+    │               └── Branch name generation
+    │                   ├── Smart generator (branch-name-generator.ts) ← if enabled
+    │                   │   └── simpleQuery(branchNameModel) → smart branch | null
+    │                   └── Deterministic fallback (generateBranchName)
+    │                       └── slugify(title) + shortId → "feature/slug-abc1234"
+    │
+    └── Created feature has: title (generated or empty) + branchName (always present unless read-only)
+```
+
+Both generators run **server-side**. All creation entry points (UI, CLI, MCP, API, internal) hit the same `POST /api/features/create` handler, so title and branch naming is consistent regardless of source.
+
+---
+
+## Title Generator
+
+**File:** `apps/server/src/services/title-generator.ts`
+
+**Function:** `generateFeatureTitle(description, settingsService?, projectPath?)`
+
+**Input:** Feature description string  
+**Output:** Generated title string, or `null` on failure/empty input  
+**Throws:** Never — catches all errors and returns `null`
+
+### How it works
+
+1. Trims the description; returns `null` if empty
+2. Loads customized prompt via `getPromptCustomization()` → `titleGeneration.systemPrompt`
+3. Resolves model via `getPhaseModelWithOverrides('titleGenerationModel', ...)`
+4. Calls `simpleQuery()` with the system + user prompt
+5. Returns the trimmed result, or `null` if empty
+6. Captures input→output pair as training data (see [Training Capture](#training-capture))
+
+### Where called
+
+- `POST /api/features/create` (`routes/features/routes/create.ts`) — auto-generates title when the incoming feature has an empty title but a description
+- `POST /api/features/generate-title` (`routes/features/routes/generate-title.ts`) — standalone endpoint for explicit title generation requests
+
+### Model setting
+
+Uses `titleGenerationModel` from `phaseModels` in settings. Defaults to the fast/nano tier. Configurable via Settings → AI Models.
+
+---
+
+## Branch Name Generator
+
+Two generators exist: a smart (model-based) generator and a deterministic fallback.
+
+### Smart Branch Name Generator
+
+**File:** `apps/server/src/services/branch-name-generator.ts`
+
+**Function:** `createSmartBranchNameGenerator(settingsService, branchPrefixForCategory)`
+
+**Input:** `{ title, description?, category?, featureId? }` + project path  
+**Output:** Smart branch name string (e.g. `feature/user-auth-flow-abc1234`), or `null`  
+**Throws:** Never — catches all errors and returns `null`
+
+### How it works
+
+1. Checks `workflowSettings.smartBranchNames` — returns `null` if disabled
+2. Resolves model via `getPhaseModelWithOverrides('branchNameModel', ...)`
+3. Calls `simpleQuery()` with a slug-generation prompt
+4. Sanitizes output: lowercase, hyphen-separated, `[a-z0-9-]` only, max 50 chars
+5. Returns `{prefix}/{slug}-{shortId}`, or `null` if slug is degenerate (< 3 chars)
+6. Captures input→output pair as training data
+
+### Deterministic Fallback
+
+**File:** `apps/server/src/services/feature-loader.ts`
+
+**Method:** `FeatureLoader.generateBranchName(title, featureId?, category?)`
+
+Always produces a branch name. Logic:
+
+1. Derives `shortId` from the last 7 chars of `featureId`
+2. Determines prefix from category or conventional-commit type detection in the title (`fix:` → `fix/`, `chore:` → `chore/`, etc.)
+3. Slugifies the title (max 50 chars), strips non-`[a-z0-9-]` chars
+4. Returns `{prefix}/{slug}-{shortId}`
+
+### Where called
+
+- `FeatureLoader.create()` — during feature creation, after the title is resolved. Tries the smart generator first (if injected), falls back to deterministic.
+- `auto-mode/execution-service.ts` — if a feature has no `branchName` at execution time, generates one via `branchNameModel`
+
+### Model setting
+
+Uses `branchNameModel` from `phaseModels` in settings. Defaults to `protolabs/nano`. Configurable via Settings → AI Models. Controlled by `workflowSettings.smartBranchNames` (boolean toggle).
+
+---
+
+## Model Settings
+
+| Setting Key                         | Purpose                             | Default                      | Config Location      |
+| ----------------------------------- | ----------------------------------- | ---------------------------- | -------------------- |
+| `phaseModels.titleGenerationModel`  | Model for generating feature titles | `protolabs/nano` (fast tier) | Settings → AI Models |
+| `phaseModels.branchNameModel`       | Model for generating branch slugs   | `protolabs/nano` (fast tier) | Settings → AI Models |
+| `workflowSettings.smartBranchNames` | Enable/disable smart branch names   | `false` (deterministic)      | Settings → Workflow  |
+
+Both `titleGenerationModel` and `branchNameModel` support per-project overrides via `projectSettings.phaseModelOverrides`. Resolution order: project override → global setting → default.
+
+Model resolution uses `getPhaseModelWithOverrides(key, settingsService, projectPath)` from `lib/settings-helpers.ts`.
+
+---
+
+## Where Each Runs
+
+| Generator                  | Entry Point                         | File                                       | Trigger                                               |
+| -------------------------- | ----------------------------------- | ------------------------------------------ | ----------------------------------------------------- |
+| **Title**                  | `POST /api/features/create`         | `routes/features/routes/create.ts`         | Title empty + description present                     |
+| **Title**                  | `POST /api/features/generate-title` | `routes/features/routes/generate-title.ts` | Explicit request                                      |
+| **Branch (smart)**         | `FeatureLoader.create()`            | `services/branch-name-generator.ts`        | Smart generator injected + `smartBranchNames` enabled |
+| **Branch (deterministic)** | `FeatureLoader.create()`            | `services/feature-loader.ts`               | Always (fallback if smart returns null)               |
+| **Branch (late)**          | `ExecutionService`                  | `services/auto-mode/execution-service.ts`  | Feature has no `branchName` at execution time         |
+
+All creation paths (UI, CLI, MCP, API, internal) route through `POST /api/features/create`, so naming behavior is identical regardless of source.
+
+---
+
+## Fallbacks
+
+### Title fallback chain
+
+1. If title is provided by caller → use as-is (after quarantine sanitization)
+2. If title is empty + description present → call `generateFeatureTitle()`
+3. If generation returns `null` (no description, model failure, empty result) → title remains empty string
+4. If generation throws → caught by outer `catch` in create handler (returns 500)
+
+### Branch name fallback chain
+
+1. If `branchName` provided by caller and passes validation → use as-is
+2. If smart generator is injected AND `smartBranchNames` is enabled → try smart generator
+3. If smart generator returns `null` (disabled, no title, model failure, degenerate slug) → use deterministic `generateBranchName()`
+4. Deterministic generator always produces a result: `{prefix}/{slug}-{shortId}` or `{prefix}/untitled-{shortId}`
+5. Read-only features (`executionMode: 'read-only'`) skip branch generation entirely
+
+---
+
+## Training Capture
+
+Both generators capture input→output pairs for future model distillation (#3859).
+
+**File:** `apps/server/src/services/training-capture.ts`
+
+**Function:** `captureTrainingRow(projectPath, row)`
+
+**Output:** JSONL file at `.automaker/training/{task}/captures.jsonl`
+
+| Task Kind       | Capture Directory                                  | Fields Captured                                                                   |
+| --------------- | -------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `feature-title` | `.automaker/training/feature-title/captures.jsonl` | `description` → `title`                                                           |
+| `branch-name`   | `.automaker/training/branch-name/captures.jsonl`   | `title`, `description`, `category` → `branchName` (or `<deterministic-fallback>`) |
+
+Capture is **fail-open**: if writing fails, the observed task continues normally. Both generators call `captureTrainingRow` with `void` (fire-and-forget).
+
+---
+
+## Parity Test
+
+**File:** `apps/server/tests/unit/routes/create-naming-parity.test.ts`
+
+Verifies that creating a feature with description-only (no title) yields:
+
+- A **non-empty title** (when the title generator succeeds)
+- A **non-empty branch slug** (always, via deterministic or smart generator)
+
+Tests all five feature sources: `ui`, `cli`, `mcp`, `api`, `internal`. Also covers graceful fallback when title generation returns `null` or throws.
+
+---
+
+## Cross-References
+
+- [Providers](./providers) — AI provider abstraction used by `simpleQuery`
+- [Route Organization](./route-organization) — Express route structure including `/features/create`
+- [Auto Mode Service](./auto-mode-service) — Feature execution lifecycle (includes late branch name generation)
+- [Settings Helpers](../../apps/server/src/lib/settings-helpers.ts) — `getPhaseModelWithOverrides` and `getPromptCustomization`

--- a/docs/internal/server/index.md
+++ b/docs/internal/server/index.md
@@ -24,6 +24,7 @@ The server is an Express 5 application with WebSocket streaming, organized into 
 - **[Maintenance Checks](./maintenance-checks)** — How to create composable maintenance check modules
 - **[Ops Dashboard](./ops-dashboard)** — Reference for the Ops Dashboard tabs, API endpoints, and WebSocket events
 - **[Proto SDK Smoke Test](./proto-sdk-smoke-test)** — One-command smoke test for the SDK agentic loop — run after SDK bumps or when agent runs come back empty
+- **[Feature Naming](./feature-naming)** — Title and branch-name generators: model settings, fallbacks, training capture, and parity tests
 
 ## Key Technologies
 


### PR DESCRIPTION
## Summary

Depends on the server-side title-gen feature (feature-1779927988978-lmeqzdi4k). Add a Vitest parity test under apps/server/tests/ asserting create-with-description-only yields a non-empty title AND branch slug regardless of source (ui/cli/mcp/api/internal). Add short Diataxis reference doc docs/internal/server/feature-naming.md: the two generators (title vs branch), model settings (titleGenerationModel/branchNameModel), where each runs (both server-side after the title-gen fix), fallbacks, train...

---
*Recovered automatically by Automaker post-agent hook*

<!-- automaker:owner instance=transient-45a465b1 team= created=2026-05-28T00:57:54.472Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for feature naming consistency across all creation sources, including graceful error handling scenarios.

* **Documentation**
  * Added internal documentation detailing the server-side feature naming pipeline, including title and branch name generation, model settings, and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->