### PR TITLE
feat(cli): add feature dependency management to the protomaker CLI

### DIFF
--- a/packages/cli/src/feature.ts
+++ b/packages/cli/src/feature.ts
@@ -433,6 +433,11 @@ export function updateCommand(parent: Command): void {
   cmd.option('--category <text>', 'New category');
   cmd.option('--complexity <level>', 'New complexity level (small|medium|large|architectural)');
   cmd.option('--priority <n>', 'New priority (1=urgent, 2=high, 3=normal, 4=low)');
+  cmd.option(
+    '--depends-on <ids>',
+    'Comma-separated feature IDs this feature depends on (replaces the existing dependency list)'
+  );
+  cmd.option('--clear-deps', 'Clear all dependencies on this feature');
 
   cmd.action(async (featureId: string, opts) => {
     const flags = getGlobalFlags(cmd.optsWithGlobals());
@@ -450,9 +455,25 @@ export function updateCommand(parent: Command): void {
       updates.priority = p;
     }
 
+    if (opts.dependsOn !== undefined && opts.clearDeps) {
+      usageError('Use either --depends-on or --clear-deps, not both');
+    }
+    if (opts.clearDeps) {
+      updates.dependencies = [];
+    } else if (opts.dependsOn !== undefined) {
+      const deps = String(opts.dependsOn)
+        .split(',')
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0);
+      if (deps.includes(featureId)) {
+        usageError('A feature cannot depend on itself');
+      }
+      updates.dependencies = deps;
+    }
+
     if (Object.keys(updates).length === 0) {
       usageError(
-        'At least one update option is required (--title, --description, --category, --complexity, --priority)'
+        'At least one update option is required (--title, --description, --category, --complexity, --priority, --depends-on, --clear-deps)'
       );
     }
 

--- a/packages/cli/test/cli-wiring.test.ts
+++ b/packages/cli/test/cli-wiring.test.ts
@@ -107,6 +107,40 @@ describe('global flag propagation (--project / --json) reaches the request body'
   });
 });
 
+describe('feature update maps dependency flags into updates.dependencies (#3962)', () => {
+  it('--depends-on sends a trimmed dependency array', async () => {
+    await buildProgram().parseAsync([
+      'node',
+      'protomaker',
+      '--project',
+      '/custom/project',
+      '--json',
+      'feature',
+      'update',
+      'feat-target',
+      '--depends-on',
+      'feat-a, feat-b ,feat-c',
+    ]);
+    expect(lastUrl).toMatch(/\/features\/update$/);
+    const updates = lastBody!.updates as Record<string, unknown>;
+    expect(updates.dependencies).toEqual(['feat-a', 'feat-b', 'feat-c']);
+  });
+
+  it('--clear-deps sends an empty dependency array', async () => {
+    await buildProgram().parseAsync([
+      'node',
+      'protomaker',
+      '--json',
+      'feature',
+      'update',
+      'feat-target',
+      '--clear-deps',
+    ]);
+    const updates = lastBody!.updates as Record<string, unknown>;
+    expect(updates.dependencies).toEqual([]);
+  });
+});
+
 describe('feature create maps --execution-mode / --workflow into the payload (#3946)', () => {
   it('sends executionMode and workflow on the created feature', async () => {
     await buildProgram().parseAsync([

--- a/packages/mcp-server/plugins/automaker/commands/cli-control.md
+++ b/packages/mcp-server/plugins/automaker/commands/cli-control.md
@@ -33,8 +33,12 @@ protomaker feature list --status review --compact  # list grouped by status
 protomaker feature get <featureId> --json          # full detail for one feature
 protomaker feature create --title "Add X" --category fix --complexity small --priority 2
 protomaker feature update <featureId> --priority 1 --title "…"
+protomaker feature update <featureId> --depends-on <id1,id2>  # set the dependency list (replaces existing)
+protomaker feature update <featureId> --clear-deps            # remove all dependencies
 protomaker feature move <featureId> <status> --reason "…"   # --reason required when moving to blocked
 ```
+
+Dependencies gate execution: a feature is only eligible for auto-mode once all `--depends-on` features reach `done`. Use this to sequence epic children (e.g. `--depends-on <epicChildId>`).
 
 Statuses: `backlog | in_progress | review | blocked | done`. Complexity: `small | medium | large | architectural`. Priority: `1=urgent … 4=low`.
 


### PR DESCRIPTION
Fixes #3962.

## What
Adds dependency management to `protomaker feature update`:
- `--depends-on <id1,id2,...>` — set the dependency list (replaces existing; comma-separated, trimmed)
- `--clear-deps` — remove all dependencies

Maps to the server's existing contract: `POST /api/features/update` with `updates.dependencies` (same path `set_feature_dependencies` uses in the MCP server).

## Why
Roxy (the new CLI-only, autonomous per-project board/crew manager — epic `feature-1779929420214-slptr3fd9`) must sequence epic children and dependency chains. The CLI had no way to set dependencies, forcing raw `curl` against the API. This closes that gap.

## Guards
- A feature cannot depend on itself.
- `--depends-on` and `--clear-deps` are mutually exclusive.

## Scope note
Read views (`orchestrate order` / `graph`) are intentionally out of scope — they're derivable from `query --json` and weren't the blocker. Can follow up if Roxy wants first-class topological-order output.

## Tests
- `cli-wiring.test.ts`: asserts both flags map into `updates.dependencies` (trimmed array / empty array). All 56 CLI tests pass; typecheck clean.
- Live e2e against the running server: set → verify `["feat-a","feat-b"]`, clear → verify `[]`, both guards fire.

## Docs
- Updated the `/cli-control` skill doc (`commands/cli-control.md`) with the new flags + a note that dependencies gate auto-mode eligibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)