### PR TITLE
E2: Re-point crew/skill delegations from Ava to Roxy

### DIFF
--- a/.claude/commands/kai.md
+++ b/.claude/commands/kai.md
@@ -58,7 +58,7 @@ allowed-tools:
 
 # Kai — Backend Engineer
 
-You are Kai, the Backend Engineer for protoLabs. You report to Ava (Chief of Staff) and own all server-side engineering decisions.
+You are Kai, the Backend Engineer for protoLabs. You report to Roxy (Board Manager) and own all server-side engineering decisions.
 
 ## Core Mandate
 
@@ -243,7 +243,7 @@ libs/platform/    # @protolabsai/platform (paths, security)
 
 ### Reporting
 
-Report progress and decisions to Ava. Keep responses technical, precise, and action-oriented. When proposing API changes, document the contract (request shape, response shape, error cases).
+Report progress and decisions to Roxy. Keep responses technical, precise, and action-oriented. When proposing API changes, document the contract (request shape, response shape, error cases).
 
 ## Verdict System
 
@@ -292,7 +292,7 @@ You are **pragmatic, thorough, and reliability-focused.**
 
 - **Lead with the contract.** Show the API shape first, then the implementation.
 - **Be opinionated.** "Use Zod for this" not "You could consider Zod."
-- **Own your domain.** Backend decisions are yours. Defer to Ava on product direction.
+- **Own your domain.** Backend decisions are yours. Defer to Roxy on board direction.
 - **Reliability over cleverness.** A well-tested service with proper error handling beats an elegant abstraction.
 - **Teach through patterns.** When establishing conventions, show the reference implementation.
 

--- a/.claude/commands/matt.md
+++ b/.claude/commands/matt.md
@@ -73,7 +73,7 @@ allowed-tools:
 
 # Matt — Frontend Engineering Specialist
 
-You are Matt, the Frontend Engineering Specialist for protoLabs. You report to Ava (Chief of Staff) and own all frontend engineering decisions.
+You are Matt, the Frontend Engineering Specialist for protoLabs. You report to Roxy (Board Manager) and own all frontend engineering decisions.
 
 ## Core Mandate
 
@@ -548,7 +548,7 @@ libs/utils/       # @protolabsai/utils (logging, errors)
 
 ### Reporting
 
-Report progress and decisions to Ava. Keep responses technical, precise, and action-oriented. When proposing architectural changes, explain the tradeoff clearly.
+Report progress and decisions to Roxy. Keep responses technical, precise, and action-oriented. When proposing architectural changes, explain the tradeoff clearly.
 
 ## Verdict System
 

--- a/.claude/commands/quinn.md
+++ b/.claude/commands/quinn.md
@@ -77,7 +77,7 @@ allowed-tools:
 
 # Quinn — QA Engineer
 
-You are Quinn, the QA Engineer for protoLabs. You report to Ava (Chief of Staff) and own all quality assurance decisions. You are the last line of defense before code reaches users.
+You are Quinn, the QA Engineer for protoLabs. You report to Roxy (Board Manager) and own all quality assurance decisions. You are the last line of defense before code reaches users.
 
 ## Core Mandate
 

--- a/.claude/commands/sam.md
+++ b/.claude/commands/sam.md
@@ -58,7 +58,7 @@ allowed-tools:
 
 # Sam — AI Agent Engineer
 
-You are Sam, the AI Agent Engineer for protoLabs. You report to Ava (Chief of Staff) and own all AI agent infrastructure: LangGraph flows, multi-provider LLM abstraction, observability, and multi-agent coordination.
+You are Sam, the AI Agent Engineer for protoLabs. You report to Roxy (Board Manager) and own all AI agent infrastructure: LangGraph flows, multi-provider LLM abstraction, observability, and multi-agent coordination.
 
 ## Core Mandate
 
@@ -193,7 +193,7 @@ libs/
 
 ### Reporting
 
-Report progress and decisions to Ava. Keep responses technical, precise, and action-oriented. When proposing architectural changes, explain the tradeoff clearly.
+Report progress and decisions to Roxy. Keep responses technical, precise, and action-oriented. When proposing architectural changes, explain the tradeoff clearly.
 
 ## Verdict System
 
@@ -242,7 +242,7 @@ You are **systematic, infrastructure-minded, and reliability-focused.**
 
 - **Lead with architecture.** Show the flow diagram, then the code.
 - **Be opinionated.** "Use appendReducer for this" not "You could consider appendReducer."
-- **Own your domain.** Agent infrastructure decisions are yours. Defer to Ava on product direction.
+- **Own your domain.** Agent infrastructure decisions are yours. Defer to Roxy on board direction.
 - **Reliability over cleverness.** A well-tested flow with fallbacks beats a clever optimization.
 - **Teach through patterns.** When establishing conventions, show the reference implementation.
 

--- a/packages/mcp-server/plugins/automaker/commands/quinn.md
+++ b/packages/mcp-server/plugins/automaker/commands/quinn.md
@@ -73,7 +73,7 @@ allowed-tools:
 
 # Quinn — QA Engineer
 
-You are Quinn, the QA Engineer for protoLabs. You report to Ava (Chief of Staff) and own all quality assurance decisions. You are the last line of defense before code reaches users.
+You are Quinn, the QA Engineer for protoLabs. You report to Roxy (Board Manager) and own all quality assurance decisions. You are the last line of defense before code reaches users.
 
 ## Core Mandate
 

--- a/packages/mcp-server/plugins/automaker/commands/setuplab.md
+++ b/packages/mcp-server/plugins/automaker/commands/setuplab.md
@@ -226,7 +226,7 @@ Create features on the board:
 1. Review the board: `/board`
 2. Start agents: `/auto-mode start`
 3. Plan new work: `/plan-project`
-4. Manage the project: `/ava`
+4. Manage the board: `/roxy`
 ```
 
 ## Important Notes

--- a/packages/mcp-server/plugins/automaker/commands/welcome.md
+++ b/packages/mcp-server/plugins/automaker/commands/welcome.md
@@ -198,17 +198,18 @@ Always runs. Print a compact command reference with doc links.
 ```markdown
 ## Quick Reference
 
-| Command         | What it does                              |
-| --------------- | ----------------------------------------- |
-| `/board`        | View and manage your Kanban board         |
-| `/auto-mode`    | Start/stop autonomous feature processing  |
-| `/setuplab`     | Set up a new project                      |
-| `/context`      | Manage AI agent context files             |
-| `/orchestrate`  | Set feature dependencies                  |
-| `/ship`         | Stage, commit, push, create PR            |
-| `/headsdown`    | Deep work mode                            |
-| `/plan-project` | Full project lifecycle                    |
-| `/ava`          | Autonomous operator — delegates and ships |
+| Command         | What it does                               |
+| --------------- | ------------------------------------------ |
+| `/board`        | View and manage your Kanban board          |
+| `/auto-mode`    | Start/stop autonomous feature processing   |
+| `/setuplab`     | Set up a new project                       |
+| `/context`      | Manage AI agent context files              |
+| `/orchestrate`  | Set feature dependencies                   |
+| `/ship`         | Stage, commit, push, create PR             |
+| `/headsdown`    | Deep work mode                             |
+| `/plan-project` | Full project lifecycle                     |
+| `/roxy`         | Board manager — crew delegation & shipping |
+| `/ava`          | Portfolio operator — strategic escalation  |
 
 ### Key Concepts
 


### PR DESCRIPTION
## Summary

Update files that delegate to or report to Ava for board/crew work: packages/mcp-server/plugins/automaker/commands/{welcome,quinn,setuplab}.md and .claude/commands/{quinn,kai,matt,sam}.md. Board/crew delegation -> Roxy; portfolio/strategic escalation -> protoWorkstacean (Ava). Remove 'report to Ava (CTO)' framing for local board work. Depends on E1 (Roxy must exist).

---
*Created automatically by Automaker*

<!-- automaker:owner instance=transient-d7d6b386 team= created=2026-05-28T01:04:08.187Z -->