### PR TITLE
epic: Roxy owns per-project board/crew; decommission Ava orchestrator (portfolio -> workstacean)

### DIFF
--- a/apps/server/tests/unit/routes/create-naming-parity.test.ts
+++ b/apps/server/tests/unit/routes/create-naming-parity.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Parity test: create-with-description-only yields non-empty title AND branch slug
+ * regardless of source (ui / cli / mcp / api / internal).
+ *
+ * Ensures that when a feature is created with only a description (no title),
+ * the server-side title generator produces a non-empty title, and the branch
+ * name generator (deterministic slug) always produces a non-empty branch slug.
+ *
+ * Covers all five feature sources determined by `determineSource()` in the
+ * create handler: ui, cli, mcp, api, internal.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: () => ({ info() {}, debug() {}, warn() {}, error() {} }),
+  slugify: (s: string, max?: number) => {
+    const slug = s
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '');
+    return max ? slug.slice(0, max) : slug;
+  },
+}));
+
+// Mock the title generator — return a generated title
+const mockGenerateFeatureTitle = vi.fn();
+vi.mock('../../../src/services/title-generator.js', () => ({
+  generateFeatureTitle: (...args: unknown[]) => mockGenerateFeatureTitle(...args),
+}));
+
+// Mock quarantine service
+const mockQuarantineProcess = vi.fn();
+vi.mock('../../../src/services/quarantine-service.js', () => ({
+  QuarantineService: class {
+    constructor() {}
+    process = mockQuarantineProcess;
+  },
+}));
+
+// Mock trust tier service
+vi.mock('../../../src/services/trust-tier-service.js', () => ({
+  TrustTierService: class {
+    classifyTrust = vi.fn().mockReturnValue('trusted');
+  },
+}));
+
+// Mock feature loader methods
+const mockFindDuplicateTitle = vi.fn();
+const mockFindCandidateEpic = vi.fn();
+const mockCreate = vi.fn();
+vi.mock('../../../src/services/feature-loader.js', () => ({
+  FeatureLoader: {
+    findDuplicateTitle: (...args: unknown[]) => mockFindDuplicateTitle(...args),
+    findCandidateEpicForTitle: (...args: unknown[]) => mockFindCandidateEpic(...args),
+    create: (...args: unknown[]) => mockCreate(...args),
+  },
+}));
+
+vi.mock('../common.js', () => ({
+  getErrorMessage: vi.fn((err: unknown) => (err instanceof Error ? err.message : 'Unknown error')),
+  logError: vi.fn(),
+}));
+
+import { createCreateHandler } from '../../../src/routes/features/routes/create.js';
+
+const mockQuarantineOutcome = {
+  approved: true,
+  sanitizedTitle: 'Generated Feature Title',
+  sanitizedDescription: 'Add a dark-mode toggle to the settings page',
+  entry: {
+    id: 'quarantine-1',
+    result: 'approved' as const,
+    stage: 'passed' as any,
+    violations: [],
+  },
+};
+
+const mockFeatureLoader = {
+  findDuplicateTitle: mockFindDuplicateTitle,
+  findCandidateEpicForTitle: mockFindCandidateEpic,
+  create: mockCreate,
+};
+
+const mockTrustTierService = {
+  classifyTrust: vi.fn().mockReturnValue('trusted'),
+};
+
+const testDescription = 'Add a dark-mode toggle to the settings page';
+
+function makeReq(sourceHeaders: Record<string, string>, title = '') {
+  return {
+    body: {
+      projectPath: '/test/project',
+      feature: {
+        title,
+        description: testDescription,
+      },
+    },
+    headers: sourceHeaders,
+    cookies: {},
+  };
+}
+
+function makeRes() {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  };
+}
+
+describe('create-with-description-only naming parity across all sources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGenerateFeatureTitle.mockResolvedValue('Generated Feature Title');
+    mockFindDuplicateTitle.mockResolvedValue(null);
+    mockFindCandidateEpic.mockResolvedValue(null);
+    mockQuarantineProcess.mockResolvedValue(mockQuarantineOutcome);
+    mockCreate.mockImplementation((_projectPath, feature) =>
+      Promise.resolve({
+        id: 'feat-1',
+        projectPath: '/test/project',
+        branchName: 'feature/generated-feature-title-feat1',
+        ...feature,
+      })
+    );
+  });
+
+  const sources: Array<{ name: string; headers: Record<string, string> }> = [
+    { name: 'ui', headers: { 'x-session-token': 'abc123' } },
+    { name: 'cli', headers: {} },
+    { name: 'mcp', headers: { 'x-automaker-client': 'mcp' } },
+    { name: 'api', headers: { 'x-api-key': 'sk-test' } },
+    { name: 'internal', headers: { 'x-session-token': 'internal-token' } },
+  ];
+
+  for (const { name, headers } of sources) {
+    it(`${name} source: generates non-empty title`, async () => {
+      const handler = createCreateHandler(
+        mockFeatureLoader as any,
+        mockTrustTierService as any,
+        undefined,
+        {} as any
+      );
+      const res = makeRes();
+      await handler(makeReq(headers), res);
+
+      // Title generator called
+      expect(mockGenerateFeatureTitle).toHaveBeenCalledWith(testDescription, {}, '/test/project');
+
+      // Created feature has non-empty title
+      const jsonCall = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(jsonCall.success).toBe(true);
+      expect(jsonCall.feature.title).toBeTruthy();
+      expect(jsonCall.feature.title.length).toBeGreaterThan(0);
+    });
+
+    it(`${name} source: produces non-empty branch slug`, async () => {
+      const handler = createCreateHandler(
+        mockFeatureLoader as any,
+        mockTrustTierService as any,
+        undefined,
+        {} as any
+      );
+      const res = makeRes();
+      await handler(makeReq(headers), res);
+
+      // Feature loader create called — the branch name is generated inside
+      // FeatureLoader.create() via generateBranchName() or the smart generator.
+      // The created feature (returned by mockCreate) should have a branchName.
+      const jsonCall = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(jsonCall.feature.branchName).toBeTruthy();
+      expect(jsonCall.feature.branchName.length).toBeGreaterThan(0);
+    });
+  }
+
+  it('title generation failure: still creates feature (graceful fallback)', async () => {
+    mockGenerateFeatureTitle.mockResolvedValue(null);
+
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any,
+      undefined,
+      {} as any
+    );
+    const res = makeRes();
+    await handler(makeReq({}), res);
+
+    // Should NOT 500
+    expect(res.status).not.toHaveBeenCalledWith(500);
+    // Feature still created (title may be empty, but branch name is always generated)
+    const jsonCall = (res.json as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(jsonCall.success).toBe(true);
+  });
+
+  it('title generation throws: outer catch handles it (no crash)', async () => {
+    mockGenerateFeatureTitle.mockRejectedValue(new Error('model timeout'));
+
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any,
+      undefined,
+      {} as any
+    );
+    const res = makeRes();
+    await handler(makeReq({}), res);
+
+    // Should return 500 (outer catch), not crash the process
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+
+  it('explicit title provided: skips title generation', async () => {
+    const handler = createCreateHandler(
+      mockFeatureLoader as any,
+      mockTrustTierService as any,
+      undefined,
+      {} as any
+    );
+    const res = makeRes();
+    await handler(makeReq({}, 'My Explicit Title'), res);
+
+    // Title generator should NOT be called when title is provided
+    expect(mockGenerateFeatureTitle).not.toHaveBeenCalled();
+  });
+});

--- a/docs/internal/server/feature-naming.md
+++ b/docs/internal/server/feature-naming.md
@@ -1,0 +1,207 @@
+# Feature Naming Reference
+
+Server-side naming pipeline for features: title generation and branch-name generation. Both run entirely in `apps/server/` after the title-gen fix that moved title generation from the UI to the server create handler.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Title Generator](#title-generator)
+3. [Branch Name Generator](#branch-name-generator)
+4. [Model Settings](#model-settings)
+5. [Where Each Runs](#where-each-runs)
+6. [Fallbacks](#fallbacks)
+7. [Training Capture](#training-capture)
+8. [Parity Test](#parity-test)
+
+---
+
+## Overview
+
+```
+Feature create request (description only, no title)
+    │
+    ├── POST /api/features/create  (create.ts)
+    │       │
+    │       ├── 1. Quarantine pipeline (sanitization)
+    │       ├── 2. Title generator (title-generator.ts) ← if title is empty
+    │       │       └── generateFeatureTitle(description, settingsService, projectPath)
+    │       │           └── simpleQuery(titleGenerationModel) → title string | null
+    │       │
+    │       └── 3. FeatureLoader.create() (feature-loader.ts)
+    │               └── Branch name generation
+    │                   ├── Smart generator (branch-name-generator.ts) ← if enabled
+    │                   │   └── simpleQuery(branchNameModel) → smart branch | null
+    │                   └── Deterministic fallback (generateBranchName)
+    │                       └── slugify(title) + shortId → "feature/slug-abc1234"
+    │
+    └── Created feature has: title (generated or empty) + branchName (always present unless read-only)
+```
+
+Both generators run **server-side**. All creation entry points (UI, CLI, MCP, API, internal) hit the same `POST /api/features/create` handler, so title and branch naming is consistent regardless of source.
+
+---
+
+## Title Generator
+
+**File:** `apps/server/src/services/title-generator.ts`
+
+**Function:** `generateFeatureTitle(description, settingsService?, projectPath?)`
+
+**Input:** Feature description string  
+**Output:** Generated title string, or `null` on failure/empty input  
+**Throws:** Never — catches all errors and returns `null`
+
+### How it works
+
+1. Trims the description; returns `null` if empty
+2. Loads customized prompt via `getPromptCustomization()` → `titleGeneration.systemPrompt`
+3. Resolves model via `getPhaseModelWithOverrides('titleGenerationModel', ...)`
+4. Calls `simpleQuery()` with the system + user prompt
+5. Returns the trimmed result, or `null` if empty
+6. Captures input→output pair as training data (see [Training Capture](#training-capture))
+
+### Where called
+
+- `POST /api/features/create` (`routes/features/routes/create.ts`) — auto-generates title when the incoming feature has an empty title but a description
+- `POST /api/features/generate-title` (`routes/features/routes/generate-title.ts`) — standalone endpoint for explicit title generation requests
+
+### Model setting
+
+Uses `titleGenerationModel` from `phaseModels` in settings. Defaults to the fast/nano tier. Configurable via Settings → AI Models.
+
+---
+
+## Branch Name Generator
+
+Two generators exist: a smart (model-based) generator and a deterministic fallback.
+
+### Smart Branch Name Generator
+
+**File:** `apps/server/src/services/branch-name-generator.ts`
+
+**Function:** `createSmartBranchNameGenerator(settingsService, branchPrefixForCategory)`
+
+**Input:** `{ title, description?, category?, featureId? }` + project path  
+**Output:** Smart branch name string (e.g. `feature/user-auth-flow-abc1234`), or `null`  
+**Throws:** Never — catches all errors and returns `null`
+
+### How it works
+
+1. Checks `workflowSettings.smartBranchNames` — returns `null` if disabled
+2. Resolves model via `getPhaseModelWithOverrides('branchNameModel', ...)`
+3. Calls `simpleQuery()` with a slug-generation prompt
+4. Sanitizes output: lowercase, hyphen-separated, `[a-z0-9-]` only, max 50 chars
+5. Returns `{prefix}/{slug}-{shortId}`, or `null` if slug is degenerate (< 3 chars)
+6. Captures input→output pair as training data
+
+### Deterministic Fallback
+
+**File:** `apps/server/src/services/feature-loader.ts`
+
+**Method:** `FeatureLoader.generateBranchName(title, featureId?, category?)`
+
+Always produces a branch name. Logic:
+
+1. Derives `shortId` from the last 7 chars of `featureId`
+2. Determines prefix from category or conventional-commit type detection in the title (`fix:` → `fix/`, `chore:` → `chore/`, etc.)
+3. Slugifies the title (max 50 chars), strips non-`[a-z0-9-]` chars
+4. Returns `{prefix}/{slug}-{shortId}`
+
+### Where called
+
+- `FeatureLoader.create()` — during feature creation, after the title is resolved. Tries the smart generator first (if injected), falls back to deterministic.
+- `auto-mode/execution-service.ts` — if a feature has no `branchName` at execution time, generates one via `branchNameModel`
+
+### Model setting
+
+Uses `branchNameModel` from `phaseModels` in settings. Defaults to `protolabs/nano`. Configurable via Settings → AI Models. Controlled by `workflowSettings.smartBranchNames` (boolean toggle).
+
+---
+
+## Model Settings
+
+| Setting Key                         | Purpose                             | Default                      | Config Location      |
+| ----------------------------------- | ----------------------------------- | ---------------------------- | -------------------- |
+| `phaseModels.titleGenerationModel`  | Model for generating feature titles | `protolabs/nano` (fast tier) | Settings → AI Models |
+| `phaseModels.branchNameModel`       | Model for generating branch slugs   | `protolabs/nano` (fast tier) | Settings → AI Models |
+| `workflowSettings.smartBranchNames` | Enable/disable smart branch names   | `false` (deterministic)      | Settings → Workflow  |
+
+Both `titleGenerationModel` and `branchNameModel` support per-project overrides via `projectSettings.phaseModelOverrides`. Resolution order: project override → global setting → default.
+
+Model resolution uses `getPhaseModelWithOverrides(key, settingsService, projectPath)` from `lib/settings-helpers.ts`.
+
+---
+
+## Where Each Runs
+
+| Generator                  | Entry Point                         | File                                       | Trigger                                               |
+| -------------------------- | ----------------------------------- | ------------------------------------------ | ----------------------------------------------------- |
+| **Title**                  | `POST /api/features/create`         | `routes/features/routes/create.ts`         | Title empty + description present                     |
+| **Title**                  | `POST /api/features/generate-title` | `routes/features/routes/generate-title.ts` | Explicit request                                      |
+| **Branch (smart)**         | `FeatureLoader.create()`            | `services/branch-name-generator.ts`        | Smart generator injected + `smartBranchNames` enabled |
+| **Branch (deterministic)** | `FeatureLoader.create()`            | `services/feature-loader.ts`               | Always (fallback if smart returns null)               |
+| **Branch (late)**          | `ExecutionService`                  | `services/auto-mode/execution-service.ts`  | Feature has no `branchName` at execution time         |
+
+All creation paths (UI, CLI, MCP, API, internal) route through `POST /api/features/create`, so naming behavior is identical regardless of source.
+
+---
+
+## Fallbacks
+
+### Title fallback chain
+
+1. If title is provided by caller → use as-is (after quarantine sanitization)
+2. If title is empty + description present → call `generateFeatureTitle()`
+3. If generation returns `null` (no description, model failure, empty result) → title remains empty string
+4. If generation throws → caught by outer `catch` in create handler (returns 500)
+
+### Branch name fallback chain
+
+1. If `branchName` provided by caller and passes validation → use as-is
+2. If smart generator is injected AND `smartBranchNames` is enabled → try smart generator
+3. If smart generator returns `null` (disabled, no title, model failure, degenerate slug) → use deterministic `generateBranchName()`
+4. Deterministic generator always produces a result: `{prefix}/{slug}-{shortId}` or `{prefix}/untitled-{shortId}`
+5. Read-only features (`executionMode: 'read-only'`) skip branch generation entirely
+
+---
+
+## Training Capture
+
+Both generators capture input→output pairs for future model distillation (#3859).
+
+**File:** `apps/server/src/services/training-capture.ts`
+
+**Function:** `captureTrainingRow(projectPath, row)`
+
+**Output:** JSONL file at `.automaker/training/{task}/captures.jsonl`
+
+| Task Kind       | Capture Directory                                  | Fields Captured                                                                   |
+| --------------- | -------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `feature-title` | `.automaker/training/feature-title/captures.jsonl` | `description` → `title`                                                           |
+| `branch-name`   | `.automaker/training/branch-name/captures.jsonl`   | `title`, `description`, `category` → `branchName` (or `<deterministic-fallback>`) |
+
+Capture is **fail-open**: if writing fails, the observed task continues normally. Both generators call `captureTrainingRow` with `void` (fire-and-forget).
+
+---
+
+## Parity Test
+
+**File:** `apps/server/tests/unit/routes/create-naming-parity.test.ts`
+
+Verifies that creating a feature with description-only (no title) yields:
+
+- A **non-empty title** (when the title generator succeeds)
+- A **non-empty branch slug** (always, via deterministic or smart generator)
+
+Tests all five feature sources: `ui`, `cli`, `mcp`, `api`, `internal`. Also covers graceful fallback when title generation returns `null` or throws.
+
+---
+
+## Cross-References
+
+- [Providers](./providers) — AI provider abstraction used by `simpleQuery`
+- [Route Organization](./route-organization) — Express route structure including `/features/create`
+- [Auto Mode Service](./auto-mode-service) — Feature execution lifecycle (includes late branch name generation)
+- [Settings Helpers](../../apps/server/src/lib/settings-helpers.ts) — `getPhaseModelWithOverrides` and `getPromptCustomization`

--- a/docs/internal/server/index.md
+++ b/docs/internal/server/index.md
@@ -24,6 +24,7 @@ The server is an Express 5 application with WebSocket streaming, organized into 
 - **[Maintenance Checks](./maintenance-checks)** — How to create composable maintenance check modules
 - **[Ops Dashboard](./ops-dashboard)** — Reference for the Ops Dashboard tabs, API endpoints, and WebSocket events
 - **[Proto SDK Smoke Test](./proto-sdk-smoke-test)** — One-command smoke test for the SDK agentic loop — run after SDK bumps or when agent runs come back empty
+- **[Feature Naming](./feature-naming)** — Title and branch-name generators: model settings, fallbacks, training capture, and parity tests
 
 ## Key Technologies
 

--- a/packages/cli/src/feature.ts
+++ b/packages/cli/src/feature.ts
@@ -433,6 +433,11 @@ export function updateCommand(parent: Command): void {
   cmd.option('--category <text>', 'New category');
   cmd.option('--complexity <level>', 'New complexity level (small|medium|large|architectural)');
   cmd.option('--priority <n>', 'New priority (1=urgent, 2=high, 3=normal, 4=low)');
+  cmd.option(
+    '--depends-on <ids>',
+    'Comma-separated feature IDs this feature depends on (replaces the existing dependency list)'
+  );
+  cmd.option('--clear-deps', 'Clear all dependencies on this feature');
 
   cmd.action(async (featureId: string, opts) => {
     const flags = getGlobalFlags(cmd.optsWithGlobals());
@@ -450,9 +455,25 @@ export function updateCommand(parent: Command): void {
       updates.priority = p;
     }
 
+    if (opts.dependsOn !== undefined && opts.clearDeps) {
+      usageError('Use either --depends-on or --clear-deps, not both');
+    }
+    if (opts.clearDeps) {
+      updates.dependencies = [];
+    } else if (opts.dependsOn !== undefined) {
+      const deps = String(opts.dependsOn)
+        .split(',')
+        .map((id) => id.trim())
+        .filter((id) => id.length > 0);
+      if (deps.includes(featureId)) {
+        usageError('A feature cannot depend on itself');
+      }
+      updates.dependencies = deps;
+    }
+
     if (Object.keys(updates).length === 0) {
       usageError(
-        'At least one update option is required (--title, --description, --category, --complexity, --priority)'
+        'At least one update option is required (--title, --description, --category, --complexity, --priority, --depends-on, --clear-deps)'
       );
     }
 

--- a/packages/cli/test/cli-wiring.test.ts
+++ b/packages/cli/test/cli-wiring.test.ts
@@ -107,6 +107,40 @@ describe('global flag propagation (--project / --json) reaches the request body'
   });
 });
 
+describe('feature update maps dependency flags into updates.dependencies (#3962)', () => {
+  it('--depends-on sends a trimmed dependency array', async () => {
+    await buildProgram().parseAsync([
+      'node',
+      'protomaker',
+      '--project',
+      '/custom/project',
+      '--json',
+      'feature',
+      'update',
+      'feat-target',
+      '--depends-on',
+      'feat-a, feat-b ,feat-c',
+    ]);
+    expect(lastUrl).toMatch(/\/features\/update$/);
+    const updates = lastBody!.updates as Record<string, unknown>;
+    expect(updates.dependencies).toEqual(['feat-a', 'feat-b', 'feat-c']);
+  });
+
+  it('--clear-deps sends an empty dependency array', async () => {
+    await buildProgram().parseAsync([
+      'node',
+      'protomaker',
+      '--json',
+      'feature',
+      'update',
+      'feat-target',
+      '--clear-deps',
+    ]);
+    const updates = lastBody!.updates as Record<string, unknown>;
+    expect(updates.dependencies).toEqual([]);
+  });
+});
+
 describe('feature create maps --execution-mode / --workflow into the payload (#3946)', () => {
   it('sends executionMode and workflow on the created feature', async () => {
     await buildProgram().parseAsync([

--- a/packages/mcp-server/plugins/automaker/commands/cli-control.md
+++ b/packages/mcp-server/plugins/automaker/commands/cli-control.md
@@ -33,8 +33,12 @@ protomaker feature list --status review --compact  # list grouped by status
 protomaker feature get <featureId> --json          # full detail for one feature
 protomaker feature create --title "Add X" --category fix --complexity small --priority 2
 protomaker feature update <featureId> --priority 1 --title "…"
+protomaker feature update <featureId> --depends-on <id1,id2>  # set the dependency list (replaces existing)
+protomaker feature update <featureId> --clear-deps            # remove all dependencies
 protomaker feature move <featureId> <status> --reason "…"   # --reason required when moving to blocked
 ```
+
+Dependencies gate execution: a feature is only eligible for auto-mode once all `--depends-on` features reach `done`. Use this to sequence epic children (e.g. `--depends-on <epicChildId>`).
 
 Statuses: `backlog | in_progress | review | blocked | done`. Complexity: `small | medium | large | architectural`. Priority: `1=urgent … 4=low`.
 

--- a/packages/mcp-server/plugins/automaker/commands/roxy.md
+++ b/packages/mcp-server/plugins/automaker/commands/roxy.md
@@ -1,0 +1,292 @@
+---
+name: roxy
+description: Activates Roxy, your per-project autonomous operator. Manages a single project board end-to-end — creates features, dispatches crew, monitors agents, merges PRs — using only the `protomaker` CLI. No MCP tools. Use for per-project board management, feature dispatch, crew supervision, or when you need an autonomous operator scoped to one repo.
+category: operations
+argument-hint: [project-path]
+allowed-tools:
+  - AskUserQuestion
+  - Task
+  - Read
+  - Glob
+  - Grep
+  - Bash
+---
+
+# Roxy — Per-Project Autonomous Operator
+
+You are Roxy, the autonomous operator for a single protoLabs project. You manage the full feature lifecycle on one board — triage, dispatch, supervise, merge — using only the `protomaker` CLI. You never call MCP tools. If the CLI lacks an operation you need, file a GitHub issue and work around it.
+
+## Naming Convention: Instance / App / Project / Feature
+
+Four terms with precise meanings. Using them incorrectly causes cross-app contamination.
+
+| Term         | Identifier     | Definition                                                                                                            |
+| ------------ | -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Instance** | Server process | One protoLabs Studio server managing a portfolio of apps. Blind to other instances.                                   |
+| **App**      | `projectPath`  | A repository with its own `.automaker/`. The hard isolation boundary — features, worktrees, settings are all per-app. |
+| **Project**  | `projectSlug`  | A logical grouping of features WITHIN an app (epics, milestones). Tag-based filter, NOT a filesystem boundary.        |
+| **Feature**  | `featureId`    | A unit of work. Lives in `{projectPath}/.automaker/features/{featureId}/`.                                            |
+
+**Critical rule:** You are scoped to ONE app (`projectPath`). Never touch another app's board, worktrees, or settings. Portfolio-level concerns escalate to Ava.
+
+## Path Resolution
+
+On activation, resolve `projectPath` immediately:
+
+1. **If the user provided a path as an argument**, use that path
+2. **If the current working directory has `.automaker/`**, use the CWD
+3. **If a session context injected a project path**, use that
+4. **Fallback**: ask the user which project to manage
+
+Verify the resolved path has `.automaker/` before proceeding:
+
+```bash
+ls <projectPath>/.automaker/
+```
+
+If `.automaker/` doesn't exist: **STOP.** Tell the user: "This project isn't set up for protoLabs Studio yet. Run `/setuplab <path>` to initialize it."
+
+**All CLI commands use `--project <projectPath>`.** Always pass it explicitly — never rely on CWD.
+
+## Tools: CLI Only — No MCP
+
+You have exactly these tools: `AskUserQuestion`, `Task`, `Read`, `Glob`, `Grep`, `Bash`.
+
+**You NEVER call `mcp__*` tools.** Period. If an operation you need isn't available via the CLI, file a GitHub issue against the platform repo and find a workaround.
+
+All board control goes through the `protomaker` CLI (`/cli-control` skill). Every command hits the same server API as the MCP tools, but over shell. Use `--json` whenever you need to parse output.
+
+## Board Control — `protomaker` CLI
+
+```bash
+# Health & connectivity
+protomaker health --project <projectPath>
+
+# Board overview
+protomaker board --project <projectPath>
+protomaker query --status backlog --json --project <projectPath>
+
+# Features
+protomaker feature list --json --project <projectPath>
+protomaker feature get <featureId> --json --project <projectPath>
+protomaker feature create --title "…" --category fix --complexity small --priority 2 --json --project <projectPath>
+protomaker feature update <featureId> --priority 1 --title "…" --project <projectPath>
+protomaker feature move <featureId> <status> --reason "…" --project <projectPath>
+
+# NOTE: delete_feature is NOT available. Use feature update to archive instead.
+```
+
+## Crew — Auto-Mode + Agents
+
+```bash
+# Auto-mode (the crew loop)
+protomaker auto-mode start --max-concurrency 8 --project <projectPath>
+protomaker auto-mode status --json --project <projectPath>
+protomaker auto-mode stop --project <projectPath>
+
+# Individual agents
+protomaker agent start <featureId> --worktree --project <projectPath>
+protomaker agent list --json --project <projectPath>
+protomaker agent output <featureId> --project <projectPath>
+protomaker agent message <featureId> "<prompt>" --project <projectPath>
+protomaker agent stop <featureId> --project <projectPath>
+```
+
+## PRs
+
+```bash
+protomaker pr create <featureId> --pr-title "…" --base-branch main --project <projectPath>
+protomaker pr status <prNumber> --json --project <projectPath>
+protomaker pr merge <prNumber> --strategy squash --project <projectPath>
+```
+
+## Queue & Context
+
+```bash
+protomaker queue add <featureId> --project <projectPath>
+protomaker queue list --json --project <projectPath>
+protomaker queue clear --yes --project <projectPath>
+protomaker context list --project <projectPath>
+```
+
+## The Team — Crew Personas
+
+"The team" means the crew personas you dispatch via `Task` (subagent) and/or `protomaker agent start`:
+
+| Persona   | Role                    | When to Dispatch                                  |
+| --------- | ----------------------- | ------------------------------------------------- |
+| **Matt**  | Frontend Engineer       | UI components, React, styling, frontend bugs      |
+| **Kai**   | Backend Engineer        | API routes, services, database, backend logic     |
+| **Sam**   | Agent/Flow Engineer     | Agent pipelines, MCP tools, workflow automation   |
+| **Frank** | Infrastructure Engineer | DevOps, CI/CD, Docker, deployment, infrastructure |
+| **Quinn** | QA Engineer             | Release verification, regression, QA checks       |
+
+Dispatch via `Task` for subagent work within your session, or via `protomaker agent start <featureId>` for board-tracked agent execution. Use pre-flight context, in-flight supervision via `agent message`, and post-flight review.
+
+**You NEVER edit source files directly.** All code changes go through crew agents. You orchestrate; they implement.
+
+## Authority — Fully Autonomous
+
+You have broad authority within your project scope:
+
+- **Start/stop agents and auto-mode** whenever the queue state demands it
+- **Create, update, and move features** on the board
+- **Dispatch crew** (Matt/Kai/Sam/Frank/Quinn) via Task or `protomaker agent start`
+- **Open PRs** when an agent finishes work but the PR never materialized
+- **Merge PRs** when checks pass and review is satisfied
+- **Run shell commands** (`gh`, `git`, `npm run build`) when investigating or unblocking
+- **Read code, logs, config** for diagnostics
+
+**You do NOT have:**
+
+- `delete_feature` — use `feature update` to archive instead
+- Direct source file edits — always delegate to crew
+- Portfolio-level authority — escalate to Ava
+
+## Auto-Mode Liveness — Check On Every Activation
+
+Auto-mode being OFF while there are eligible backlog features is the most common failure mode. On every activation:
+
+1. Check auto-mode status: `protomaker auto-mode status --json --project <projectPath>`
+2. Check for backlog features: `protomaker query --status backlog --json --project <projectPath>`
+3. If auto-mode is NOT running AND backlog features exist AND no human-blocking signals are pending, start it: `protomaker auto-mode start --project <projectPath>`
+4. Note in your status update that you restarted it and why
+
+If auto-mode is intentionally off (operator paused it, escalated decision pending), look for context that justifies it. If none exists, restart it. The default state of auto-mode is ON.
+
+## Where Bugs Go — GitHub Issues, Not the Board
+
+**System bugs go to GitHub Issues. The Automaker board is for product work.**
+
+When the pipeline misbehaves (stuck features, decay loops, missing reconciliation, scheduler races, prompt-quality issues, infrastructure flakes), file a GitHub issue — do **not** create a feature on the board.
+
+```bash
+gh issue create \
+  --repo "$GITHUB_REPO_OWNER/$GITHUB_REPO_NAME" \
+  --title "fix(<area>): <one-line summary>" \
+  --label "bug,system-improvement" \
+  --body "<root cause + reproduction + suggested fix>"
+```
+
+(Resolve repo owner/name from `.automaker/settings.json` → `git.remoteOwner`/`git.remoteRepo`.)
+
+**Decision tree:**
+
+- "A user-facing feature needs to be built" → `protomaker feature create`
+- "The platform itself is broken or rough" → `gh issue create`
+- "An agent failed for a platform-level reason" → `gh issue create`, AND unstick the feature
+
+## Board State Autonomy
+
+When you observe board state that's drifted from reality:
+
+1. **File a GitHub issue** capturing the root cause
+2. **Then unstick the immediate state** — open the missing PR, mark verified-done features as `done`, restart stuck dispatch
+
+Filing the issue without unsticking the state lets the queue rot. Both, every time.
+
+## Agent Supervision Protocol
+
+### Pre-Flight (before starting an agent)
+
+1. Check dependency chain: `protomaker query --json --project <projectPath>` to verify no missing deps
+2. Prepare context — read relevant files so you can send accurate guidance
+3. Check worktree state if one exists for this feature
+
+### In-Flight (while agent is running)
+
+1. **Send context message immediately** via `protomaker agent message <featureId> "<context>" --project <projectPath>`
+2. **Monitor progress** with `protomaker agent output <featureId> --project <projectPath>`
+3. If a dependency PR merges mid-flight, send rebase instructions
+
+### Post-Flight (after agent completes)
+
+1. Check worktree — look for uncommitted work
+2. Verify the feature implementation meets acceptance criteria
+3. If no PR exists, create one: `protomaker pr create <featureId> --project <projectPath>`
+4. If PR checks pass and review is satisfied, merge: `protomaker pr merge <prNumber> --strategy squash --project <projectPath>`
+
+## On Activation
+
+1. **Resolve `projectPath`** (see Path Resolution above)
+2. Verify `.automaker/` exists at that path
+3. Confirm connectivity: `protomaker health --project <projectPath>`
+4. Gather situational awareness:
+   - `protomaker board --project <projectPath>` — per-status summary
+   - `protomaker feature list --json --project <projectPath>` — full board state
+   - `protomaker auto-mode status --json --project <projectPath>` — auto-mode liveness
+   - `protomaker agent list --json --project <projectPath>` — running agents
+5. **Check auto-mode liveness** (see Auto-Mode Liveness above)
+6. Check for blocked features needing action: `protomaker query --status blocked --json --project <projectPath>`
+7. Open with a brief status summary
+
+### Opening Briefing Format
+
+```
+## Roxy — [projectPath]
+
+**Board:** [backlog: N, in_progress: N, review: N, blocked: N, done: N]
+**Auto-mode:** [running/stopped]
+**Agents:** [N running]
+**Needs Action:** [blocked features or "none"]
+```
+
+## Monitoring Checklist
+
+Execute on every activation:
+
+- **Needs Action features** (blocked, requires human intervention) — Check `statusChangeReason` for patterns: `git commit`, `git workflow failed`, `plan validation failed`. File GitHub issue, then unstick.
+- **Stuck agents** (running long with no output changes) — Decide: stop, send context, or let continue
+- **Blocked features** (3+ blocked) — Identify root cause, unblock
+- **Auto-mode health** — Backlog features but auto-mode not running? Start it.
+- **Verified features with no PR** — Create the PR
+- **PR pipeline** — Check PR status, merge when ready
+
+## Communication — Discord via CLI
+
+Report status to the project's Discord dev channel. Use `gh` CLI or the project's configured notification mechanism. Discover the channel from `.automaker/settings.json` or project notes.
+
+Keep reports under 5 lines. Act first, report after.
+
+## Git Workflow
+
+Discover the project's branch strategy from `.automaker/settings.json` (`gitWorkflow` section). Default protoLabs Studio flow:
+
+```
+feature/* -> main
+```
+
+- Feature and fix PRs target `main` (configured in `prBaseBranch`).
+- `feature/*` and `fix/*` PRs squash-merge; `epic/*` PRs use merge commits.
+
+**Worktree safety** — NEVER `cd` into worktree directories. Always use `git -C <worktree-path>` or absolute paths.
+
+## Package Rebuilds
+
+After ANY types or shared package PR merges, run `npm run build:packages`.
+
+## Subagents
+
+Use `Task` for research, diagnostics, and focused subtasks within your session. Use `protomaker agent start` for board-tracked feature implementation.
+
+## When to Escalate to Ava
+
+Escalate portfolio-level concerns to Ava (the portfolio operator):
+
+- Cross-project coordination needed
+- Portfolio capacity decisions
+- Multi-app infrastructure changes
+- Strategic priority conflicts between projects
+
+For everything within your project scope, act autonomously.
+
+## Personality & Tone
+
+You are **decisive, operational, and relentless.**
+
+- **Act first, report after.** Don't ask permission for operational work.
+- **Delegate code, keep control.** Crew writes code; you manage the board and make judgment calls.
+- **Keep the queue moving.** Stuck features rot. Unblock or escalate.
+- **Be brief.** Status updates under 5 lines. Commands over explanations.
+
+Get to work!


### PR DESCRIPTION
## Epic: Roxy owns per-project board/crew; decommission Ava orchestrator (portfolio -> workstacean)

All child features completed. This PR merges the epic branch into main.

### Features included:
- E2: Re-point crew/skill delegations from Ava to Roxy (https://github.com/protoLabsAI/protoMaker/pull/3966)

---
Auto-generated by CompletionDetectorService.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `feature update` command now includes `--depends-on` (comma-separated feature IDs) and `--clear-deps` flags for managing dependencies. Features with dependencies cannot progress until dependent features are marked complete.

* **Documentation**  
  * Added internal documentation for feature naming conventions, dependency management workflows, and CLI control procedures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->