### PR TITLE
fix(recovery): worktree-recovery preserves work only — single guarded PR chokepoint (#3979)

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -1241,35 +1241,14 @@ Output the branch name only.`,
         );
         if (recoveryResult.detected) {
           if (recoveryResult.recovered) {
-            // Recovery committed, pushed, and created a PR.
-            // Update feature status to 'review' and emit completion so
-            // lead-engineer-service waitForCompletion resolves.
+            // Recovery preserved the agent's work (commit + push). It does NOT
+            // create a PR — that is owned by the single guarded chokepoint
+            // (runPostCompletionWorkflow, below), which enforces the epic-base
+            // invariant. Fall through (no early return) so the work flows into
+            // it. See CLAUDE.md "Philosophy: protoMaker Is a Pure Executor".
             logger.info(
-              `[PostAgentHook] Recovered uncommitted work for ${featureId}: PR at ${recoveryResult.prUrl}`
+              `[PostAgentHook] Preserved uncommitted work for ${featureId} on ${feature.branchName ?? 'branch'} — proceeding to the guarded git workflow for PR creation`
             );
-            await this.featureLoader.update(projectPath, featureId, {
-              status: 'review',
-              prUrl: recoveryResult.prUrl,
-              ...(recoveryResult.prNumber !== undefined && {
-                prNumber: recoveryResult.prNumber,
-              }),
-              ...(recoveryResult.prCreatedAt && { prCreatedAt: recoveryResult.prCreatedAt }),
-            });
-            this.typedEventBus.emitAutoModeEvent('auto_mode_git_workflow', {
-              featureId,
-              pushed: true,
-              prUrl: recoveryResult.prUrl,
-              prNumber: recoveryResult.prNumber,
-              projectPath,
-            });
-            this.events.emit('feature:completed', {
-              projectPath,
-              featureId,
-              featureTitle: feature.title,
-              projectSlug: feature.projectSlug,
-              status: 'review',
-            });
-            return;
           } else {
             // Recovery failed — mark as blocked and surface error to waitForCompletion
             const reason = `git workflow failed — uncommitted work in worktree at ${workDir}: ${recoveryResult.error ?? 'unknown'}`;

--- a/apps/server/src/services/auto-mode/post-execution-middleware.ts
+++ b/apps/server/src/services/auto-mode/post-execution-middleware.ts
@@ -131,33 +131,15 @@ export class PostExecutionMiddleware {
 
         if (result.detected) {
           if (result.recovered) {
+            // Recovery preserved the agent's work (commit + push) — it does NOT
+            // create a PR or force a status change (pure-executor: PR creation
+            // is the guarded chokepoint's job; this is a finally-net). On the
+            // success path the inline workflow already created the PR (so this
+            // is a no-op); on error/abort paths the work is now safely on the
+            // branch for retry/human follow-up. See CLAUDE.md "Pure Executor".
             logger.info(
-              `[PostExecution] ${featureId}: recovery succeeded — PR created at ${result.prUrl}`
+              `[PostExecution] ${featureId}: preserved uncommitted work on the feature branch (commit + push) — no PR created here`
             );
-
-            // Move feature to 'review' status now that a recovery PR exists.
-            if (ctx.updateFeatureStatus) {
-              try {
-                await ctx.updateFeatureStatus(projectPath, featureId, 'review');
-                logger.info(`[PostExecution] ${featureId}: feature status updated to 'review'`);
-              } catch (statusError) {
-                logger.error(
-                  `[PostExecution] ${featureId}: failed to update feature status to 'review':`,
-                  statusError
-                );
-              }
-            }
-
-            // Emit a recovery event so listeners can react (e.g. UI, Discord).
-            if (ctx.emitEvent) {
-              ctx.emitEvent('auto_mode_recovery_pr_created', {
-                featureId,
-                projectPath,
-                prUrl: result.prUrl,
-                prNumber: result.prNumber,
-                prCreatedAt: result.prCreatedAt,
-              });
-            }
           } else {
             logger.warn(
               `[PostExecution] ${featureId}: uncommitted work detected but recovery failed: ${result.error}`
@@ -235,34 +217,12 @@ export class PostExecutionMiddleware {
             );
 
             if (nestedRecovery.detected && nestedRecovery.recovered) {
+              // Preserved nested work onto the feature branch (commit + push).
+              // No PR / no forced status change — the guarded chokepoint owns
+              // PR creation. See CLAUDE.md "Pure Executor".
               logger.info(
-                `[PostExecution] ${featureId}: nested worktree recovery succeeded — PR at ${nestedRecovery.prUrl}`
+                `[PostExecution] ${featureId}: preserved nested worktree work on the feature branch (commit + push) — no PR created here`
               );
-
-              if (ctx.updateFeatureStatus) {
-                try {
-                  await ctx.updateFeatureStatus(projectPath, featureId, 'review');
-                  logger.info(
-                    `[PostExecution] ${featureId}: feature status updated to 'review' (nested recovery)`
-                  );
-                } catch (statusError) {
-                  logger.error(
-                    `[PostExecution] ${featureId}: failed to update feature status after nested recovery:`,
-                    statusError
-                  );
-                }
-              }
-
-              if (ctx.emitEvent) {
-                ctx.emitEvent('auto_mode_recovery_pr_created', {
-                  featureId,
-                  projectPath,
-                  prUrl: nestedRecovery.prUrl,
-                  prNumber: nestedRecovery.prNumber,
-                  prCreatedAt: nestedRecovery.prCreatedAt,
-                  source: 'nested_worktree',
-                });
-              }
             } else if (nestedRecovery.detected && !nestedRecovery.recovered) {
               logger.warn(
                 `[PostExecution] ${featureId}: nested worktree recovery failed: ${nestedRecovery.error}`

--- a/apps/server/src/services/worktree-recovery-service.ts
+++ b/apps/server/src/services/worktree-recovery-service.ts
@@ -2,7 +2,10 @@
  * Worktree Recovery Service - Post-agent uncommitted work detection and recovery
  *
  * After every agent exits, scans the worktree for uncommitted changes and
- * attempts auto-recovery: format → stage → commit → push → PR creation.
+ * preserves them: format → stage → commit → push. It does NOT create a PR —
+ * PR creation is owned by the single guarded chokepoint
+ * (git-workflow-service.runPostCompletionWorkflow). See CLAUDE.md
+ * "Philosophy: protoMaker Is a Pure Executor".
  * Returns structured results; callers are responsible for status updates and events.
  */
 
@@ -15,7 +18,6 @@ import type { Feature } from '@protolabsai/types';
 import { DEFAULT_GIT_WORKFLOW_SETTINGS } from '@protolabsai/types';
 import { buildGitAddArgs } from '../lib/git-staging-utils.js';
 import { createGitExecEnv, safeGit, safeExec, assertSafeRef } from '@protolabsai/git-utils';
-import { createPrWithFallback } from '../lib/gh-pr-create.js';
 
 const execFileAsync = promisify(execFile);
 const logger = createLogger('WorktreeRecovery');
@@ -25,14 +27,8 @@ const execEnv = createGitExecEnv();
 export interface WorktreeRecoveryResult {
   /** Whether any uncommitted changes were detected */
   detected: boolean;
-  /** Whether recovery succeeded (commit + push + PR) */
+  /** Whether recovery succeeded (work preserved: commit + push). PR creation is NOT done here. */
   recovered: boolean;
-  /** PR URL if one was created */
-  prUrl?: string;
-  /** PR number if one was created */
-  prNumber?: number;
-  /** PR creation timestamp */
-  prCreatedAt?: string;
   /** Error message if recovery failed */
   error?: string;
 }
@@ -247,55 +243,16 @@ export async function checkAndRecoverUncommittedWork(
 
     logger.info(`[PostAgentHook] Pushed branch ${branchName} for feature ${feature.id}`);
 
-    // Step 5: Create PR via gh CLI targeting main
-    const prTitle = (feature.title || commitTitle).replace(/"/g, "'");
-    const summary = feature.description.substring(0, 500);
-    const ellipsis = feature.description.length > 500 ? '...' : '';
-    const prBody =
-      `## Summary\n\n${summary}${ellipsis}\n\n---\n*Recovered automatically by Automaker post-agent hook*`.replace(
-        /"/g,
-        "'"
-      );
-
-    const prResult = await createPrWithFallback({
-      cwd: worktreePath,
-      env: execEnv,
-      base: baseBranch,
-      head: branchName,
-      title: prTitle,
-      body: prBody,
-    });
-
-    const prUrl = prResult.url;
-    const prNumber = prResult.number;
-    logger.info(`[PostAgentHook] PR created via ${prResult.via}: ${prUrl}`);
-
-    result.prUrl = prUrl;
-    result.prNumber = prNumber;
-    result.prCreatedAt = new Date().toISOString();
+    // Work is now preserved (committed + pushed). PR creation is intentionally
+    // NOT done here — see CLAUDE.md "Philosophy: protoMaker Is a Pure Executor".
+    // There is exactly one guarded PR-creation chokepoint
+    // (git-workflow-service.runPostCompletionWorkflow), which enforces the
+    // epic-base invariant. This safety net only ensures the agent's work isn't
+    // lost; the caller funnels through the chokepoint to create the PR.
     result.recovered = true;
 
-    // Enable auto-merge so PRs don't sit BLOCKED waiting for manual intervention
-    // Use --merge for epic PRs to preserve DAG integrity
-    if (prNumber) {
-      const mergeFlag =
-        baseBranch === 'main' || baseBranch.startsWith('epic/') ? '--merge' : '--squash';
-      try {
-        await execFileAsync('gh', ['pr', 'merge', String(prNumber), '--auto', mergeFlag], {
-          cwd: worktreePath,
-          env: execEnv,
-        });
-        logger.info(`[PostAgentHook] Auto-merge enabled on PR #${prNumber} (${mergeFlag})`);
-      } catch (autoMergeError) {
-        logger.warn(
-          `[PostAgentHook] Failed to enable auto-merge on PR #${prNumber}:`,
-          autoMergeError
-        );
-      }
-    }
-
     logger.info(
-      `[PostAgentHook] Recovery successful for feature ${feature.id}: PR created at ${prUrl}`
+      `[PostAgentHook] Recovery preserved work for feature ${feature.id} on branch ${branchName} (commit + push); PR creation deferred to the guarded git workflow`
     );
 
     return result;

--- a/apps/server/tests/unit/services/post-execution-middleware.test.ts
+++ b/apps/server/tests/unit/services/post-execution-middleware.test.ts
@@ -125,13 +125,10 @@ describe('PostExecutionMiddleware', () => {
       expect(emitEvent).not.toHaveBeenCalled();
     });
 
-    it('updates feature status to review and emits event on successful recovery', async () => {
+    it('preserves work but does NOT change status or emit a PR event on successful recovery', async () => {
       mockCheckAndRecoverUncommittedWork.mockResolvedValueOnce({
         detected: true,
         recovered: true,
-        prUrl: 'https://github.com/owner/repo/pull/42',
-        prNumber: 42,
-        prCreatedAt: '2024-01-01T00:00:00Z',
       });
 
       const updateFeatureStatus = vi.fn(async () => {});
@@ -140,19 +137,14 @@ describe('PostExecutionMiddleware', () => {
 
       await middleware.run(ctx);
 
-      expect(updateFeatureStatus).toHaveBeenCalledWith(
-        '/mock/project',
-        'feature-test-001',
-        'review'
+      // Pure-executor invariant (#3979): the safety net preserves work
+      // (commit + push) but never creates a PR, forces a status change, or
+      // emits a PR-created event — PR creation is the guarded chokepoint's job.
+      expect(updateFeatureStatus).not.toHaveBeenCalled();
+      expect(emitEvent).not.toHaveBeenCalledWith(
+        'auto_mode_recovery_pr_created',
+        expect.anything()
       );
-
-      expect(emitEvent).toHaveBeenCalledWith('auto_mode_recovery_pr_created', {
-        featureId: 'feature-test-001',
-        projectPath: '/mock/project',
-        prUrl: 'https://github.com/owner/repo/pull/42',
-        prNumber: 42,
-        prCreatedAt: '2024-01-01T00:00:00Z',
-      });
     });
 
     it('emits recovery_failed event when detection succeeds but recovery fails', async () => {
@@ -176,30 +168,6 @@ describe('PostExecutionMiddleware', () => {
         projectPath: '/mock/project',
         error: 'git push failed: remote rejected',
       });
-    });
-
-    it('does not throw when updateFeatureStatus rejects', async () => {
-      mockCheckAndRecoverUncommittedWork.mockResolvedValueOnce({
-        detected: true,
-        recovered: true,
-        prUrl: 'https://github.com/owner/repo/pull/7',
-        prNumber: 7,
-        prCreatedAt: '2024-01-01T00:00:00Z',
-      });
-
-      const updateFeatureStatus = vi.fn(async () => {
-        throw new Error('database write failed');
-      });
-      const emitEvent = vi.fn();
-      const ctx = makeContext({ updateFeatureStatus, emitEvent });
-
-      // Must not throw — middleware swallows all errors
-      await expect(middleware.run(ctx)).resolves.toBeUndefined();
-
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        expect.stringContaining("failed to update feature status to 'review'"),
-        expect.any(Error)
-      );
     });
 
     it('skips safety net and status update when feature is null', async () => {

--- a/apps/server/tests/unit/services/worktree-recovery-service.test.ts
+++ b/apps/server/tests/unit/services/worktree-recovery-service.test.ts
@@ -24,6 +24,18 @@ import { execFile } from 'child_process';
 
 const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
 
+/**
+ * Pure-executor invariant (#3979): the recovery net must never run
+ * `gh pr create` or `gh pr merge`. Asserts no such command was issued.
+ */
+function noPrWasCreated(mock: ReturnType<typeof vi.fn>): boolean {
+  return !mock.mock.calls.some((call) => {
+    const cmd = call[0];
+    const args = Array.isArray(call[1]) ? (call[1] as string[]) : [];
+    return cmd === 'gh' && args[0] === 'pr' && (args[1] === 'create' || args[1] === 'merge');
+  });
+}
+
 const baseFeature: Feature = {
   id: 'feature-test-001',
   title: 'Test feature',
@@ -72,7 +84,7 @@ describe('worktree-recovery-service', () => {
       expect(result.error).toContain('no branchName set on feature');
     });
 
-    it('successfully recovers uncommitted work (commit + push + PR)', async () => {
+    it('preserves uncommitted work (commit + push) and does NOT create a PR', async () => {
       // git status --short: uncommitted files
       mockExecFile.mockResolvedValueOnce({ stdout: 'M  src/index.ts\n', stderr: '' });
       // git add (step 1: stage)
@@ -93,11 +105,7 @@ describe('worktree-recovery-service', () => {
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git push --force-with-lease
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // gh pr create (execFileAsync)
-      mockExecFile.mockResolvedValueOnce({
-        stdout: 'https://github.com/owner/repo/pull/42\n',
-        stderr: '',
-      });
+      // NOTE: no `gh pr create` mock — recovery no longer creates PRs.
 
       const result = await checkAndRecoverUncommittedWork(
         baseFeature,
@@ -107,10 +115,10 @@ describe('worktree-recovery-service', () => {
 
       expect(result.detected).toBe(true);
       expect(result.recovered).toBe(true);
-      expect(result.prUrl).toBe('https://github.com/owner/repo/pull/42');
-      expect(result.prNumber).toBe(42);
-      expect(result.prCreatedAt).toBeDefined();
       expect(result.error).toBeUndefined();
+      // Pure-executor invariant (#3979): recovery preserves work but creates NO
+      // PR — PR creation is the single guarded chokepoint's job.
+      expect(noPrWasCreated(mockExecFile)).toBe(true);
     });
 
     it('invokes project-local prettier with --ignore-path /dev/null on staged files', async () => {
@@ -234,11 +242,6 @@ describe('worktree-recovery-service', () => {
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git push --force-with-lease succeeds
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // gh pr create (execFileAsync)
-      mockExecFile.mockResolvedValueOnce({
-        stdout: 'https://github.com/owner/repo/pull/99\n',
-        stderr: '',
-      });
 
       const result = await checkAndRecoverUncommittedWork(
         baseFeature,
@@ -249,7 +252,7 @@ describe('worktree-recovery-service', () => {
       // Recovery should succeed even though formatting failed
       expect(result.detected).toBe(true);
       expect(result.recovered).toBe(true);
-      expect(result.prNumber).toBe(99);
+      expect(noPrWasCreated(mockExecFile)).toBe(true);
     });
 
     it('recovers when rebase conflicts — pushes without force-with-lease', async () => {
@@ -277,11 +280,6 @@ describe('worktree-recovery-service', () => {
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git push (NO --force-with-lease since rebase was aborted)
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // gh pr create (execFileAsync)
-      mockExecFile.mockResolvedValueOnce({
-        stdout: 'https://github.com/owner/repo/pull/55\n',
-        stderr: '',
-      });
 
       const result = await checkAndRecoverUncommittedWork(
         baseFeature,
@@ -291,7 +289,7 @@ describe('worktree-recovery-service', () => {
 
       expect(result.detected).toBe(true);
       expect(result.recovered).toBe(true);
-      expect(result.prNumber).toBe(55);
+      expect(noPrWasCreated(mockExecFile)).toBe(true);
     });
 
     it('recovers when rebase fails for non-conflict reason — aborts and pushes normally', async () => {
@@ -315,11 +313,6 @@ describe('worktree-recovery-service', () => {
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
       // git push (NO --force-with-lease)
       mockExecFile.mockResolvedValueOnce({ stdout: '', stderr: '' });
-      // gh pr create (execFileAsync)
-      mockExecFile.mockResolvedValueOnce({
-        stdout: 'https://github.com/owner/repo/pull/77\n',
-        stderr: '',
-      });
 
       const result = await checkAndRecoverUncommittedWork(
         baseFeature,
@@ -329,7 +322,7 @@ describe('worktree-recovery-service', () => {
 
       expect(result.detected).toBe(true);
       expect(result.recovered).toBe(true);
-      expect(result.prNumber).toBe(77);
+      expect(noPrWasCreated(mockExecFile)).toBe(true);
     });
   });
 


### PR DESCRIPTION
Fixes #3979. First code application of the pure-executor principle (#3978 / CLAUDE.md).

## Problem
The worktree-recovery net (`worktree-recovery-service.ts`, PostAgentHook) was a **parallel PR-creation path**: on uncommitted work it committed, pushed, ran `gh pr create` (base defaulting to `main`), and enabled `--auto` merge — bypassing the epic-base guard in `runPostCompletionWorkflow`. A synthetic validation epic caught an epic child landing a PR on `main` this way and auto-merging it (#3970). The unit/integration tests for the guard never exercised this path.

## Fix (Option B — single chokepoint)
- **`worktree-recovery-service.ts`**: remove PR creation + auto-merge. Recovery now ends at commit + push (preserve work). `WorktreeRecoveryResult` no longer carries `prUrl`/`prNumber`/`prCreatedAt`; `recovered` means "work preserved".
- **`execution-service.ts`** (success path): on `recovered`, fall through to `runPostCompletionWorkflow` (the one guarded PR creator) instead of returning with a recovery PR. Verified the fall-through reaches the chokepoint (no stranding).
- **`post-execution-middleware.ts`** (all-paths finally net): on `recovered`, preserve only — no forced `review`, no `auto_mode_recovery_pr_created` event. A crashed/aborted run no longer auto-PRs itself (more correct).
- Tests updated to assert the new contract: recovery creates **no** PR (`noPrWasCreated` helper; middleware asserts no status change / no PR event).

## Verification
- `npm run typecheck` clean.
- Full server suite green: **3549 passed**, 0 failed.
- End-to-end: re-run a synthetic epic against this build — every child PRs to the epic branch, none to main, none auto-merged by recovery. (Pending merge + staging restart.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the auto-mode recovery workflow to separate work preservation from PR creation. Recovery now commits and pushes uncommitted changes without immediately creating a pull request; PR creation is now deferred to a later validation step in the workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3984?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->