### PR TITLE
feat(engine): pass channelContext through /api/engine/signal/submit (board-ingestion intake)

### DIFF
--- a/apps/server/src/routes/engine/index.ts
+++ b/apps/server/src/routes/engine/index.ts
@@ -343,8 +343,16 @@ export function createEngineRoutes(
    */
   router.post('/signal/submit', async (req: Request, res: Response) => {
     try {
-      const { projectPath, content, source, images, files, autoApprove, webResearch } = (req.body ??
-        {}) as {
+      const {
+        projectPath,
+        content,
+        source,
+        images,
+        files,
+        autoApprove,
+        webResearch,
+        channelContext,
+      } = (req.body ?? {}) as {
         projectPath?: string;
         content?: string;
         source?: string;
@@ -352,6 +360,11 @@ export function createEngineRoutes(
         files?: string[];
         autoApprove?: boolean;
         webResearch?: boolean;
+        // Source-specific metadata (e.g. GitHub issueNumber + repository for
+        // idempotent intake) passed through to SignalIntakeService. Used by the
+        // protoWorkstacean switchboard's board-ingestion forwarder: it resolves
+        // the project (repo->projectPath) and POSTs the issue here.
+        channelContext?: Record<string, unknown>;
       };
 
       if (!content) {
@@ -371,6 +384,7 @@ export function createEngineRoutes(
         files,
         autoApprove,
         webResearch,
+        channelContext,
       });
 
       res.json({


### PR DESCRIPTION
Reframes #3975 per the switchboard model (protoWorkstacean ADR-0001/0002). Since workstacean already receives every project repo's GitHub webhooks AND owns the repo→project registry, it resolves the project and forwards to a protoMaker HTTP intake — protoMaker no longer needs to receive webhooks or route by repo.

The intake is the existing `POST /api/engine/signal/submit` → `SignalIntakeService.submitSignal()`, which already dedups on `github:repo#issue`, honors `channelContext.projectPath`, and creates a backlog `idea`. The only gap was the route not forwarding `channelContext` — this adds that passthrough.

**Contract for the workstacean forwarder** (X-API-Key auth):
```
POST /api/engine/signal/submit
{ source: 'github', content: '<title>\n\n<body>', projectPath: '<ws-resolved>',
  channelContext: { issueNumber, repository, labels, author } }
```
Double-handling is handled on the switchboard side (ws decides what to forward), so no in-protoMaker label filter is needed.

typecheck clean; signal-intake suite green (276 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)