### PR TITLE
fix(ci): registry cache for image builds (unblock deploys, #3993)

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -65,7 +65,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Scope the GHA cache per target so the ui/server builds don't evict
-          # each other's layers.
-          cache-from: type=gha,scope=${{ matrix.target }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.target }}
+          # Registry cache (not type=gha): the GHA cache backend hands out a
+          # ~10-min SAS token, but the server image build runs longer than that,
+          # so the cached-layer fetch 403'd mid-build and blocked every deploy
+          # (protoMaker#3993). Registry cache is stored in GHCR alongside the
+          # image (packages:write is already granted) — no expiring token.
+          # Per-target ref so ui/server don't evict each other's layers.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/protolabsai/${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/protolabsai/${{ matrix.image }}:buildcache,mode=max


### PR DESCRIPTION
Fixes #3993. The `protomaker-server` image build runs >10 min; the buildx `type=gha` cache hands out a ~10-min SAS token that expired mid-build, 403ing the cached-layer fetch and **failing every deploy** (so #3992 + everything since never reached `protomaker-server`).

Switches the cache to `type=registry` (GHCR `:buildcache` per target) — stored alongside the image, no expiring token. `packages:write` is already granted. First run after merge is a full uncached build (slow but reliable, no 403), then subsequent builds read the registry cache.

Merging this triggers a publish run on `main` (which already has #3992), so a green run here ships the backlog of merged work to `protomaker-server` → watchtower deploys → protoContent#12 round-trip becomes verifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker image build caching configuration to optimize build performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->