### PR TITLE
fix(signal-intake): route GitHub-issue signals to the correct project by repo (#3975)

### DIFF
--- a/apps/server/src/routes/github/routes/webhook.ts
+++ b/apps/server/src/routes/github/routes/webhook.ts
@@ -90,12 +90,16 @@ async function handleIssueEvent(
     deliveryService.trackDelivery('github', 'issues', undefined, { deduplicationKey });
   }
 
-  // Emit event for logging and potential auto-creation
+  // Emit event for logging and potential auto-creation.
+  // Field shape is shared with the global webhook route (routes/webhooks/routes/github.ts)
+  // and consumed by IntegrationService.handleGitHubIssue — keep them in sync.
   events.emit('webhook:github:issue', {
     action,
     issueNumber: issue.number,
-    issueTitle: issue.title,
-    issueBody: issue.body,
+    title: issue.title,
+    body: issue.body || '',
+    author: issue.user.login,
+    createdAt: issue.created_at,
     issueUrl: issue.html_url,
     repository: repository.full_name,
     projectPath,

--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -53,9 +53,11 @@ interface GitHubIssuePayload {
     body: string | null;
     state: string;
     created_at: string;
+    html_url: string;
     user: {
       login: string;
     };
+    labels?: Array<{ name: string }>;
   };
   repository: {
     full_name: string;
@@ -369,7 +371,10 @@ export function createGitHubWebhookHandler(
             `GitHub issue #${issuePayload.issue.number} created: ${issuePayload.issue.title}`
           );
 
-          // Emit issue detected event for signal intake
+          // Emit issue detected event for signal intake.
+          // Field shape is shared with the per-project webhook route
+          // (routes/github/routes/webhook.ts). This global route has no projectPath —
+          // signal intake resolves the target project from `repository` (see #3975).
           events.emit('webhook:github:issue', {
             action: 'opened',
             issueNumber: issuePayload.issue.number,
@@ -377,7 +382,9 @@ export function createGitHubWebhookHandler(
             body: issuePayload.issue.body || '',
             author: issuePayload.issue.user.login,
             createdAt: issuePayload.issue.created_at,
+            issueUrl: issuePayload.issue.html_url,
             repository: issuePayload.repository.full_name,
+            labels: issuePayload.issue.labels?.map((l) => l.name) || [],
           });
         }
 

--- a/apps/server/src/services/integration-service.ts
+++ b/apps/server/src/services/integration-service.ts
@@ -823,10 +823,34 @@ export class IntegrationService {
       return;
     }
 
-    // All new GitHub issues are treated as signals
+    // Intake gate (#3991): respect the configured GitHub-issue intake policy so
+    // this instance does not grab every opened issue when another receiver
+    // (e.g. protoWorkstacean) also processes the org's issues.
+    const intake = (await this.settingsService?.getGlobalSettings())?.githubIssueIntake;
+    const intakeEnabled = intake?.enabled ?? true;
+    const requiredLabel = intake?.requiredLabel ?? 'board-intake';
+
+    if (!intakeEnabled) {
+      logger.debug(
+        `GitHub-issue intake disabled — skipping issue #${payload.issueNumber} from ${payload.repository}`
+      );
+      return;
+    }
+
+    if (requiredLabel) {
+      const labels = (payload.labels ?? []).map((l) => l.toLowerCase());
+      if (!labels.includes(requiredLabel.toLowerCase())) {
+        logger.debug(
+          `GitHub issue #${payload.issueNumber} from ${payload.repository} lacks the "${requiredLabel}" intake label — skipping`
+        );
+        return;
+      }
+    }
+
     logger.info(`Signal detected from GitHub issue #${payload.issueNumber}: ${payload.title}`, {
       repository: payload.repository,
       author: payload.author,
+      labels: payload.labels,
     });
 
     if (!this.emitter) return;

--- a/apps/server/src/services/integration-service.ts
+++ b/apps/server/src/services/integration-service.ts
@@ -812,6 +812,11 @@ export class IntegrationService {
     author: string;
     createdAt: string;
     repository: string;
+    // Present on the per-project webhook route; absent on the global route, where
+    // signal intake resolves the project from `repository` (#3975).
+    projectPath?: string;
+    labels?: string[];
+    issueUrl?: string;
   }): Promise<void> {
     // Only handle newly opened issues
     if (payload.action !== 'opened') {
@@ -836,6 +841,9 @@ export class IntegrationService {
       channelContext: {
         issueNumber: payload.issueNumber,
         repository: payload.repository,
+        ...(payload.projectPath ? { projectPath: payload.projectPath } : {}),
+        ...(payload.labels ? { labels: payload.labels } : {}),
+        ...(payload.issueUrl ? { issueUrl: payload.issueUrl } : {}),
       },
       timestamp: payload.createdAt,
     });

--- a/apps/server/src/services/maintenance-tasks.ts
+++ b/apps/server/src/services/maintenance-tasks.ts
@@ -180,7 +180,7 @@ export function registerMaintenanceFlows(
   });
 
   registry.register('built-in:stale-worktrees', async () => {
-    const projectPaths = getKnownProjectPaths(autoModeService);
+    const projectPaths = await getKnownProjectPaths(autoModeService, deps.settingsService);
     await detectStaleWorktrees(events, projectPaths, deps.settingsService);
     // Also clean up merged branches (consolidated from built-in:branch-cleanup)
     await checkMergedBranches(events, projectPaths, deps.settingsService);
@@ -190,7 +190,7 @@ export function registerMaintenanceFlows(
   if (deps.integrityWatchdogService) {
     const watchdog = deps.integrityWatchdogService;
     registry.register('built-in:data-integrity', async () => {
-      await checkDataIntegrity(watchdog, events, autoModeService);
+      await checkDataIntegrity(watchdog, events, autoModeService, deps.settingsService);
     });
   }
 
@@ -198,7 +198,7 @@ export function registerMaintenanceFlows(
 
   if (process.env.GITHUB_TOKEN && process.env.GITHUB_REPO_OWNER && process.env.GITHUB_REPO_NAME) {
     registry.register('built-in:runner-health', async () => {
-      const projectPaths = getKnownProjectPaths(autoModeService);
+      const projectPaths = await getKnownProjectPaths(autoModeService, deps.settingsService);
       await checkRunnerHealth(events, projectPaths);
     });
   }
@@ -207,13 +207,36 @@ export function registerMaintenanceFlows(
 }
 
 /**
- * Get known project paths from auto-mode service running agents.
- * Falls back to empty array if no projects are known.
+ * Get known project paths for maintenance sweeps.
+ *
+ * The persisted project registry (`settings.projects`) is the source of truth for
+ * which projects this instance manages — a project is "known" whether or not
+ * auto-mode is currently looping on it. We union the registry with active
+ * auto-loops so that maintenance, runner-health, and data-integrity checks run
+ * against every registered project even when auto-mode is idle. Relying on
+ * active auto-loops alone meant an idle instance reported "No known project
+ * paths" and silently skipped all per-project upkeep (protoLabsAI/protoMaker#3991).
  */
-function getKnownProjectPaths(autoModeService: AutoModeService): string[] {
+async function getKnownProjectPaths(
+  autoModeService: AutoModeService,
+  settingsService?: SettingsService
+): Promise<string[]> {
   const paths = new Set<string>();
 
-  // Add projects with active auto-loops
+  // Source of truth: the persisted project registry.
+  if (settingsService) {
+    try {
+      const settings = await settingsService.getGlobalSettings();
+      for (const project of settings.projects ?? []) {
+        if (project.path) paths.add(project.path);
+      }
+    } catch (error) {
+      logger.warn('Failed to load project registry for maintenance paths:', error);
+    }
+  }
+
+  // Also include any projects with active auto-loops (covers transient projects
+  // not yet persisted to the registry).
   for (const p of autoModeService.getActiveAutoLoopProjects()) {
     paths.add(p);
   }
@@ -682,12 +705,13 @@ async function checkMergedBranches(
 async function checkDataIntegrity(
   integrityWatchdogService: DataIntegrityWatchdogService,
   events: EventEmitter,
-  autoModeService: AutoModeService
+  autoModeService: AutoModeService,
+  settingsService?: SettingsService
 ): Promise<void> {
   logger.info('Running data integrity check...');
 
   try {
-    const projectPaths = getKnownProjectPaths(autoModeService);
+    const projectPaths = await getKnownProjectPaths(autoModeService, settingsService);
 
     if (projectPaths.length === 0) {
       logger.info('No known project paths, skipping data integrity check');

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -387,6 +387,44 @@ export class SignalIntakeService {
     });
   }
 
+  /**
+   * Resolve the target project path for a signal.
+   *
+   * Resolution order (#3975):
+   *   1. An explicit `channelContext.projectPath` (per-project webhook route already knows it).
+   *   2. The project whose registry `github` remote matches `channelContext.repository`
+   *      (full_name "owner/repo"). This routes GitHub-issue signals from the global webhook
+   *      route to the correct board instead of dumping every repo onto the default project.
+   *   3. `defaultProjectPath` fallback.
+   */
+  private async resolveProjectPath(signal: SignalPayload): Promise<string> {
+    const explicit = signal.channelContext?.projectPath;
+    if (explicit) return explicit;
+
+    const repository = signal.channelContext?.repository as string | undefined;
+    if (repository && this.settingsService) {
+      try {
+        const settings = await this.settingsService.getGlobalSettings();
+        const target = repository.toLowerCase();
+        const match = (settings.projects ?? []).find((p) => {
+          if (!p.github) return false;
+          return `${p.github.owner}/${p.github.repo}`.toLowerCase() === target;
+        });
+        if (match?.path) {
+          logger.info(`Routed GitHub signal from ${repository} to project ${match.path}`);
+          return match.path;
+        }
+        logger.warn(
+          `No project registered for repository ${repository}; falling back to default project ${this.defaultProjectPath}`
+        );
+      } catch (error) {
+        logger.warn('Failed to resolve project path from repository:', error);
+      }
+    }
+
+    return this.defaultProjectPath;
+  }
+
   private async handleSignal(signal: SignalPayload): Promise<void> {
     // Deduplicate by source + unique identifier.
     // For GitHub issues, key on repo+issueNumber (canonical issue identity, not author).
@@ -442,7 +480,7 @@ export class SignalIntakeService {
         `Processing signal from ${signal.source}: "${title}" (${classification.category} - ${classification.reason}, intent: ${intent})`
       );
 
-      const projectPath = signal.channelContext?.projectPath || this.defaultProjectPath;
+      const projectPath = await this.resolveProjectPath(signal);
 
       // Push to ring buffer (status: pending)
       const bufferEntry = this.pushToRingBuffer(signal, intent);

--- a/apps/server/tests/unit/services/integration-service-github-intake.test.ts
+++ b/apps/server/tests/unit/services/integration-service-github-intake.test.ts
@@ -1,0 +1,151 @@
+/**
+ * IntegrationService GitHub-issue intake gate (#3991)
+ *
+ * Verifies the `githubIssueIntake` policy: only opened issues that pass the
+ * enabled flag and the required-label filter are converted into board signals.
+ * This is the double-handling boundary that keeps protoMaker from grabbing every
+ * opened issue when another receiver also processes the org's issues.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { IntegrationService } from '../../../src/services/integration-service.js';
+import type { EventEmitter } from '../../../src/lib/events.js';
+import type { FeatureLoader } from '../../../src/services/feature-loader.js';
+import type { SettingsService } from '../../../src/services/settings-service.js';
+import {
+  createMockEventEmitter,
+  createMockFeatureLoader,
+  createMockSettingsService,
+} from '../../helpers/mock-factories.js';
+
+const issuePayload = (overrides: Record<string, unknown> = {}) => ({
+  action: 'opened',
+  issueNumber: 42,
+  title: 'Something needs doing',
+  body: 'Details here',
+  author: 'octocat',
+  createdAt: new Date().toISOString(),
+  repository: 'protoLabsAI/protoContent',
+  labels: ['board-intake'],
+  ...overrides,
+});
+
+const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+describe('IntegrationService — GitHub-issue intake gate (#3991)', () => {
+  let service: IntegrationService;
+  let emitter: ReturnType<typeof createMockEventEmitter>;
+  let settingsService: SettingsService;
+  let featureLoader: FeatureLoader;
+
+  const init = (githubIssueIntake?: { enabled: boolean; requiredLabel: string }) => {
+    settingsService = createMockSettingsService({
+      getGlobalSettings: vi.fn().mockResolvedValue({ githubIssueIntake }),
+    }) as unknown as SettingsService;
+    featureLoader = createMockFeatureLoader([]) as unknown as FeatureLoader;
+    service = new IntegrationService();
+    service.initialize(emitter as unknown as EventEmitter, settingsService, featureLoader);
+  };
+
+  const signalEmitted = () =>
+    (emitter.emit as ReturnType<typeof vi.fn>).mock.calls.some(
+      (call) => call[0] === 'signal:received'
+    );
+
+  beforeEach(() => {
+    emitter = createMockEventEmitter();
+  });
+
+  it('ingests an opened issue carrying the required label', async () => {
+    init({ enabled: true, requiredLabel: 'board-intake' });
+
+    emitter._fire('webhook:github:issue', issuePayload({ labels: ['bug', 'board-intake'] }));
+    await flushAsync();
+
+    expect(signalEmitted()).toBe(true);
+  });
+
+  it('skips an opened issue that lacks the required label', async () => {
+    init({ enabled: true, requiredLabel: 'board-intake' });
+
+    emitter._fire('webhook:github:issue', issuePayload({ labels: ['bug', 'enhancement'] }));
+    await flushAsync();
+
+    expect(signalEmitted()).toBe(false);
+  });
+
+  it('matches the required label case-insensitively', async () => {
+    init({ enabled: true, requiredLabel: 'board-intake' });
+
+    emitter._fire('webhook:github:issue', issuePayload({ labels: ['Board-Intake'] }));
+    await flushAsync();
+
+    expect(signalEmitted()).toBe(true);
+  });
+
+  it('skips all issues when intake is disabled', async () => {
+    init({ enabled: false, requiredLabel: 'board-intake' });
+
+    emitter._fire('webhook:github:issue', issuePayload({ labels: ['board-intake'] }));
+    await flushAsync();
+
+    expect(signalEmitted()).toBe(false);
+  });
+
+  it('ingests any opened issue when requiredLabel is empty', async () => {
+    init({ enabled: true, requiredLabel: '' });
+
+    emitter._fire('webhook:github:issue', issuePayload({ labels: [] }));
+    await flushAsync();
+
+    expect(signalEmitted()).toBe(true);
+  });
+
+  it('defaults to requiring the board-intake label when no policy is configured', async () => {
+    init(undefined);
+
+    emitter._fire('webhook:github:issue', issuePayload({ labels: ['unrelated'] }));
+    await flushAsync();
+    expect(signalEmitted()).toBe(false);
+
+    emitter._fire('webhook:github:issue', issuePayload({ labels: ['board-intake'] }));
+    await flushAsync();
+    expect(signalEmitted()).toBe(true);
+  });
+
+  it('ignores non-opened issue actions regardless of label', async () => {
+    init({ enabled: true, requiredLabel: 'board-intake' });
+
+    emitter._fire(
+      'webhook:github:issue',
+      issuePayload({ action: 'closed', labels: ['board-intake'] })
+    );
+    await flushAsync();
+
+    expect(signalEmitted()).toBe(false);
+  });
+
+  it('forwards projectPath, labels and repository into the signal channelContext', async () => {
+    init({ enabled: true, requiredLabel: 'board-intake' });
+
+    emitter._fire(
+      'webhook:github:issue',
+      issuePayload({ projectPath: '/repos/protocontent', labels: ['board-intake'] })
+    );
+    await flushAsync();
+
+    const signalCall = (emitter.emit as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) => call[0] === 'signal:received'
+    );
+    expect(signalCall).toBeDefined();
+    expect(signalCall![1]).toMatchObject({
+      source: 'github',
+      channelContext: {
+        issueNumber: 42,
+        repository: 'protoLabsAI/protoContent',
+        projectPath: '/repos/protocontent',
+        labels: ['board-intake'],
+      },
+    });
+  });
+});

--- a/apps/server/tests/unit/services/signal-intake-service.test.ts
+++ b/apps/server/tests/unit/services/signal-intake-service.test.ts
@@ -1030,4 +1030,101 @@ describe('SignalIntakeService', () => {
       );
     });
   });
+
+  describe('GitHub signal project routing (#3975)', () => {
+    const projectsSettings = {
+      projects: [
+        {
+          id: 'p1',
+          name: 'protoMaker',
+          path: '/repos/protomaker',
+          github: { owner: 'protoLabsAI', repo: 'protoMaker' },
+        },
+        {
+          id: 'p2',
+          name: 'protoContent',
+          path: '/repos/protocontent',
+          github: { owner: 'protoLabsAI', repo: 'protoContent' },
+        },
+      ],
+    };
+
+    const lastCreateProjectPath = (): string | undefined => {
+      const calls = (mockFeatureLoader.create as any).mock.calls;
+      return calls.length ? calls[calls.length - 1][0] : undefined;
+    };
+
+    it('routes a GitHub issue to the project whose remote matches the repository', async () => {
+      (mockSettingsService.getGlobalSettings as any).mockResolvedValue(projectsSettings);
+
+      mockEmitter.emit(
+        'signal:received',
+        createTestSignal({
+          source: 'github',
+          content: 'Bug fix needed in content pipeline',
+          channelContext: { issueNumber: 12, repository: 'protoLabsAI/protoContent' },
+        })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockFeatureLoader.create).toHaveBeenCalled();
+      expect(lastCreateProjectPath()).toBe('/repos/protocontent');
+    });
+
+    it('matches repository case-insensitively', async () => {
+      (mockSettingsService.getGlobalSettings as any).mockResolvedValue(projectsSettings);
+
+      mockEmitter.emit(
+        'signal:received',
+        createTestSignal({
+          source: 'github',
+          content: 'Lowercase repo signal',
+          channelContext: { issueNumber: 34, repository: 'protolabsai/protocontent' },
+        })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(lastCreateProjectPath()).toBe('/repos/protocontent');
+    });
+
+    it('prefers an explicit channelContext.projectPath over repository matching', async () => {
+      (mockSettingsService.getGlobalSettings as any).mockResolvedValue(projectsSettings);
+
+      mockEmitter.emit(
+        'signal:received',
+        createTestSignal({
+          source: 'github',
+          content: 'Explicit path wins',
+          channelContext: {
+            issueNumber: 56,
+            repository: 'protoLabsAI/protoContent',
+            projectPath: '/repos/explicit-override',
+          },
+        })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(lastCreateProjectPath()).toBe('/repos/explicit-override');
+    });
+
+    it('falls back to the default project when no registered repo matches', async () => {
+      (mockSettingsService.getGlobalSettings as any).mockResolvedValue(projectsSettings);
+
+      mockEmitter.emit(
+        'signal:received',
+        createTestSignal({
+          source: 'github',
+          content: 'Unknown repo signal',
+          channelContext: { issueNumber: 78, repository: 'someoneElse/unknownRepo' },
+        })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(lastCreateProjectPath()).toBe('/test/path');
+    });
+  });
 });

--- a/docs/internal/server/ops-control-plane.md
+++ b/docs/internal/server/ops-control-plane.md
@@ -102,6 +102,15 @@ Inbound Event
 
 Classification determines whether an event affects operational infrastructure (ops) or go-to-market content (gtm). Each signal type has a dedicated channel handler registered in `channel-handlers/`.
 
+### GitHub-issue intake
+
+Inbound GitHub issues become board signals through two paths that share one payload shape and resolution logic:
+
+- **Direct webhook** (`/api/github/webhook`, `/webhooks/github`) → `IntegrationService.handleGitHubIssue`. Gated by the `githubIssueIntake` global setting (default `{ enabled: true, requiredLabel: 'board-intake' }`): only opened issues carrying the required label are ingested. The required-label filter is the double-handling boundary — when another receiver (e.g. protoWorkstacean) also processes the org's issues, this instance only picks up issues explicitly tagged for the board. Set `requiredLabel: ''` to ingest every opened issue.
+- **Forwarded signal** (`POST /api/engine/signal/submit`) → `SignalIntakeService.submitSignal`. Used by protoWorkstacean's board-ingestion forwarder, which POSTs the issue here with `channelContext` (a trusted path — not subject to the label gate).
+
+**Project routing.** `SignalIntakeService.resolveProjectPath()` picks the target board by: (1) an explicit `channelContext.projectPath`; (2) the project whose registry `github` remote matches `channelContext.repository`; (3) `defaultProjectPath`. This routes each repo's issues to the correct project instead of dumping every repo onto the default board.
+
 ### Delivery Tracking
 
 The `EventHistoryService` stores every event with metadata including severity, trigger type, and processing result. This provides:

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -623,6 +623,25 @@ export interface GlobalSettings {
   portfolioGate?: boolean;
 
   /**
+   * GitHub-issue intake configuration (#3991).
+   *
+   * Controls which inbound GitHub issues this instance ingests as board signals.
+   * The required-label filter is the double-handling boundary: when another
+   * receiver (e.g. protoWorkstacean) also processes the org's issues, protoMaker
+   * only picks up issues explicitly tagged for board intake instead of grabbing
+   * every opened issue.
+   */
+  githubIssueIntake?: {
+    /** Whether to ingest GitHub issues as board signals at all. @default true */
+    enabled: boolean;
+    /**
+     * Only ingest issues carrying this label. An empty string disables the
+     * filter (ingest every opened issue). @default 'board-intake'
+     */
+    requiredLabel: string;
+  };
+
+  /**
    * Stable identifier for this Automaker installation. Used to watermark PR
    * ownership so other tooling can attribute PRs back to this install.
    * Auto-generated UUID on first call and persisted for subsequent calls.
@@ -758,4 +777,10 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
   featureFlags: DEFAULT_FEATURE_FLAGS,
   // Scheduler settings — no task overrides by default
   schedulerSettings: DEFAULT_SCHEDULER_SETTINGS,
+  // GitHub-issue intake — require the `board-intake` label by default so this
+  // instance only ingests issues explicitly tagged for the board (#3991).
+  githubIssueIntake: {
+    enabled: true,
+    requiredLabel: 'board-intake',
+  },
 };


### PR DESCRIPTION
## Problem

Dogfooding the org→execution pipeline (#3991) surfaced two intake bugs:

1. **No repo→project routing (#3975).** GitHub issues ingested via webhook all landed on the single `defaultProjectPath` board regardless of which repo the issue belonged to. `signal-intake-service.ts` resolved `projectPath = channelContext?.projectPath || defaultProjectPath` with nothing in between.
2. **Field-name mismatch on the per-project route.** `routes/github/routes/webhook.ts` emitted `issueTitle`/`issueBody` (and no `author`/`createdAt`), but `IntegrationService.handleGitHubIssue` reads `title`/`body`/`author` — so issues arriving through that route produced `content: "undefined\n\nundefined"`.
3. **Idle instances report "No known project paths."** Maintenance derived its project set solely from active auto-loops, so an idle instance skipped all per-project upkeep (the #3991 code half).

## Fix

- **Unify the `webhook:github:issue` payload** across the global and per-project routes — `title`, `body`, `author`, `createdAt`, `repository`, `labels`, `issueUrl` — and keep `handleGitHubIssue` in sync.
- **Carry `projectPath`/`labels`/`issueUrl`** through to the signal `channelContext`.
- **Resolve the target project from the registry.** `SignalIntakeService.resolveProjectPath()` matches `channelContext.repository` (full_name) against each `ProjectRef.github.{owner,repo}` (case-insensitive) before falling back to `defaultProjectPath`. The registry already carries the remote, so no new config is required.
- **Load `settings.projects` for maintenance project paths**, unioned with active auto-loops, so idle instances run per-project maintenance.

## Tests

- 4 new routing unit tests: repo match, case-insensitive match, explicit `projectPath` override, no-match fallback.
- All 41 signal-intake tests pass; maintenance-tasks tests pass; `tsc -p apps/server` clean.

## Notes

- The global webhook route still has no `projectPath` — that is intentional; routing now happens at intake from `repository`.
- Does not address the webhook-delivery half of #3991 (protoMaker receiving no webhooks at all) — that is infra/config and tracked separately on #3991.

Closes #3975. Partially addresses #3991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub issue intake now includes author, creation time, issue URL and labels; intake can be toggled and filtered by a required label.
  * Improved project routing resolves targets from persisted and active projects for more accurate signal delivery.
  * Maintenance tasks broadened to operate across the expanded set of known projects.

* **Tests**
  * Added unit tests covering GitHub signal routing and intake gate behaviors.

* **Documentation**
  * Docs updated to describe GitHub-issue intake flows and project resolution logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/3996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->