### PR TITLE
fix(triage): refuse closure-equivalent classifications on unverified evidence (#3972)

### DIFF
--- a/.claude/commands/gh-issue.md
+++ b/.claude/commands/gh-issue.md
@@ -62,7 +62,7 @@ This command accepts a GitHub issue number as input (e.g., `123`).
 
 Before asserting ANY closure-equivalent classification — `already_fixed`, `duplicate`, `not_a_bug`, `wontfix`, `resolved`, `not_reproducible`, `invalid`, `works_as_intended` — you MUST verify that every file path you cite as evidence actually exists at the relevant ref:
 
-- For each cited path, confirm existence: `git cat-file -e HEAD:<path>` (exit 0 = exists), or `Read` the file. Do NOT trust path names from memory, branch names, or the issue text.
+- For each cited path, confirm existence **at the same ref you are asserting against** with a ref-scoped check: `git cat-file -e <ref>:<path>` (exit 0 = exists) or `git show <ref>:<path>`. Do NOT use a plain working-tree `Read` — it can validate a file that does not exist at the target ref, reintroducing the false-closure failure mode. Do NOT trust path names from memory, branch names, or the issue text.
 - Equivalently, call the `verify_triage_evidence` MCP tool with `{ projectPath, classification, citedPaths, ref }`. If it returns `classificationAllowed: false`, you are forbidden from applying that classification.
 - A closure-equivalent classification with NO verified file:line or commit evidence is invalid. Never mark an issue `already_fixed` against files that do not exist — this silently neutralizes real bugs (the #3970/#3972 incident).
 - If your cited evidence cannot be verified: do NOT classify. Either re-investigate against the real source and cite verified evidence, or escalate/label as needs-investigation.

--- a/.claude/commands/gh-issue.md
+++ b/.claude/commands/gh-issue.md
@@ -58,6 +58,16 @@ This command accepts a GitHub issue number as input (e.g., `123`).
      - Run tests to ensure nothing broke
      - If possible, manually verify the fix addresses the issue
 
+### Classification verification (MANDATORY — #3972)
+
+Before asserting ANY closure-equivalent classification — `already_fixed`, `duplicate`, `not_a_bug`, `wontfix`, `resolved`, `not_reproducible`, `invalid`, `works_as_intended` — you MUST verify that every file path you cite as evidence actually exists at the relevant ref:
+
+- For each cited path, confirm existence: `git cat-file -e HEAD:<path>` (exit 0 = exists), or `Read` the file. Do NOT trust path names from memory, branch names, or the issue text.
+- Equivalently, call the `verify_triage_evidence` MCP tool with `{ projectPath, classification, citedPaths, ref }`. If it returns `classificationAllowed: false`, you are forbidden from applying that classification.
+- A closure-equivalent classification with NO verified file:line or commit evidence is invalid. Never mark an issue `already_fixed` against files that do not exist — this silently neutralizes real bugs (the #3970/#3972 incident).
+- If your cited evidence cannot be verified: do NOT classify. Either re-investigate against the real source and cite verified evidence, or escalate/label as needs-investigation.
+- Every closure-equivalent comment you post MUST include the verification evidence inline (commit SHA + a path confirmed to exist at that ref).
+
 6. **Report summary**
    - Issue number and title
    - Issue state (open/closed)

--- a/apps/server/src/routes/github/index.ts
+++ b/apps/server/src/routes/github/index.ts
@@ -27,6 +27,7 @@ import { createRotateSecretHandler } from './routes/rotate-secret.js';
 const webhookRateLimiter = createRateLimiter();
 import { createMergePRHandler } from './routes/merge-pr.js';
 import { createAddCommentHandler } from './routes/add-comment.js';
+import { createVerifyTriageEvidenceHandler } from './routes/verify-triage-evidence.js';
 import { createCheckPRStatusHandler } from './routes/check-pr-status.js';
 import { createPRReviewCommentsHandler } from './routes/pr-review-comments.js';
 import { createResolvePRCommentHandler } from './routes/resolve-pr-comment.js';
@@ -94,6 +95,11 @@ export function createGitHubRoutes(
   // PR merge operations
   router.post('/merge-pr', validatePathParams('projectPath'), createMergePRHandler());
   router.post('/comment', validatePathParams('projectPath'), createAddCommentHandler());
+  router.post(
+    '/verify-triage-evidence',
+    validatePathParams('projectPath'),
+    createVerifyTriageEvidenceHandler()
+  );
   router.post(
     '/check-pr-status',
     validatePathParams('projectPath'),

--- a/apps/server/src/routes/github/routes/verify-triage-evidence.ts
+++ b/apps/server/src/routes/github/routes/verify-triage-evidence.ts
@@ -21,6 +21,11 @@ interface VerifyTriageEvidenceRequest {
 export function createVerifyTriageEvidenceHandler() {
   return async (req: Request, res: Response): Promise<void> => {
     try {
+      if (!req.body || typeof req.body !== 'object' || Array.isArray(req.body)) {
+        res.status(400).json({ success: false, error: 'Request body must be a JSON object' });
+        return;
+      }
+
       const { projectPath, classification, citedPaths, ref } =
         req.body as VerifyTriageEvidenceRequest;
 

--- a/apps/server/src/routes/github/routes/verify-triage-evidence.ts
+++ b/apps/server/src/routes/github/routes/verify-triage-evidence.ts
@@ -1,0 +1,48 @@
+/**
+ * POST /verify-triage-evidence endpoint (#3972)
+ *
+ * Deterministically verifies that the file paths a triage agent cites as
+ * evidence actually exist at the given git ref, and reports whether a
+ * closure-equivalent classification (already_fixed, duplicate, ...) is
+ * supported. Triage agents must call this before applying any such label.
+ */
+
+import type { Request, Response } from 'express';
+import { verifyTriageEvidence } from '../../../services/triage-evidence-verifier.js';
+import { getErrorMessage, logError } from './common.js';
+
+interface VerifyTriageEvidenceRequest {
+  projectPath: string;
+  classification?: string;
+  citedPaths: string[];
+  ref?: string;
+}
+
+export function createVerifyTriageEvidenceHandler() {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, classification, citedPaths, ref } =
+        req.body as VerifyTriageEvidenceRequest;
+
+      if (typeof projectPath !== 'string' || !projectPath.trim()) {
+        res
+          .status(400)
+          .json({ success: false, error: 'projectPath is required (non-empty string)' });
+        return;
+      }
+      if (!Array.isArray(citedPaths) || citedPaths.some((p) => typeof p !== 'string')) {
+        res.status(400).json({
+          success: false,
+          error: 'citedPaths is required and must be an array of strings',
+        });
+        return;
+      }
+
+      const result = await verifyTriageEvidence({ projectPath, classification, citedPaths, ref });
+      res.json({ success: true, ...result });
+    } catch (error) {
+      logError(error, 'Verify triage evidence failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/services/triage-evidence-verifier.ts
+++ b/apps/server/src/services/triage-evidence-verifier.ts
@@ -1,0 +1,163 @@
+/**
+ * Triage Evidence Verifier (#3972)
+ *
+ * Guards against the silent failure mode where a triage agent confidently
+ * classifies an issue (`already_fixed`, `duplicate`, ...) while citing file
+ * paths that do not exist in the repository — neutralizing a real bug while
+ * looking like progress.
+ *
+ * This is deterministic, LLM-free verification: given the file paths an agent
+ * cites as evidence, it confirms each one actually exists at the relevant git
+ * ref and refuses closure-equivalent classifications whose evidence cannot be
+ * found. Triage agents are instructed to call this (via the
+ * `verify_triage_evidence` MCP tool) before applying any closure-equivalent
+ * label, and the regression suite asserts a fabricated reference is rejected.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createLogger } from '@protolabsai/utils';
+import { createGitExecEnv } from '@protolabsai/git-utils';
+
+const execFileAsync = promisify(execFile);
+const logger = createLogger('TriageEvidenceVerifier');
+
+/**
+ * Classifications that close or neutralize an issue. These must never be
+ * asserted on unverified evidence — a wrong one silently kills a real bug.
+ * Compared after normalizing case and separators (so `already-fixed`,
+ * `already_fixed`, and `Already Fixed` all match).
+ */
+export const CLOSURE_EQUIVALENT_CLASSIFICATIONS = [
+  'already_fixed',
+  'duplicate',
+  'not_a_bug',
+  'wontfix',
+  'resolved',
+  'not_reproducible',
+  'invalid',
+  'works_as_intended',
+] as const;
+
+export interface VerifyTriageEvidenceInput {
+  /** Absolute path to the repository being triaged. */
+  projectPath: string;
+  /** The classification the agent intends to apply (optional). */
+  classification?: string;
+  /** File paths the agent cites as evidence for its classification. */
+  citedPaths: string[];
+  /** Git ref to check paths against. Defaults to 'HEAD'. */
+  ref?: string;
+}
+
+export interface VerifyTriageEvidenceResult {
+  ref: string;
+  existingPaths: string[];
+  missingPaths: string[];
+  /** Whether the intended classification is closure-equivalent. */
+  isClosureEquivalent: boolean;
+  /**
+   * False when a closure-equivalent classification is unsupported — either it
+   * cites a path that doesn't exist, or it cites no evidence at all. When false,
+   * the agent must NOT apply the classification.
+   */
+  classificationAllowed: boolean;
+  /** Human-readable guidance for the agent. */
+  recommendation: string;
+}
+
+/** Normalize a classification string for matching (case + separator insensitive). */
+function normalizeClassification(classification: string): string {
+  return classification
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, '_');
+}
+
+export function isClosureEquivalent(classification?: string): boolean {
+  if (!classification) return false;
+  return (CLOSURE_EQUIVALENT_CLASSIFICATIONS as readonly string[]).includes(
+    normalizeClassification(classification)
+  );
+}
+
+/**
+ * Confirm a path exists at a git ref. `git cat-file -e <ref>:<path>` exits 0 if
+ * the blob/tree exists. execFile (no shell) keeps arbitrary paths injection-safe.
+ */
+async function pathExistsAtRef(
+  projectPath: string,
+  ref: string,
+  filePath: string
+): Promise<boolean> {
+  const clean = filePath.replace(/^\.?\//, '');
+  try {
+    await execFileAsync('git', ['cat-file', '-e', `${ref}:${clean}`], {
+      cwd: projectPath,
+      env: createGitExecEnv(),
+      timeout: 10_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function verifyTriageEvidence(
+  input: VerifyTriageEvidenceInput
+): Promise<VerifyTriageEvidenceResult> {
+  const ref = input.ref?.trim() || 'HEAD';
+  const citedPaths = [...new Set((input.citedPaths ?? []).map((p) => p.trim()).filter(Boolean))];
+
+  const existingPaths: string[] = [];
+  const missingPaths: string[] = [];
+  for (const p of citedPaths) {
+    const exists = await pathExistsAtRef(input.projectPath, ref, p);
+    (exists ? existingPaths : missingPaths).push(p);
+  }
+
+  const closure = isClosureEquivalent(input.classification);
+  // A closure-equivalent verdict requires at least one cited path AND every
+  // cited path must exist. Non-closure classifications are always allowed
+  // (the result still surfaces missing paths as a warning).
+  const classificationAllowed = !closure || (citedPaths.length > 0 && missingPaths.length === 0);
+
+  let recommendation: string;
+  if (closure && !classificationAllowed) {
+    if (citedPaths.length === 0) {
+      recommendation =
+        `REJECT classification "${input.classification}": closure-equivalent verdicts require verified ` +
+        `evidence (a file:line or commit reference that exists at ${ref}); none was cited. ` +
+        `Re-investigate against the real source, cite verified evidence, or escalate as needs-investigation.`;
+    } else {
+      recommendation =
+        `REJECT classification "${input.classification}": ${missingPaths.length} cited path(s) do not exist ` +
+        `at ${ref} (${missingPaths.join(', ')}). Do not assert a closure-equivalent verdict against a ` +
+        `non-existent codebase. Re-investigate against the real source and either cite verified file:line ` +
+        `evidence or escalate as needs-investigation.`;
+    }
+  } else if (missingPaths.length > 0) {
+    recommendation =
+      `WARNING: ${missingPaths.length} of ${citedPaths.length} cited path(s) do not exist at ${ref} ` +
+      `(${missingPaths.join(', ')}). Verify your evidence before relying on it.`;
+  } else if (citedPaths.length === 0) {
+    recommendation = `No paths cited. Cite the file:line evidence that supports your assessment.`;
+  } else {
+    recommendation = `All ${citedPaths.length} cited path(s) exist at ${ref}.`;
+  }
+
+  if (!classificationAllowed) {
+    logger.warn(
+      `Triage evidence verification rejected "${input.classification}" at ${ref} — missing: [${missingPaths.join(', ')}], cited: ${citedPaths.length}`
+    );
+  }
+
+  return {
+    ref,
+    existingPaths,
+    missingPaths,
+    isClosureEquivalent: closure,
+    classificationAllowed,
+    recommendation,
+  };
+}

--- a/apps/server/src/services/triage-evidence-verifier.ts
+++ b/apps/server/src/services/triage-evidence-verifier.ts
@@ -62,6 +62,11 @@ export interface VerifyTriageEvidenceResult {
    * the agent must NOT apply the classification.
    */
   classificationAllowed: boolean;
+  /**
+   * Whether the requested git ref could be resolved. When false, paths could
+   * not be checked, so no closure-equivalent classification is permitted.
+   */
+  refResolved: boolean;
   /** Human-readable guidance for the agent. */
   recommendation: string;
 }
@@ -79,6 +84,24 @@ export function isClosureEquivalent(classification?: string): boolean {
   return (CLOSURE_EQUIVALENT_CLASSIFICATIONS as readonly string[]).includes(
     normalizeClassification(classification)
   );
+}
+
+/**
+ * Confirm a git ref resolves to a commit in the repo. Distinguishes "the ref is
+ * bad" from "the path is missing" so an invalid ref can't masquerade as missing
+ * evidence (which would otherwise produce misleading per-path results).
+ */
+async function refResolves(projectPath: string, ref: string): Promise<boolean> {
+  try {
+    await execFileAsync('git', ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], {
+      cwd: projectPath,
+      env: createGitExecEnv(),
+      timeout: 10_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -108,6 +131,31 @@ export async function verifyTriageEvidence(
 ): Promise<VerifyTriageEvidenceResult> {
   const ref = input.ref?.trim() || 'HEAD';
   const citedPaths = [...new Set((input.citedPaths ?? []).map((p) => p.trim()).filter(Boolean))];
+
+  // An unresolvable ref means we cannot verify any evidence. Fail safe: never
+  // permit a closure-equivalent classification we couldn't check.
+  if (!(await refResolves(input.projectPath, ref))) {
+    const closure = isClosureEquivalent(input.classification);
+    if (closure) {
+      logger.warn(
+        `Triage evidence verification could not resolve ref "${ref}" — refusing closure verdict "${input.classification}"`
+      );
+    }
+    return {
+      ref,
+      existingPaths: [],
+      missingPaths: citedPaths,
+      isClosureEquivalent: closure,
+      classificationAllowed: !closure,
+      refResolved: false,
+      recommendation:
+        `Could not resolve git ref "${ref}" in this repository, so cited evidence cannot be verified. ` +
+        (closure
+          ? `Do not apply the closure-equivalent classification "${input.classification}". `
+          : '') +
+        `Re-run against a valid ref (e.g. HEAD or a commit SHA).`,
+    };
+  }
 
   const existingPaths: string[] = [];
   const missingPaths: string[] = [];
@@ -158,6 +206,7 @@ export async function verifyTriageEvidence(
     missingPaths,
     isClosureEquivalent: closure,
     classificationAllowed,
+    refResolved: true,
     recommendation,
   };
 }

--- a/apps/server/tests/unit/services/triage-evidence-verifier.test.ts
+++ b/apps/server/tests/unit/services/triage-evidence-verifier.test.ts
@@ -125,5 +125,32 @@ describe('triage-evidence-verifier (#3972)', () => {
       citedPaths: [REAL_PATH],
     });
     expect(result.ref).toBe('HEAD');
+    expect(result.refResolved).toBe(true);
+  });
+
+  it('refuses a closure verdict when the ref cannot be resolved (no false-missing)', async () => {
+    const result = await verifyTriageEvidence({
+      projectPath: repoRoot,
+      classification: 'already_fixed',
+      citedPaths: [REAL_PATH],
+      ref: 'this-ref-does-not-exist-deadbeef',
+    });
+
+    expect(result.refResolved).toBe(false);
+    expect(result.classificationAllowed).toBe(false);
+    expect(result.recommendation).toMatch(/Could not resolve git ref/);
+  });
+
+  it('reports a non-closure check against an unresolvable ref without throwing', async () => {
+    const result = await verifyTriageEvidence({
+      projectPath: repoRoot,
+      classification: 'needs_investigation',
+      citedPaths: [REAL_PATH],
+      ref: 'nope-not-a-real-ref',
+    });
+
+    expect(result.refResolved).toBe(false);
+    // Non-closure classifications are not blocked, but the unresolved ref is surfaced.
+    expect(result.classificationAllowed).toBe(true);
   });
 });

--- a/apps/server/tests/unit/services/triage-evidence-verifier.test.ts
+++ b/apps/server/tests/unit/services/triage-evidence-verifier.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Triage Evidence Verifier regression tests (#3972)
+ *
+ * Asserts that closure-equivalent classifications are refused when their cited
+ * file paths do not exist — the exact failure mode from the #3970/#3971
+ * incident, where a triage marked an issue `already_fixed` citing files
+ * (`packages/epic-manager/src/base-resolver.ts`, ...) that never existed.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import {
+  verifyTriageEvidence,
+  isClosureEquivalent,
+  CLOSURE_EQUIVALENT_CLASSIFICATIONS,
+} from '../../../src/services/triage-evidence-verifier.js';
+
+// The literal fabricated paths cited in the #3971 false `already_fixed` triage.
+const FABRICATED_PATHS = [
+  'packages/epic-manager/src/base-resolver.ts',
+  'src/board/dep-gate.ts',
+  'src/orchestration/dep-gate.ts',
+  'src/board/reconciliation.ts',
+];
+
+// A path that genuinely exists at HEAD in this repo (committed, not just in the
+// working tree — the verifier checks paths at the git ref).
+const REAL_PATH = 'CLAUDE.md';
+
+describe('triage-evidence-verifier (#3972)', () => {
+  let repoRoot: string;
+
+  beforeAll(() => {
+    repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf-8',
+    }).trim();
+  });
+
+  describe('isClosureEquivalent', () => {
+    it('matches all known closure-equivalent classifications', () => {
+      for (const c of CLOSURE_EQUIVALENT_CLASSIFICATIONS) {
+        expect(isClosureEquivalent(c)).toBe(true);
+      }
+    });
+
+    it('normalizes case and separators', () => {
+      expect(isClosureEquivalent('already-fixed')).toBe(true);
+      expect(isClosureEquivalent('Already Fixed')).toBe(true);
+      expect(isClosureEquivalent('NOT_A_BUG')).toBe(true);
+    });
+
+    it('does not match investigative classifications', () => {
+      expect(isClosureEquivalent('needs_investigation')).toBe(false);
+      expect(isClosureEquivalent('confirmed')).toBe(false);
+      expect(isClosureEquivalent(undefined)).toBe(false);
+      expect(isClosureEquivalent('')).toBe(false);
+    });
+  });
+
+  it('REFUSES already_fixed when the cited evidence does not exist (the #3971 regression)', async () => {
+    const result = await verifyTriageEvidence({
+      projectPath: repoRoot,
+      classification: 'already_fixed',
+      citedPaths: FABRICATED_PATHS,
+    });
+
+    expect(result.classificationAllowed).toBe(false);
+    expect(result.isClosureEquivalent).toBe(true);
+    expect(result.missingPaths).toEqual(expect.arrayContaining(FABRICATED_PATHS));
+    expect(result.existingPaths).toEqual([]);
+    expect(result.recommendation).toMatch(/REJECT/);
+  });
+
+  it('allows already_fixed when every cited path exists', async () => {
+    const result = await verifyTriageEvidence({
+      projectPath: repoRoot,
+      classification: 'already_fixed',
+      citedPaths: [REAL_PATH],
+    });
+
+    expect(result.classificationAllowed).toBe(true);
+    expect(result.missingPaths).toEqual([]);
+    expect(result.existingPaths).toEqual([REAL_PATH]);
+  });
+
+  it('refuses a closure-equivalent classification that cites no evidence at all', async () => {
+    const result = await verifyTriageEvidence({
+      projectPath: repoRoot,
+      classification: 'duplicate',
+      citedPaths: [],
+    });
+
+    expect(result.classificationAllowed).toBe(false);
+    expect(result.recommendation).toMatch(/require verified/i);
+  });
+
+  it('mixed existing + missing paths still rejects a closure verdict', async () => {
+    const result = await verifyTriageEvidence({
+      projectPath: repoRoot,
+      classification: 'already_fixed',
+      citedPaths: [REAL_PATH, FABRICATED_PATHS[0]],
+    });
+
+    expect(result.classificationAllowed).toBe(false);
+    expect(result.existingPaths).toEqual([REAL_PATH]);
+    expect(result.missingPaths).toEqual([FABRICATED_PATHS[0]]);
+  });
+
+  it('allows a non-closure classification even with missing paths, but surfaces a warning', async () => {
+    const result = await verifyTriageEvidence({
+      projectPath: repoRoot,
+      classification: 'needs_investigation',
+      citedPaths: FABRICATED_PATHS,
+    });
+
+    expect(result.classificationAllowed).toBe(true);
+    expect(result.isClosureEquivalent).toBe(false);
+    expect(result.missingPaths.length).toBe(FABRICATED_PATHS.length);
+    expect(result.recommendation).toMatch(/WARNING/);
+  });
+
+  it('defaults the ref to HEAD', async () => {
+    const result = await verifyTriageEvidence({
+      projectPath: repoRoot,
+      citedPaths: [REAL_PATH],
+    });
+    expect(result.ref).toBe('HEAD');
+  });
+});

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -797,6 +797,14 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         body: args.body,
       });
 
+    case 'verify_triage_evidence':
+      return apiCall('/github/verify-triage-evidence', {
+        projectPath: args.projectPath,
+        classification: args.classification,
+        citedPaths: args.citedPaths,
+        ref: args.ref,
+      });
+
     case 'check_pr_status':
       return apiCall('/github/check-pr-status', {
         projectPath: args.projectPath,

--- a/packages/mcp-server/src/tools/git-tools.ts
+++ b/packages/mcp-server/src/tools/git-tools.ts
@@ -269,4 +269,34 @@ export const gitTools: Tool[] = [
       required: ['projectPath', 'issueNumber', 'body'],
     },
   },
+  {
+    name: 'verify_triage_evidence',
+    description:
+      'Deterministically verify that the file paths you cite as triage evidence actually exist at a git ref, BEFORE applying a classification. You MUST call this before applying any closure-equivalent label (already_fixed, duplicate, not_a_bug, wontfix, resolved, not_reproducible, invalid, works_as_intended). If `classificationAllowed` is false, do NOT apply that classification — re-investigate against the real source or escalate as needs-investigation. Prevents the silent failure mode where an issue is wrongly marked already-fixed against a non-existent codebase (#3972).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          minLength: 1,
+          description: 'Absolute path to the repository being triaged',
+        },
+        classification: {
+          type: 'string',
+          description:
+            'The classification you intend to apply (e.g. already_fixed, duplicate, needs_investigation)',
+        },
+        citedPaths: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'The file paths you cite as evidence for your classification',
+        },
+        ref: {
+          type: 'string',
+          description: 'Git ref to check the paths against (default: HEAD)',
+        },
+      },
+      required: ['projectPath', 'citedPaths'],
+    },
+  },
 ];


### PR DESCRIPTION
## Problem

On #3970, a triage classified the issue `already_fixed` citing files (`packages/epic-manager/src/base-resolver.ts`, `src/board/dep-gate.ts`, ...) that **never existed** in the repo. A false `already_fixed` is a silent failure: it neutralizes a real bug while looking like progress, and authority/triage agents lend it credibility. This is a class, not a one-off (#3972).

## Fix — deterministic, LLM-free verification

- **`TriageEvidenceVerifier` service** (`apps/server/src/services/triage-evidence-verifier.ts`): given the file paths an agent cites as evidence, confirms each exists at a git ref (`git cat-file -e <ref>:<path>`) and **refuses** closure-equivalent classifications (`already_fixed`, `duplicate`, `not_a_bug`, `wontfix`, `resolved`, `not_reproducible`, `invalid`, `works_as_intended`) when the evidence is missing — or when none is cited at all. `classificationAllowed: false` ⇒ the agent must not apply the label.
- **`POST /api/github/verify-triage-evidence`** + **`verify_triage_evidence` MCP tool** — a real gate any triage agent can call, including cross-repo protoWorkstacean ceremonies that drive protoMaker over MCP.
- **Prompt hardening** (`.claude/commands/gh-issue.md`): MANDATES file-existence verification (via `git cat-file -e` or the MCP tool) before any closure-equivalent classification, and requires inline verified evidence (commit SHA + a path confirmed to exist).

## Tests

- 9 regression tests in `triage-evidence-verifier.test.ts`, including the **exact #3971 fabricated paths** → refused; closure-with-no-evidence → refused; mixed existing/missing → refused; non-closure with missing paths → allowed but warned; classification-string normalization.
- Server + mcp-server typecheck clean.

## Audit (acceptance #3)

Scanned current closure-equivalent triages: #4000 (`duplicate`, cites real #3997 + `settings.json`) and #3958 (`resolved`, cites real PR numbers) are plausible — no fabricated-file hallucinations remain. #3971 (the original) is already corrected/closed.

## Acceptance mapping
- ✅ Verify-before-asserting enforced (prompt + deterministic tool).
- ✅ Closure-equivalent verdicts rejected on unverified/absent evidence.
- ✅ Regression test asserts refusal on a fabricated reference.
- ✅ Audit of recent triages.

Closes #3972.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a verification endpoint and tool to confirm cited file paths exist at a specified git ref before allowing closure-equivalent classifications; integrated into the triage toolset and UI flow.

* **Documentation**
  * Updated classification guidance: closure-equivalent classifications require verifiable file/commit evidence inline; absent verification, such classifications are disallowed and should be re-investigated or escalated.

* **Tests**
  * Expanded verifier tests, including unresolved refs, mixed/missing paths, and acceptance/rejection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/4001?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->