### PR TITLE
feat(cli): add `feature delete` + fix --help/--version Error noise

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -25,7 +25,14 @@ import { pathToFileURL } from 'node:url';
 import { realpathSync } from 'node:fs';
 import { Command } from 'commander';
 import { type GlobalFlags, usageError, exitError } from './output.js';
-import { listCommand, getCommand, createCommand, updateCommand, moveCommand } from './feature.js';
+import {
+  listCommand,
+  getCommand,
+  createCommand,
+  updateCommand,
+  moveCommand,
+  deleteCommand,
+} from './feature.js';
 import {
   startCommand,
   stopCommand,
@@ -137,6 +144,7 @@ export function buildProgram(): Command {
   createCommand(featureCmd);
   updateCommand(featureCmd);
   moveCommand(featureCmd);
+  deleteCommand(featureCmd);
 
   /**
    * PR commands — pull request lifecycle (create, status, merge).
@@ -271,20 +279,22 @@ const invokedDirectly = isInvokedDirectly(process.argv[1], import.meta.url);
 
 if (invokedDirectly) {
   main().catch((err: any) => {
-    // Commander exitOverride throws CommanderError on failures
-    const commanderCode = err?.code;
+    // Commander (with exitOverride) throws a CommanderError whose `.code` is a
+    // dotted string like `commander.version` and whose `.exitCode` is the exit
+    // code it would have used. See https://github.com/tj/commander.js.
+    const commanderCode: string | undefined = typeof err?.code === 'string' ? err.code : undefined;
+    const isCommander = commanderCode?.startsWith('commander.') ?? false;
 
-    // --help / --version are fine
-    if (commanderCode === 'COMMANDER_HELP' || commanderCode === 'COMMANDER_VERSION') {
+    // Clean display exits — --help and --version print their output and Commander
+    // throws with exitCode 0. These are not errors; exit 0 with no "Error:" noise.
+    if (isCommander && err?.exitCode === 0) {
       process.exit(0);
     }
 
-    // Usage errors (unknown command, missing required arg, etc.) → exit 2
-    if (
-      commanderCode === 'COMMANDER_INCORRECTVALUE' ||
-      commanderCode === 'COMMANDER_ARGUMENT_MISSING' ||
-      commanderCode === 'COMMANDER_CREATE_OPTION_FAILED'
-    ) {
+    // Usage errors (unknown command/option, missing/excess args, bad value) → exit 2.
+    // Any other commander.* code is a usage problem; Commander already printed the
+    // specifics to stderr, so surface its message at exit code 2.
+    if (isCommander) {
       usageError(err.message || String(err));
     }
 

--- a/packages/cli/src/feature.ts
+++ b/packages/cli/src/feature.ts
@@ -557,3 +557,56 @@ export function moveCommand(parent: Command): void {
 
   parent.addCommand(cmd);
 }
+
+/**
+ * protomaker feature delete <featureId>
+ *
+ * Permanently delete a feature from the board (removes its
+ * {projectPath}/.automaker/features/{featureId}/ directory). Prompts for
+ * confirmation unless --yes is passed.
+ */
+export function deleteCommand(parent: Command): void {
+  const cmd = new Command('delete').arguments('<featureId>');
+  cmd.description('Permanently delete a feature from the board');
+  cmd.option('--yes', 'Skip confirmation prompt');
+
+  cmd.action(async (featureId: string, opts) => {
+    const flags = getGlobalFlags(cmd.optsWithGlobals());
+
+    if (!opts.yes && getOutputMode(flags) !== 'json') {
+      const readline = await import('node:readline');
+      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+      const answer = await new Promise<string>((resolve) => {
+        rl.question(`Permanently delete feature "${featureId}"? (y/N) `, (a) => {
+          rl.close();
+          resolve(a.trim().toLowerCase());
+        });
+      });
+      if (answer !== 'y' && answer !== 'yes') {
+        output('Cancelled.', flags);
+        return;
+      }
+    }
+
+    const client = createClient(flags);
+
+    const result = await client.post<{ success: boolean; error?: string }>('/features/delete', {
+      projectPath: flags.project,
+      featureId,
+    });
+
+    if (!result.ok) {
+      error(result.error || `Failed to delete feature "${featureId}"`);
+      process.exit(1);
+      return;
+    }
+
+    if (getOutputMode(flags) === 'json') {
+      output({ success: true, featureId }, flags);
+    } else {
+      output(`Deleted feature: ${featureId}`, flags);
+    }
+  });
+
+  parent.addCommand(cmd);
+}

--- a/packages/cli/src/feature.ts
+++ b/packages/cli/src/feature.ts
@@ -574,6 +574,11 @@ export function deleteCommand(parent: Command): void {
     const flags = getGlobalFlags(cmd.optsWithGlobals());
 
     if (!opts.yes && getOutputMode(flags) !== 'json') {
+      if (!process.stdin.isTTY) {
+        usageError(
+          'Refusing interactive confirmation without a TTY. Re-run with --yes (or --json).'
+        );
+      }
       const readline = await import('node:readline');
       const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
       const answer = await new Promise<string>((resolve) => {

--- a/packages/cli/src/queue.ts
+++ b/packages/cli/src/queue.ts
@@ -198,6 +198,11 @@ export function clearCommand(parent: Command): void {
     const flags = getGlobalFlags(cmd.optsWithGlobals());
 
     if (!opts.yes) {
+      if (!process.stdin.isTTY) {
+        usageError(
+          'Refusing interactive confirmation without a TTY. Re-run with --yes to clear the queue non-interactively.'
+        );
+      }
       // Read confirmation from stdin
       const readline = await import('node:readline');
       const rl = readline.createInterface({

--- a/packages/cli/src/queue.ts
+++ b/packages/cli/src/queue.ts
@@ -206,10 +206,13 @@ export function clearCommand(parent: Command): void {
       });
 
       const answer = await new Promise<string>((resolve) => {
-        rl.question('This will delete all backlog features. Are you sure? (y/N) ', (a) => {
-          rl.close();
-          resolve(a.trim().toLowerCase());
-        });
+        rl.question(
+          'Clearing the queue permanently deletes every backlog (queued) feature. This cannot be undone. Continue? (y/N) ',
+          (a) => {
+            rl.close();
+            resolve(a.trim().toLowerCase());
+          }
+        );
       });
 
       if (answer !== 'y' && answer !== 'yes') {

--- a/packages/cli/test/cli-wiring.test.ts
+++ b/packages/cli/test/cli-wiring.test.ts
@@ -62,7 +62,7 @@ function subcommandsOf(group: string): string[] {
 
 describe('command group registration', () => {
   it.each([
-    ['feature', ['create', 'get', 'list', 'move', 'update']],
+    ['feature', ['create', 'delete', 'get', 'list', 'move', 'update']],
     ['agent', ['list', 'message', 'output', 'start', 'stop']],
     ['pr', ['create', 'merge', 'status']],
     ['queue', ['add', 'clear', 'list']],
@@ -138,6 +138,25 @@ describe('feature update maps dependency flags into updates.dependencies (#3962)
     ]);
     const updates = lastBody!.updates as Record<string, unknown>;
     expect(updates.dependencies).toEqual([]);
+  });
+});
+
+describe('feature delete hits /features/delete with the featureId', () => {
+  it('sends projectPath + featureId to the delete endpoint', async () => {
+    await buildProgram().parseAsync([
+      'node',
+      'protomaker',
+      '--project',
+      '/custom/project',
+      '--json',
+      'feature',
+      'delete',
+      'feat-target',
+      '--yes',
+    ]);
+    expect(lastUrl).toMatch(/\/features\/delete$/);
+    expect(lastBody!.projectPath).toBe('/custom/project');
+    expect(lastBody!.featureId).toBe('feat-target');
   });
 });
 


### PR DESCRIPTION
Dogfooding the CLI to drive the board surfaced two gaps.

## 1. Missing `feature delete`
The board's delete operation existed on the server (`/api/features/delete`) and in MCP (`delete_feature`) but **not in the CLI** — you couldn't remove a feature with `protomaker`. Added:

```
protomaker feature delete <featureId> [--yes]
```

Confirms by default; `--yes` skips the prompt; `--json` skips the prompt and emits `{ success, featureId }`.

## 2. `--help` / `--version` printed a spurious `Error:`
The top-level catch checked for `COMMANDER_HELP` / `COMMANDER_VERSION`, but Commander emits dotted codes (`commander.helpDisplayed`, `commander.version`, exitCode 0). So help/version fell through to `exitError` and printed `Error: (outputHelp)` / `Error: 0.1.0` (while still exiting 0-ish). Now:
- any `commander.*` with `exitCode === 0` (help/version) → clean exit 0, no noise
- other `commander.*` (unknown command/option, missing/excess args, bad value) → usage error, exit 2
- everything else → runtime error, exit 1

## Verification
- `protomaker --version` → `0.1.0`, exit 0 (no `Error:`)
- `protomaker --help` → clean, exit 0
- `protomaker feature delete --help` lists the command
- 21 CLI tests pass (added a wiring test asserting `feature delete` → `/features/delete`); cli typecheck clean

Found while using the CLI to inspect the board (also caught + cleaned a leftover #3991 smoke-test feature that the queue had picked up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a feature-delete command to remove features by ID, with --yes to skip confirmation and JSON output support.

* **Bug Fixes**
  * Improved CLI error handling to better distinguish help/usage vs. real failures and exit appropriately.
  * Backlog-clear confirmation now requires a TTY when interactive and shows a more detailed prompt.

* **Tests**
  * Updated CLI wiring tests to cover the new feature-delete flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/4020?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->