### PR TITLE
feat(observability): propagate upstream trace.traceId on signal/submit (#3995)

### DIFF
--- a/apps/server/src/providers/traced-provider.ts
+++ b/apps/server/src/providers/traced-provider.ts
@@ -20,6 +20,13 @@ export interface TracedProviderContext {
   agentRole?: string;
   projectSlug?: string;
   phase?: string;
+  /**
+   * Originating trace correlationId from an upstream caller (e.g. protoWorkstacean).
+   * Emitted as `caller_trace_id` in trace metadata + a `caller_trace:<id>` tag so the
+   * full cross-system flow is searchable by the caller's traceId. Mirrors Quinn's
+   * `a2a.trace` -> `caller_trace_id` convention on the A2A path.
+   */
+  callerTraceId?: string;
 }
 
 /**
@@ -52,7 +59,16 @@ export class TracedProvider extends BaseProvider {
     this.tracingConfig.defaultMetadata = {
       ...this.tracingConfig.defaultMetadata,
       ...ctx,
+      // Surface the upstream correlationId under the canonical key so Langfuse
+      // searches by the caller's traceId resolve this feature's spans too.
+      ...(ctx.callerTraceId ? { caller_trace_id: ctx.callerTraceId } : {}),
     };
+    if (ctx.callerTraceId) {
+      this.tracingConfig.defaultTags = [
+        ...(this.tracingConfig.defaultTags ?? []),
+        `caller_trace:${ctx.callerTraceId}`,
+      ];
+    }
     // Also add feature-specific tags
     if (ctx.featureId) {
       this.tracingConfig.defaultTags = [

--- a/apps/server/src/routes/engine/index.ts
+++ b/apps/server/src/routes/engine/index.ts
@@ -352,6 +352,7 @@ export function createEngineRoutes(
         autoApprove,
         webResearch,
         channelContext,
+        trace,
       } = (req.body ?? {}) as {
         projectPath?: string;
         content?: string;
@@ -365,6 +366,11 @@ export function createEngineRoutes(
         // protoWorkstacean switchboard's board-ingestion forwarder: it resolves
         // the project (repo->projectPath) and POSTs the issue here.
         channelContext?: Record<string, unknown>;
+        // Distributed-trace context from an upstream caller (protoWorkstacean
+        // propagates the originating correlationId here). `trace.traceId` is
+        // recorded on the resulting feature and emitted as `caller_trace_id` on
+        // its Langfuse spans so the GitHub issue -> board -> PRD flow is one trace.
+        trace?: { traceId?: string; caller?: string; source?: string };
       };
 
       if (!content) {
@@ -375,7 +381,13 @@ export function createEngineRoutes(
         return;
       }
 
-      // Emit signal:received event for SignalIntakeService to pick up
+      // Emit signal:received event for SignalIntakeService to pick up.
+      // Fold an upstream trace correlationId into channelContext so it flows
+      // through intake onto the created feature (persisted as callerTraceId).
+      const enrichedChannelContext =
+        trace?.traceId !== undefined
+          ? { ...(channelContext ?? {}), callerTraceId: trace.traceId }
+          : channelContext;
       signalIntakeService.submitSignal({
         source: source || 'ui:flow-graph',
         content,
@@ -384,7 +396,7 @@ export function createEngineRoutes(
         files,
         autoApprove,
         webResearch,
-        channelContext,
+        channelContext: enrichedChannelContext,
       });
 
       res.json({

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -2637,6 +2637,7 @@ This mock response was generated because AUTOMAKER_MOCK_AGENT=true was set.
         agentRole: 'engineer',
         projectSlug: featureForTrace?.projectSlug,
         phase: 'execute',
+        callerTraceId: featureForTrace?.callerTraceId,
       });
     }
 

--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -653,6 +653,12 @@ export class SignalIntakeService {
         ...(signal.channelContext?.issueNumber
           ? { githubIssueNumber: signal.channelContext.issueNumber as number }
           : {}),
+        // Persist an upstream trace correlationId (e.g. protoWorkstacean's
+        // forwarder plumbs `trace.traceId` -> channelContext.callerTraceId) so
+        // execution emits it as `caller_trace_id` on this feature's Langfuse spans.
+        ...(signal.channelContext?.callerTraceId
+          ? { callerTraceId: signal.channelContext.callerTraceId as string }
+          : {}),
       });
       this.updateRingBufferEntry(bufferEntry.id, 'created', feature.id);
 

--- a/apps/server/tests/unit/services/signal-intake-service.test.ts
+++ b/apps/server/tests/unit/services/signal-intake-service.test.ts
@@ -342,6 +342,48 @@ describe('SignalIntakeService', () => {
       expect(createCall).toMatchObject({ githubIssueNumber: 7777 });
     });
 
+    it('should persist callerTraceId when an upstream trace correlationId is forwarded', async () => {
+      // protoWorkstacean's board-ingestion forwarder plumbs the originating
+      // correlationId via channelContext.callerTraceId so execution can emit it
+      // as caller_trace_id on Langfuse spans (GitHub issue -> board -> PRD = one trace).
+      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue([]);
+
+      const signal = createTestSignal({
+        source: 'github',
+        content: 'Board-ingested issue carrying a trace id',
+        channelContext: {
+          issueNumber: 1234,
+          repository: 'protoLabsAI/protoContent',
+          callerTraceId: 'corr-abc-123',
+        },
+      });
+
+      mockEmitter.emit('signal:received', signal);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockFeatureLoader.create).toHaveBeenCalledTimes(1);
+      const createCall = vi.mocked(mockFeatureLoader.create).mock.calls[0]?.[1];
+      expect(createCall).toMatchObject({ callerTraceId: 'corr-abc-123' });
+    });
+
+    it('should not set callerTraceId when no trace is forwarded', async () => {
+      vi.mocked(mockFeatureLoader.getAll).mockResolvedValue([]);
+
+      const signal = createTestSignal({
+        source: 'github',
+        content: 'Issue with no upstream trace',
+        channelContext: { issueNumber: 5678, repository: 'protoLabsAI/protoMaker' },
+      });
+
+      mockEmitter.emit('signal:received', signal);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const createCall = vi.mocked(mockFeatureLoader.create).mock.calls[0]?.[1] as
+        | Record<string, unknown>
+        | undefined;
+      expect(createCall?.callerTraceId).toBeUndefined();
+    });
+
     it('should prevent duplicate Discord signals by author ID', async () => {
       const signal = createTestSignal({
         source: 'discord',

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -424,6 +424,13 @@ export interface Feature {
    */
   githubIssueUrl?: string;
   /**
+   * Originating trace correlationId from an upstream caller (e.g. protoWorkstacean's
+   * board-ingestion forwarder passes `trace.traceId` on /api/engine/signal/submit).
+   * Emitted as `caller_trace_id` on this feature's Langfuse spans so the whole
+   * GitHub issue -> board -> PMAgent PRD flow resolves as one searchable trace.
+   */
+  callerTraceId?: string;
+  /**
    * Per-thread review feedback tracking with agent decisions.
    * Each thread can be accepted, denied, or pending with reasoning.
    */


### PR DESCRIPTION
## Summary

Joins protoMaker's spans to the upstream workstacean trace. When the board-ingestion forwarder POSTs a GitHub issue to `/api/engine/signal/submit` with a `trace` block, the `traceId` (the originating correlationId for the whole GitHub-issue → board → PRD flow) is now recorded on protoMaker's side and surfaced on Langfuse spans.

## Plumb
- **Route** (`engine/index.ts`): captures `trace.traceId` → `channelContext.callerTraceId`.
- **SignalIntakeService**: persists it onto the created feature as `callerTraceId` (mirrors the `githubIssueNumber` passthrough).
- **`Feature`** (`libs/types`): new optional `callerTraceId` field.
- **`TracedProvider.setContext`**: emits `callerTraceId` as `caller_trace_id` trace metadata + a `caller_trace:<id>` tag — mirroring Quinn's `a2a.trace` → `caller_trace_id` convention. Langfuse searches by the caller's traceId now resolve this feature's spans.
- **execution-service**: wires `feature.callerTraceId` into the engineer-phase trace context.

## Scope / follow-up
This lands the **durable foundation** (capture → persist → emit) and the **execute-phase** spans. Extending `caller_trace_id` to the earlier PMAgent / PRD / research / review **authority spans** (built via inline `traceContext` at ~10 call sites) is filed as a follow-up — see linked issue. The persisted `callerTraceId` field + tag already make the feature searchable end to end.

## Tests
`signal-intake-service.test.ts`: persists `callerTraceId` when forwarded; omits it when absent.

> Note: local env has no installed workspace deps, so typecheck/tests run in CI.

Refs #3995

🤖 Generated with [Claude Code](https://claude.com/claude-code)