### PR TITLE
fix(gateway): route all direct Anthropic SDK + flow-model calls through the gateway (#4028)

### DIFF
--- a/apps/server/src/lib/flow-model-factory.ts
+++ b/apps/server/src/lib/flow-model-factory.ts
@@ -31,6 +31,43 @@ function isGroqModel(model: string): boolean {
   );
 }
 
+/** Default gateway base URL — mirrors lib/ai-provider.ts. */
+const GATEWAY_DEFAULT_BASE_URL = 'https://api.proto-labs.ai/v1';
+/** Gateway tier legacy Claude aliases fall back to — mirrors lib/ai-provider.ts. */
+const GATEWAY_FALLBACK_MODEL = 'protolabs/smart';
+
+/**
+ * Resolve the protoLabs gateway base URL + key. Same resolution order as
+ * lib/ai-provider.ts so the flows layer and the chat layer authenticate
+ * identically against the gateway.
+ */
+function resolveGatewayConfig(credentials: Credentials | undefined): {
+  baseURL: string;
+  apiKey: string;
+} {
+  const baseURL =
+    process.env.GATEWAY_BASE_URL || process.env.OPENAI_BASE_URL || GATEWAY_DEFAULT_BASE_URL;
+  const apiKey =
+    credentials?.apiKeys?.protolabsGateway ||
+    process.env.GATEWAY_API_KEY ||
+    process.env.OPENAI_API_KEY ||
+    '';
+  return { baseURL, apiKey };
+}
+
+/**
+ * Map a legacy Claude alias / id to a gateway tier. Gateway-native ids
+ * (`protolabs/*`) and any other non-Claude id pass through unchanged.
+ * Mirrors mapLegacyClaudeModel in lib/ai-provider.ts.
+ */
+function mapToGatewayModel(model: string): string {
+  const lower = model.toLowerCase();
+  if (lower === 'sonnet' || lower === 'opus' || lower === 'haiku' || lower.startsWith('claude')) {
+    return GATEWAY_FALLBACK_MODEL;
+  }
+  return model;
+}
+
 /**
  * Resolve the API key for a ClaudeCompatibleProvider based on its apiKeySource strategy.
  */
@@ -58,11 +95,13 @@ function resolveProviderApiKey(
  * 2. Global phase model setting
  * 3. Default phase model (from DEFAULT_PHASE_MODELS)
  *
- * Model routing:
- * - claude-* models → ChatAnthropic (with optional provider baseURL/apiKey)
+ * Model routing (gateway-first — no direct api.anthropic.com):
+ * - Explicit provider with a baseUrl → honored as-is (ChatAnthropic for claude-*,
+ *   else ChatOpenAI) so a team can wire a custom/direct endpoint deliberately.
  * - llama-*, mixtral-*, gemma-*, groq/* → ChatGroq
- * - All other models with a provider → ChatOpenAI (OpenAI-compatible)
- * - Unknown/no-provider fallback → ChatAnthropic with claude-sonnet
+ * - Everything else (incl. the default protolabs/* tiers and legacy claude-*) →
+ *   ChatOpenAI pointed at the protoLabs gateway; legacy Claude aliases remap to
+ *   a gateway tier. This is also the unknown-model fallback.
  *
  * @param phase - The phase key (e.g., 'specGenerationModel', 'fileDescriptionModel')
  * @param projectPath - Optional project path for project-level overrides
@@ -86,35 +125,40 @@ export async function createFlowModel(
     `createFlowModel: phase=${phase}, resolvedModel=${resolvedModel}, provider=${provider?.name ?? 'none'}`
   );
 
-  // Claude models (claude-* prefix) — use ChatAnthropic
-  if (resolvedModel.startsWith('claude-') || resolvedModel.startsWith('claude')) {
-    const config: {
-      model: string;
-      apiKey?: string;
-      anthropicApiUrl?: string;
-    } = { model: resolvedModel };
-
-    if (provider) {
-      const apiKey = resolveProviderApiKey(provider, credentials);
-      if (apiKey) {
-        config.apiKey = apiKey;
-      }
-      if (provider.baseUrl) {
-        config.anthropicApiUrl = provider.baseUrl;
-      }
+  // Explicitly-configured provider with a custom base URL: honor it as-is.
+  // This is the only path that still talks to a non-gateway endpoint — a team
+  // can deliberately wire a direct-Anthropic or custom OpenAI-compatible server.
+  if (provider?.baseUrl) {
+    const apiKey = resolveProviderApiKey(provider, credentials);
+    if (resolvedModel.startsWith('claude')) {
+      const config: { model: string; apiKey?: string; anthropicApiUrl: string } = {
+        model: resolvedModel,
+        anthropicApiUrl: provider.baseUrl,
+      };
+      if (apiKey) config.apiKey = apiKey;
+      logger.debug(
+        `createFlowModel: using ChatAnthropic for model=${resolvedModel} via provider ${provider.name}`
+      );
+      // LangChain's ChatAnthropic defaults topP and topK to -1 as sentinels.
+      // For newer models (opus-4-1, sonnet-4-5, haiku-4-5) the constructor handles
+      // null → undefined, but for older models (opus-4-6 etc.) the `??` branch
+      // falls back to -1 even when undefined is passed. Mutate after construction
+      // to guarantee the sentinel is cleared for all model versions.
+      const anthropicModel = new ChatAnthropic(config);
+      (anthropicModel as unknown as Record<string, unknown>).topP = undefined;
+      (anthropicModel as unknown as Record<string, unknown>).topK = undefined;
+      return { model: anthropicModel as unknown as BaseChatModel, modelName: resolvedModel };
     }
-
-    logger.debug(`createFlowModel: using ChatAnthropic for model=${resolvedModel}`);
-    // LangChain's ChatAnthropic defaults topP and topK to -1 as sentinels.
-    // For newer models (opus-4-1, sonnet-4-5, haiku-4-5) the constructor handles
-    // null → undefined, but for older models (opus-4-6 etc.) the `??` branch
-    // falls back to -1 even when undefined is passed. Mutate after construction
-    // to guarantee the sentinel is cleared for all model versions.
-    const anthropicModel = new ChatAnthropic(config);
-    (anthropicModel as unknown as Record<string, unknown>).topP = undefined;
-    (anthropicModel as unknown as Record<string, unknown>).topK = undefined;
+    const { ChatOpenAI } = await import('@langchain/openai');
+    logger.debug(
+      `createFlowModel: using ChatOpenAI for model=${resolvedModel} via provider ${provider.name}, baseURL=${provider.baseUrl}`
+    );
     return {
-      model: anthropicModel as unknown as BaseChatModel,
+      model: new ChatOpenAI({
+        model: resolvedModel,
+        openAIApiKey: apiKey,
+        configuration: { baseURL: provider.baseUrl, apiKey },
+      }) as unknown as BaseChatModel,
       modelName: resolvedModel,
     };
   }
@@ -131,44 +175,32 @@ export async function createFlowModel(
       };
     } catch {
       logger.warn(
-        `createFlowModel: @langchain/groq not available, falling back to ChatAnthropic for model=${resolvedModel}`
+        `createFlowModel: @langchain/groq not available, routing ${resolvedModel} through the gateway`
       );
     }
   }
 
-  // OpenAI-compatible models (non-claude, non-groq) — use ChatOpenAI when provider is set
-  if (provider) {
-    try {
-      const { ChatOpenAI } = await import('@langchain/openai');
-      const apiKey = resolveProviderApiKey(provider, credentials);
-      logger.debug(
-        `createFlowModel: using ChatOpenAI for model=${resolvedModel}, baseURL=${provider.baseUrl}`
-      );
-      return {
-        model: new ChatOpenAI({
-          model: resolvedModel,
-          openAIApiKey: apiKey,
-          configuration: {
-            baseURL: provider.baseUrl,
-            apiKey: apiKey,
-          },
-        }) as unknown as BaseChatModel,
-        modelName: resolvedModel,
-      };
-    } catch {
-      logger.warn(
-        `createFlowModel: @langchain/openai not available, falling back to ChatAnthropic for model=${resolvedModel}`
-      );
-    }
+  // Default: route through the protoLabs gateway (OpenAI-compatible endpoint).
+  // Gateway-first migration — no direct api.anthropic.com. This covers the
+  // default protolabs/* phase models and any unknown/legacy id; legacy Claude
+  // aliases remap to a gateway tier (mirrors lib/ai-provider.ts).
+  const { baseURL, apiKey: gatewayKey } = resolveGatewayConfig(credentials);
+  const gatewayModel = mapToGatewayModel(resolvedModel);
+  if (!gatewayKey) {
+    logger.warn(
+      `createFlowModel: no gateway key resolved for ${phase}; the gateway will reject calls until GATEWAY_API_KEY is set`
+    );
   }
-
-  // Fallback: use Claude Sonnet via ChatAnthropic
-  const fallbackModel = 'claude-sonnet-4-5-20250929';
-  logger.warn(
-    `createFlowModel: unknown model "${resolvedModel}" for phase "${phase}", falling back to ${fallbackModel}`
+  const { ChatOpenAI } = await import('@langchain/openai');
+  logger.debug(
+    `createFlowModel: routing model=${resolvedModel} -> gateway model=${gatewayModel} via ChatOpenAI (baseURL=${baseURL})`
   );
   return {
-    model: new ChatAnthropic({ model: fallbackModel }) as unknown as BaseChatModel,
-    modelName: fallbackModel,
+    model: new ChatOpenAI({
+      model: gatewayModel,
+      openAIApiKey: gatewayKey,
+      configuration: { baseURL, apiKey: gatewayKey },
+    }) as unknown as BaseChatModel,
+    modelName: gatewayModel,
   };
 }

--- a/apps/server/src/routes/chat/ava-tools.ts
+++ b/apps/server/src/routes/chat/ava-tools.ts
@@ -44,7 +44,6 @@ import { getEventHistoryService } from '../../services/event-history-service.js'
 import { getBriefingCursorService } from '../../services/briefing-cursor-service.js';
 import { queryPm } from '../project-pm/pm-agent.js';
 import { simpleQuery } from '../../providers/simple-query-service.js';
-import Anthropic from '@anthropic-ai/sdk';
 import {
   classifyAndRemediate,
   logRemediationOutcome,
@@ -1226,12 +1225,10 @@ export function buildAvaTools(
       }),
       execute: async ({ prNumber, retryAttempt, maxRetries }) => {
         try {
-          const anthropic = new Anthropic();
           const result = await classifyAndRemediate({
             projectPath,
             prNumber,
             retryAttempt: retryAttempt ?? 2,
-            anthropic,
             maxRetries: maxRetries ?? 3,
           });
           logRemediationOutcome(result);

--- a/apps/server/src/services/agent-service.ts
+++ b/apps/server/src/services/agent-service.ts
@@ -229,12 +229,11 @@ export class AgentService {
 
       if (contextEngineEnabled) {
         const dataDir = path.dirname(this.stateDir);
-        let anthropicApiKey: string | undefined;
-        if (this.settingsService) {
-          const credentials = await this.settingsService.getCredentials();
-          anthropicApiKey = credentials?.apiKeys?.anthropic || undefined;
-        }
-        this.contextSessionManager = new AgentSessionManager(dataDir, anthropicApiKey);
+        // LLM-assisted compaction routes through the protoLabs gateway
+        // (gateway-first migration); the session manager resolves the gateway
+        // credential internally and falls back to deterministic compaction if
+        // no key resolves.
+        this.contextSessionManager = new AgentSessionManager(dataDir);
         this.logger.info('AgentSessionManager initialised (contextEngine enabled)');
       } else {
         this.logger.info('Context engine disabled — skipping AgentSessionManager initialisation');

--- a/apps/server/src/services/agent-session-manager.ts
+++ b/apps/server/src/services/agent-session-manager.ts
@@ -17,7 +17,7 @@
  *   a concern.
  *
  * ## Usage
- *   const manager = new AgentSessionManager(dataDir, anthropicApiKey);
+ *   const manager = new AgentSessionManager(dataDir);
  *   const convId = manager.getOrCreateConversation(featureId);
  *   const history = manager.assembleHistory(convId);   // before sending
  *   manager.ingestMessage(convId, 'user', userText);
@@ -28,7 +28,8 @@
 
 import path from 'path';
 import * as fs from 'node:fs';
-import Anthropic from '@anthropic-ai/sdk';
+import { generateText } from 'ai';
+import { getAnthropicModel, hasGatewayKey } from '../lib/ai-provider.js';
 import { ConversationStore, type MessageRole, type MessageRow } from '@protolabsai/context-engine';
 import {
   ContextAssembler,
@@ -73,10 +74,10 @@ const FRESH_TAIL_SIZE = 6;
 const COMPACTION_MIN_FANOUT = 8;
 
 /**
- * Model used for LLM-assisted compaction summaries.
+ * Gateway model tier used for LLM-assisted compaction summaries.
  * Falls through to deterministic extraction if the call fails.
  */
-const COMPACTION_MODEL = 'claude-haiku-4-5';
+const COMPACTION_MODEL = 'protolabs/fast';
 
 // ---------------------------------------------------------------------------
 // AgentSessionManager
@@ -105,12 +106,13 @@ export class AgentSessionManager {
   // ---------------------------------------------------------------------------
 
   /**
-   * @param dataDir      Top-level data directory for the server.
-   *                     The SQLite DB is opened at `<dataDir>/context-engine/conversations.db`.
-   * @param anthropicApiKey  Optional Anthropic API key for LLM-assisted compaction.
-   *                         When absent the compactor falls back to deterministic extraction.
+   * @param dataDir  Top-level data directory for the server.
+   *                 The SQLite DB is opened at `<dataDir>/context-engine/conversations.db`.
+   *                 LLM-assisted compaction routes through the protoLabs gateway; if no
+   *                 gateway credential resolves the call throws and the compactor falls
+   *                 back to deterministic extraction.
    */
-  constructor(dataDir: string, anthropicApiKey?: string) {
+  constructor(dataDir: string) {
     // Ensure the context-engine directory exists
     const dbDir = path.join(dataDir, 'context-engine');
     if (!fs.existsSync(dbDir)) {
@@ -127,14 +129,9 @@ export class AgentSessionManager {
       recallGuidanceRole: 'user', // ensure recall guidance fits in conversation history (user|assistant only)
     });
 
-    // Build the LLM caller for compaction (or fall back to deterministic)
-    const llmCaller: LLMCaller = anthropicApiKey
-      ? this.buildAnthropicLlmCaller(anthropicApiKey)
-      : async () => {
-          throw new Error('No Anthropic API key configured; using deterministic compaction');
-        };
-
-    this.compactor = new LeafCompactor(llmCaller);
+    // LLM caller for compaction routes through the gateway. If no gateway key
+    // resolves, the call throws and LeafCompactor falls back to deterministic.
+    this.compactor = new LeafCompactor(this.buildGatewayLlmCaller());
 
     this.logger.info('AgentSessionManager initialised');
   }
@@ -336,25 +333,28 @@ export class AgentSessionManager {
   // ---------------------------------------------------------------------------
 
   /**
-   * Builds an LLM caller backed by the Anthropic SDK (claude-haiku).
-   * Falls through to deterministic compaction if the call throws.
+   * Builds an LLM caller routed through the protoLabs gateway (gateway-first
+   * migration — no direct Anthropic SDK / ANTHROPIC_API_KEY). Falls through to
+   * deterministic compaction if the call throws (e.g. no gateway key).
    */
-  private buildAnthropicLlmCaller(apiKey: string): LLMCaller {
-    const client = new Anthropic({ apiKey });
-
+  private buildGatewayLlmCaller(): LLMCaller {
     return async (system: string, user: string): Promise<string> => {
-      const response = await client.messages.create({
-        model: COMPACTION_MODEL,
-        max_tokens: 2048,
-        system,
-        messages: [{ role: 'user', content: user }],
-      });
-
-      const block = response.content[0];
-      if (!block || block.type !== 'text') {
-        throw new Error('Unexpected compaction response: no text block');
+      // Short-circuit when no gateway credential resolves: throw before any
+      // network call so LeafCompactor falls back to deterministic compaction
+      // immediately (keyless servers + unit tests don't hit the gateway).
+      if (!(await hasGatewayKey())) {
+        throw new Error('No gateway key configured; using deterministic compaction');
       }
-      return block.text;
+      const { text } = await generateText({
+        model: await getAnthropicModel(COMPACTION_MODEL),
+        maxOutputTokens: 2048,
+        system,
+        prompt: user,
+      });
+      if (!text) {
+        throw new Error('Unexpected compaction response: empty text');
+      }
+      return text;
     };
   }
 

--- a/apps/server/src/services/fact-store-service.ts
+++ b/apps/server/src/services/fact-store-service.ts
@@ -10,10 +10,10 @@
 
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
-import Anthropic from '@anthropic-ai/sdk';
+import { generateText } from 'ai';
 import { createLogger, atomicWriteJson } from '@protolabsai/utils';
-import { resolveModelString } from '@protolabsai/model-resolver';
 import type { TrajectoryFact } from '@protolabsai/types';
+import { getAnthropicModel } from '../lib/ai-provider.js';
 
 const logger = createLogger('FactStoreService');
 
@@ -45,12 +45,6 @@ Agent output to analyze:`;
  * Fact Store Service — extracts and persists structured facts from agent output.
  */
 export class FactStoreService {
-  private anthropic: Anthropic;
-
-  constructor() {
-    this.anthropic = new Anthropic();
-  }
-
   /**
    * Fire-and-forget: extract facts from agentOutput and write to facts.json.
    * Never throws — all errors are caught and logged.
@@ -71,23 +65,18 @@ export class FactStoreService {
       return;
     }
 
-    const model = resolveModelString('haiku');
     const prompt = `${EXTRACTION_PROMPT}\n\n${agentOutput}`;
 
     let responseText: string;
     try {
-      const response = await this.anthropic.messages.create({
-        model,
-        max_tokens: 2048,
-        messages: [{ role: 'user', content: prompt }],
+      // Routed through the protoLabs gateway (gateway-first migration). The
+      // gateway terminates auth — no direct Anthropic SDK / ANTHROPIC_API_KEY.
+      const result = await generateText({
+        model: await getAnthropicModel('protolabs/fast'),
+        maxOutputTokens: 2048,
+        prompt,
       });
-
-      const content = response.content[0];
-      if (content.type !== 'text') {
-        logger.warn('[FactStore] Unexpected response type from model, skipping');
-        return;
-      }
-      responseText = content.text;
+      responseText = result.text;
     } catch (err) {
       logger.error('[FactStore] LLM call failed:', err);
       return;

--- a/apps/server/src/services/knowledge-embedding-orchestrator.ts
+++ b/apps/server/src/services/knowledge-embedding-orchestrator.ts
@@ -9,8 +9,9 @@
  */
 
 import * as BetterSqlite3 from 'better-sqlite3';
-import Anthropic from '@anthropic-ai/sdk';
+import { generateText } from 'ai';
 import { createLogger } from '@protolabsai/utils';
+import { getAnthropicModel } from '../lib/ai-provider.js';
 import { EmbeddingService } from './embedding-service.js';
 
 const logger = createLogger('KnowledgeEmbeddingOrchestrator');
@@ -122,10 +123,6 @@ export class KnowledgeEmbeddingOrchestrator {
 
       logger.info(`Starting background HyPE processing for ${chunksToProcess.length} chunks`);
 
-      const anthropic = new Anthropic({
-        apiKey: process.env.ANTHROPIC_API_KEY,
-      });
-
       // Rate limiting: 10 calls per minute = 6 seconds between calls
       const RATE_LIMIT_DELAY_MS = 6000;
       let processed = 0;
@@ -140,15 +137,16 @@ export class KnowledgeEmbeddingOrchestrator {
           // Call Haiku to generate 3 short questions
           const prompt = `Generate 3 short, specific questions that this text answers. Return only a JSON array of strings, no explanation. Text: ${text}`;
 
-          const message = await anthropic.messages.create({
-            model: 'claude-haiku-4-5-20251001',
-            max_tokens: 512,
-            messages: [{ role: 'user', content: prompt }],
+          // Routed through the protoLabs gateway (gateway-first migration) —
+          // no direct Anthropic SDK / ANTHROPIC_API_KEY.
+          const message = await generateText({
+            model: await getAnthropicModel('protolabs/fast'),
+            maxOutputTokens: 512,
+            prompt,
           });
 
           // Parse the JSON response
-          const responseText =
-            message.content[0].type === 'text' ? message.content[0].text.trim() : '[]';
+          const responseText = (message.text || '[]').trim();
 
           // Extract JSON array from response (handle potential markdown code blocks)
           const jsonMatch = responseText.match(/\[[\s\S]*\]/);

--- a/apps/server/src/services/knowledge-ingestion-service.ts
+++ b/apps/server/src/services/knowledge-ingestion-service.ts
@@ -10,8 +10,9 @@
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 import * as BetterSqlite3 from 'better-sqlite3';
-import Anthropic from '@anthropic-ai/sdk';
+import { generateText } from 'ai';
 import { createLogger } from '@protolabsai/utils';
+import { getAnthropicModel } from '../lib/ai-provider.js';
 import type { PMWorldState } from '@protolabsai/types';
 import { KnowledgeEmbeddingOrchestrator } from './knowledge-embedding-orchestrator.js';
 
@@ -91,10 +92,6 @@ export class KnowledgeIngestionService {
       `Category ${categoryFile} exceeds threshold (${estimatedTokens} > ${compactionThreshold}), compacting...`
     );
 
-    const anthropic = new Anthropic({
-      apiKey: process.env.ANTHROPIC_API_KEY,
-    });
-
     const prompt = `You are summarizing a category memory file that has grown too large. Your task is to compress the content while preserving the most important patterns, decisions, and lessons.
 
 # Original Content:
@@ -109,14 +106,15 @@ ${content}
 
 Output the compressed memory file:`;
 
-    const message = await anthropic.messages.create({
-      model: 'claude-haiku-4-5-20251001',
-      max_tokens: 4096,
-      messages: [{ role: 'user', content: prompt }],
+    // Routed through the protoLabs gateway (gateway-first migration) — no direct
+    // Anthropic SDK / ANTHROPIC_API_KEY. Falls back to the original content if empty.
+    const result = await generateText({
+      model: await getAnthropicModel('protolabs/fast'),
+      maxOutputTokens: 4096,
+      prompt,
     });
 
-    const summarizedContent =
-      message.content[0].type === 'text' ? message.content[0].text : content;
+    const summarizedContent = result.text || content;
 
     fs.writeFileSync(categoryPath, summarizedContent, 'utf-8');
     logger.info(`Category ${categoryFile} compacted successfully`);

--- a/apps/server/src/services/pr-conflict-classifier.ts
+++ b/apps/server/src/services/pr-conflict-classifier.ts
@@ -12,8 +12,8 @@
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createLogger } from '@protolabsai/utils';
-import { resolveModelString } from '@protolabsai/model-resolver';
-import Anthropic from '@anthropic-ai/sdk';
+import { generateText } from 'ai';
+import { getAnthropicModel } from '../lib/ai-provider.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('PRConflictClassifier');
@@ -60,7 +60,6 @@ export interface ConflictClassification {
 export interface PRConflictClassifierInput {
   projectPath: string;
   prNumber: number;
-  anthropic: Anthropic;
 }
 
 // ---------------------------------------------------------------------------
@@ -143,13 +142,13 @@ export class PRConflictClassifier {
    */
   async classify(): Promise<ConflictClassification> {
     const prNumber = sanitizePrNumber(this.input.prNumber);
-    const { projectPath, anthropic } = this.input;
+    const { projectPath } = this.input;
 
     logger.info(`[PRConflictClassifier] Classifying PR #${prNumber}`, { projectPath });
 
     try {
       const evidence = await this.gatherEvidence(prNumber, projectPath);
-      const classification = await this.llmClassify(evidence, anthropic);
+      const classification = await this.llmClassify(evidence);
       logger.info('[PRConflictClassifier] Classification complete', {
         prNumber,
         verdict: classification.verdict,
@@ -377,26 +376,23 @@ export class PRConflictClassifier {
   // LLM classification
   // -------------------------------------------------------------------------
 
-  private async llmClassify(
-    evidence: ConflictEvidence,
-    anthropic: Anthropic
-  ): Promise<ConflictClassification> {
+  private async llmClassify(evidence: ConflictEvidence): Promise<ConflictClassification> {
     const prompt = buildClassifierPrompt(evidence);
-    const model = resolveModelString('haiku');
 
-    const response = await anthropic.messages.create({
-      model,
-      max_tokens: 1024,
-      messages: [{ role: 'user', content: prompt }],
+    // Routed through the protoLabs gateway (gateway-first migration) — no direct
+    // Anthropic SDK / ANTHROPIC_API_KEY.
+    const { text } = await generateText({
+      model: await getAnthropicModel('protolabs/fast'),
+      maxOutputTokens: 1024,
+      prompt,
     });
 
-    const content = response.content[0];
-    if (content.type !== 'text') {
+    if (!text) {
       throw new Error('Expected text response from classifier LLM');
     }
 
     // Strip markdown code fences if present
-    const raw = content.text
+    const raw = text
       .trim()
       .replace(/^```(?:json)?\n?/, '')
       .replace(/\n?```$/, '');

--- a/apps/server/src/services/pr-remediation-service.ts
+++ b/apps/server/src/services/pr-remediation-service.ts
@@ -20,7 +20,6 @@ import { exec } from 'node:child_process';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { createLogger } from '@protolabsai/utils';
-import Anthropic from '@anthropic-ai/sdk';
 import {
   PRConflictClassifier,
   type ConflictClassification,
@@ -59,7 +58,6 @@ export interface PRRemediationInput {
   prNumber: number;
   /** Current retry attempt number (1-based). Classification triggers on attempt >= 2. */
   retryAttempt: number;
-  anthropic: Anthropic;
   /** Maximum total remediation attempts before budget exhaustion (default: 3). */
   maxRetries?: number;
 }
@@ -118,7 +116,7 @@ function sanitizePrNumber(prNumber: unknown): number {
  * observability.
  */
 export async function classifyAndRemediate(input: PRRemediationInput): Promise<RemediationResult> {
-  const { projectPath, anthropic, maxRetries = 3 } = input;
+  const { projectPath, maxRetries = 3 } = input;
   const prNumber = sanitizePrNumber(input.prNumber);
   const retryAttempt = input.retryAttempt;
 
@@ -160,7 +158,7 @@ export async function classifyAndRemediate(input: PRRemediationInput): Promise<R
   // Classify the conflict
   let classification: ConflictClassification;
   try {
-    const classifier = new PRConflictClassifier({ projectPath, prNumber, anthropic });
+    const classifier = new PRConflictClassifier({ projectPath, prNumber });
     classification = await classifier.classify();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/apps/server/src/services/risk-classifier.ts
+++ b/apps/server/src/services/risk-classifier.ts
@@ -9,8 +9,8 @@
 
 import type { RiskLevel } from '@protolabsai/types';
 import { createLogger } from '@protolabsai/utils';
-import { resolveModelString } from '@protolabsai/model-resolver';
-import Anthropic from '@anthropic-ai/sdk';
+import { generateText } from 'ai';
+import { getAnthropicModel } from '../lib/ai-provider.js';
 
 const logger = createLogger('RiskClassifier');
 
@@ -64,8 +64,6 @@ export interface WorkItemForClassification {
 export interface RiskClassifierConfig {
   /** Threshold below which items are auto-approved (inclusive) */
   autoApproveThreshold: RiskLevel;
-  /** Anthropic API client */
-  anthropic: Anthropic;
 }
 
 /**
@@ -168,27 +166,22 @@ export class RiskClassifier {
     logger.info(`Classifying work item: ${item.title}`);
 
     const prompt = buildClassificationPrompt(item);
-    const model = resolveModelString('haiku');
 
     try {
-      const response = await this.config.anthropic.messages.create({
-        model,
-        max_tokens: 1024,
-        messages: [
-          {
-            role: 'user',
-            content: prompt,
-          },
-        ],
+      // Routed through the protoLabs gateway (gateway-first migration) — no
+      // direct Anthropic SDK / ANTHROPIC_API_KEY.
+      const { text } = await generateText({
+        model: await getAnthropicModel('protolabs/fast'),
+        maxOutputTokens: 1024,
+        prompt,
       });
 
-      const content = response.content[0];
-      if (content.type !== 'text') {
+      if (!text) {
         throw new Error('Expected text response from classifier');
       }
 
       // Parse JSON response
-      const result = JSON.parse(content.text);
+      const result = JSON.parse(text);
 
       const dimensions: RiskDimensions = {
         scope: result.scope as RiskLevel,
@@ -281,11 +274,9 @@ export class RiskClassifier {
  * Create a risk classifier with default configuration
  */
 export function createRiskClassifier(
-  anthropic: Anthropic,
   autoApproveThreshold: RiskLevel = DEFAULT_AUTO_APPROVE_THRESHOLD
 ): RiskClassifier {
   return new RiskClassifier({
-    anthropic,
     autoApproveThreshold,
   });
 }

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -129,6 +129,12 @@ export interface Credentials {
     openai: string;
     /** Groq API key for fast LLM inference */
     groq?: string;
+    /**
+     * protoLabs LiteLLM gateway key. Primary credential post gateway-first
+     * migration — terminates auth for all model calls (chat + flows). Resolved
+     * by lib/ai-provider.ts and lib/flow-model-factory.ts.
+     */
+    protolabsGateway?: string;
   };
   /** Webhook secrets for external integrations */
   webhookSecrets?: {


### PR DESCRIPTION
## Summary

Finishes the gateway-first migration — the cause of the #4028 401s. Several services bypassed the gateway by constructing the raw `@anthropic-ai/sdk` client (or LangChain `ChatAnthropic`) with **no gateway baseURL**, so they hit `api.anthropic.com` with the intentionally-unset `ANTHROPIC_API_KEY` and 401'd. Adding an Anthropic key was the wrong fix; the right one is to route everything through the gateway.

## Direct Anthropic SDK call sites → gateway
Replaced `new Anthropic().messages.create(...)` with `generateText({ model: await getAnthropicModel(...) })` (the established `lib/ai-provider.ts` pattern, OpenAI-compatible `/v1/chat/completions`):
- `fact-store-service`, `knowledge-ingestion-service`, `knowledge-embedding-orchestrator`
- `agent-session-manager` (compaction) — **short-circuits to deterministic** when no gateway key resolves, so keyless servers and unit tests never make a network call
- `pr-conflict-classifier` + `pr-remediation-service` + `ava-tools` — stopped threading an `Anthropic` instance through the chain
- `risk-classifier` (+ `createRiskClassifier` factory)

## LangGraph flows (`flow-model-factory`) — the bigger half
Default `protolabs/*` phase models carry no `providerId`, so `provider` was `undefined` and they fell through to a `new ChatAnthropic({ model: 'claude-sonnet-...' })` fallback → direct `api.anthropic.com` → **401 on every flow**. Now:
- Explicit providers with a `baseUrl` are still honored (custom/direct endpoints).
- Everything else (default `protolabs/*`, legacy `claude-*`, unknown ids) routes through the gateway via `ChatOpenAI`; legacy Claude aliases remap to a gateway tier (mirrors `ai-provider.ts`).

## Types
Added `Credentials.apiKeys.protolabsGateway` — the gateway key the resolver already reads at runtime (previously only on `ai-provider.ts`'s inline type).

## On `.automaker/settings.json` model tiers
No change needed: `DEFAULT_PHASE_MODELS` already defaults every phase to `protolabs/*` gateway tiers, and protoMaker's committed settings has no stale `claude-*` override, so it already inherits the gateway tiers (and satisfies the release-tools `automaker-settings-committed` rule). Adding explicit tiers would be redundant config that risks drift.

## Verification
- Zero `new Anthropic()` / `.messages.create` / direct `ChatAnthropic` fallback remain in `apps/server/src` (non-test).
- `AgentSessionManager` tests already use the no-key form; no test injected a mock Anthropic client; the two related test files (`pr-remediation`, `knowledge-embedding-invalidation`) don't exercise the migrated LLM paths.
- Local env has no built workspace deps, so typecheck/tests run in CI.

Closes #4028.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated LLM routing to use a protoLabs gateway infrastructure for improved model management and flexibility. All AI-powered features (conflict classification, knowledge extraction, risk assessment, etc.) now route through the gateway.
  
* **New Features**
  * Added optional protoLabs gateway API key credential support for gateway-based LLM routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/4029?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->