### PR TITLE
docs(cli): document putting `protomaker` on PATH (#3955)

### DIFF
--- a/docs/internal/dev/operator-tooling.md
+++ b/docs/internal/dev/operator-tooling.md
@@ -25,6 +25,21 @@ Verify after restart: the `studio` MCP tools enumerate, and `/cli-control` is av
 
 `@protolabsai/cli` (bin: `protomaker`) talks to the server's HTTP API directly — no MCP needed. Build with `npm run build:packages`; run with `node packages/cli/dist/cli.js <cmd>` (or the linked `protomaker` bin).
 
+### Put `protomaker` on your PATH (one-time)
+
+On a fresh checkout `protomaker` is a **workspace** bin (`node_modules/.bin/protomaker`), which is only on PATH inside npm scripts / `npx` — not in a normal shell. The skills (`/cli-control`, Ava) call bare `protomaker`, so link it globally once:
+
+```bash
+npm run build:packages                 # ensure packages/cli/dist exists first
+npm link --workspace=@protolabsai/cli  # global symlink → `protomaker` resolves anywhere
+protomaker health                      # verify
+```
+
+`npm link` is reversible (`npm rm -g @protolabsai/cli`) and the CLI is self-contained (only `commander` at runtime). Alternatives if you don't want a global link:
+
+- `npx --workspace=@protolabsai/cli protomaker <cmd>` — resolves the workspace bin without linking.
+- `node packages/cli/dist/cli.js <cmd>` — direct path (what the skills fall back to).
+
 Config: `AUTOMAKER_API_URL` (default `http://localhost:3008`) + `AUTOMAKER_API_KEY` (env or `.env`); `x-api-key` is sent on every request.
 
 ```bash

--- a/packages/mcp-server/plugins/automaker/commands/cli-control.md
+++ b/packages/mcp-server/plugins/automaker/commands/cli-control.md
@@ -14,7 +14,7 @@ Drive the entire board + crew over the `protomaker` CLI — no MCP server requir
 
 ## Invocation & global flags
 
-The binary is `protomaker` (from `@protolabsai/cli`). In this monorepo without a global install, run `node packages/cli/dist/cli.js …` (build first with `npm run build --workspace=@protolabsai/cli`).
+The binary is `protomaker` (from `@protolabsai/cli`). If a bare `protomaker` isn't found, it's just not on PATH yet — link it once: `npm run build:packages && npm link --workspace=@protolabsai/cli`. Without linking, fall back to `npx --workspace=@protolabsai/cli protomaker …` or `node packages/cli/dist/cli.js …` (build first with `npm run build --workspace=@protolabsai/cli`). See `docs/internal/dev/operator-tooling.md` → "Put `protomaker` on your PATH".
 
 Global flags (apply to every command):
 


### PR DESCRIPTION
## Summary

On a fresh checkout `protomaker` is a workspace bin (`node_modules/.bin/protomaker`) — only on PATH inside npm scripts / `npx`, not a normal shell. So the `/cli-control` and Ava skills' bare `protomaker` calls fail until an operator manually discovers `npm link`. This documents the one-time fix (the issue's recommended option 2 + the npx fallback from option 3).

- **`operator-tooling.md`** — new "Put `protomaker` on your PATH" section: one-time `npm link --workspace=@protolabsai/cli`, plus `npx`/`node`-path fallbacks and how to unlink.
- **`cli-control` skill** — surfaces the link command + `npx` fallback in the invocation preamble so it's discoverable from the skill itself.

Docs/skill only — no code.

Closes #3955.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced developer documentation for `protomaker` setup and installation, including step-by-step PATH configuration instructions and health verification commands.
  * Added guidance on alternative invocation methods (`npx` and direct node execution) for users with different installation preferences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/4030?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->