### PR TITLE
feat(observability): caller_trace_id on REVIEW + DEPLOY spans (#4024)

### DIFF
--- a/apps/server/src/providers/simple-query-service.ts
+++ b/apps/server/src/providers/simple-query-service.ts
@@ -15,7 +15,7 @@
  */
 
 import { ProviderFactory } from './provider-factory.js';
-import { TracedProvider } from './traced-provider.js';
+import { TracedProvider, type TracedProviderContext } from './traced-provider.js';
 import type {
   ThinkingLevel,
   ReasoningEffort,
@@ -84,14 +84,11 @@ export interface SimpleQueryOptions {
    * Tools that are explicitly disallowed for this execution.
    */
   disallowedTools?: string[];
-  /** Trace context for Langfuse enrichment (feature ID, role, project, phase) */
-  traceContext?: {
-    featureId?: string;
-    featureName?: string;
-    agentRole?: string;
-    projectSlug?: string;
-    phase?: string;
-  };
+  /**
+   * Trace context for Langfuse enrichment (feature ID, role, project, phase,
+   * caller_trace_id). Single source of truth — see TracedProviderContext.
+   */
+  traceContext?: TracedProviderContext;
 }
 
 /**

--- a/apps/server/src/services/lead-engineer-deploy-processor.ts
+++ b/apps/server/src/services/lead-engineer-deploy-processor.ts
@@ -285,6 +285,7 @@ Return ONLY the JSON array, no other text.`;
           agentRole: 'goal-verification',
           projectSlug: ctx.feature.projectSlug,
           phase: 'deploy',
+          callerTraceId: ctx.feature.callerTraceId,
         },
       });
 

--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -847,6 +847,7 @@ export class ReviewProcessor implements StateProcessor {
           featureName: ctx.feature.title,
           agentRole: 'review-feedback-audit',
           phase: 'REVIEW',
+          callerTraceId: ctx.feature.callerTraceId,
         },
       });
       return parseFeedbackAuditVerdict(result.text);


### PR DESCRIPTION
## Summary

Extends the #4023 `caller_trace_id` correlation from the **EXECUTE** phase to the **REVIEW** and **DEPLOY** phases of the board-ingested feature lifecycle — the sites where the full feature (with `callerTraceId`) is already in `ctx`:
- `lead-engineer-review-merge-processors` (review-feedback-audit)
- `lead-engineer-deploy-processor` (goal-verification)

Also makes `simpleQuery`'s `traceContext` reference `TracedProviderContext` (single source of truth) instead of duplicating a narrower inline type — so it picks up `callerTraceId` (and any future field) automatically. The wider type is a superset, so existing callers are unaffected.

## Scope — partial #4024 (kept open)
The remaining sites only have a `projectSlug` / `idea` / `prdId` in hand, **not a feature**, so `feature.callerTraceId` isn't reachable:
- project-orchestration: `project-lifecycle-service` (research), `generate-prd`, `review-prd`, `antagonistic-review-service` (ava/jon)
- PLAN: `planning-service.draftPRD`

Correlating those needs `callerTraceId` persisted at the **Project/PRD level** (tied to the project-intake path, #3983) — a distinct design piece. Filed as a follow-up; #4024 stays open for it.

## Tests
Pure additive metadata (optional field). Local env has no built deps; typecheck/tests run in CI.

Refs #4024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal trace context handling across system services for improved observability and debugging capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/4032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->