### PR TITLE
feat(archives): wire read endpoints over ArchiveQueryService (#4025)

### DIFF
--- a/apps/server/src/routes/projects/index.ts
+++ b/apps/server/src/routes/projects/index.ts
@@ -22,6 +22,8 @@ import { createUpdateHandler } from './routes/update.js';
 import { createDeleteHandler } from './routes/delete.js';
 import { createCreateFeaturesHandler } from './routes/create-features.js';
 import { createArchiveHandler } from './routes/archive.js';
+import { createArchivesListHandler, createArchivesDetailHandler } from './routes/archives.js';
+import { ArchiveQueryService } from '../../services/archive-query-service.js';
 import { createTimelineHandler } from './routes/timeline.js';
 import {
   createPostCeremonyTimelineHandler,
@@ -42,8 +44,23 @@ export function createProjectsRoutes(
 ): Router {
   const router = Router();
 
+  // Read side of the archival lifecycle (#4025) — was previously write-only.
+  const archiveQuery = new ArchiveQueryService();
+
   // List doesn't need slug validation (no slug param)
   router.post('/list', validatePathParams('projectPath'), createListHandler());
+
+  // Archived-feature reads
+  router.post(
+    '/archives/list',
+    validatePathParams('projectPath'),
+    createArchivesListHandler(archiveQuery)
+  );
+  router.post(
+    '/archives/detail',
+    validatePathParams('projectPath'),
+    createArchivesDetailHandler(archiveQuery)
+  );
 
   // All other routes use projectSlug - validate to prevent path traversal
   router.post(

--- a/apps/server/src/routes/projects/routes/archives.ts
+++ b/apps/server/src/routes/projects/routes/archives.ts
@@ -1,0 +1,69 @@
+/**
+ * Archived-feature read endpoints (#4025).
+ *
+ *   POST /archives/list   — archived features for a project (optional date range)
+ *   POST /archives/detail — full archived feature.json + agent output + meta
+ *
+ * The read side of the archival lifecycle: features are WRITTEN to the archive
+ * by ArchivalService; these expose them for read-back (audit / UI). Before this,
+ * ArchiveQueryService had no live consumer — archives were write-only.
+ */
+
+import type { Request, Response } from 'express';
+import type { ArchiveQueryService } from '../../../services/archive-query-service.js';
+import { getErrorMessage, logError } from '../common.js';
+
+export function createArchivesListHandler(archiveQuery: ArchiveQueryService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, projectSlug, dateFrom, dateTo } = req.body as {
+        projectPath: string;
+        projectSlug?: string;
+        dateFrom?: string;
+        dateTo?: string;
+      };
+
+      if (!projectPath) {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      const archives = await archiveQuery.listArchivedFeatures({
+        projectPath,
+        projectSlug,
+        dateFrom,
+        dateTo,
+      });
+      res.json({ success: true, archives });
+    } catch (error) {
+      logError(error, 'List archived features failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}
+
+export function createArchivesDetailHandler(archiveQuery: ArchiveQueryService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, featureId } = req.body as {
+        projectPath: string;
+        featureId: string;
+      };
+
+      if (!projectPath || !featureId) {
+        res.status(400).json({ success: false, error: 'projectPath and featureId are required' });
+        return;
+      }
+
+      const archive = await archiveQuery.getArchivedFeatureDetail(projectPath, featureId);
+      if (!archive) {
+        res.status(404).json({ success: false, error: `No archived feature "${featureId}"` });
+        return;
+      }
+      res.json({ success: true, archive });
+    } catch (error) {
+      logError(error, 'Get archived feature detail failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/tests/unit/routes/projects/archives.test.ts
+++ b/apps/server/tests/unit/routes/projects/archives.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for the archived-feature read endpoints (#4025).
+ *
+ * Covers the wiring between the routes and ArchiveQueryService (the read side
+ * of archival, previously write-only) and the input/404 guards.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { createMockExpressContext } from '../../../utils/mocks.js';
+import {
+  createArchivesListHandler,
+  createArchivesDetailHandler,
+} from '@/routes/projects/routes/archives.js';
+import type { ArchiveQueryService } from '@/services/archive-query-service.js';
+
+function mockArchiveQuery(overrides: Partial<ArchiveQueryService> = {}): ArchiveQueryService {
+  return {
+    listArchivedFeatures: vi.fn().mockResolvedValue([]),
+    getArchivedFeatureDetail: vi.fn().mockResolvedValue(null),
+    ...overrides,
+  } as unknown as ArchiveQueryService;
+}
+
+describe('archives read endpoints', () => {
+  describe('POST /archives/list', () => {
+    it('returns the archived features for a project', async () => {
+      const summaries = [{ featureId: 'f1', title: 'Old feature', status: 'done' }];
+      const archiveQuery = mockArchiveQuery({
+        listArchivedFeatures: vi.fn().mockResolvedValue(summaries),
+      });
+      const { req, res } = createMockExpressContext();
+      req.body = { projectPath: '/p', projectSlug: 'proj', dateFrom: '2026-01-01' };
+
+      await createArchivesListHandler(archiveQuery)(req as Request, res as Response);
+
+      expect(archiveQuery.listArchivedFeatures).toHaveBeenCalledWith({
+        projectPath: '/p',
+        projectSlug: 'proj',
+        dateFrom: '2026-01-01',
+        dateTo: undefined,
+      });
+      expect(res.json).toHaveBeenCalledWith({ success: true, archives: summaries });
+    });
+
+    it('400s when projectPath is missing', async () => {
+      const archiveQuery = mockArchiveQuery();
+      const { req, res } = createMockExpressContext();
+      req.body = {};
+
+      await createArchivesListHandler(archiveQuery)(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(archiveQuery.listArchivedFeatures).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /archives/detail', () => {
+    it('returns the archived feature detail', async () => {
+      const detail = { featureId: 'f1', feature: {}, agentOutput: null, meta: {} };
+      const archiveQuery = mockArchiveQuery({
+        getArchivedFeatureDetail: vi.fn().mockResolvedValue(detail),
+      });
+      const { req, res } = createMockExpressContext();
+      req.body = { projectPath: '/p', featureId: 'f1' };
+
+      await createArchivesDetailHandler(archiveQuery)(req as Request, res as Response);
+
+      expect(archiveQuery.getArchivedFeatureDetail).toHaveBeenCalledWith('/p', 'f1');
+      expect(res.json).toHaveBeenCalledWith({ success: true, archive: detail });
+    });
+
+    it('404s when the archived feature is not found', async () => {
+      const archiveQuery = mockArchiveQuery({
+        getArchivedFeatureDetail: vi.fn().mockResolvedValue(null),
+      });
+      const { req, res } = createMockExpressContext();
+      req.body = { projectPath: '/p', featureId: 'missing' };
+
+      await createArchivesDetailHandler(archiveQuery)(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('400s when projectPath or featureId is missing', async () => {
+      const archiveQuery = mockArchiveQuery();
+      const { req, res } = createMockExpressContext();
+      req.body = { projectPath: '/p' };
+
+      await createArchivesDetailHandler(archiveQuery)(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(archiveQuery.getArchivedFeatureDetail).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`ArchiveQueryService` had **zero live consumers** — features are written to the archive (`ArchivalService`) but were never read back except by an integration test (the "write-only archival" gap flagged in #3987). This wires the read side:

- `POST /api/projects/archives/list` — archived features for a project (optional `dateFrom`/`dateTo`, `projectSlug`)
- `POST /api/projects/archives/detail` — full archived `feature.json` + agent output + meta (404 when absent)

## Details
- Follows the existing projects-route convention (`POST` + `projectPath` in body + `validatePathParams`), not a `GET /:slug` form — consistent with `list`/`get`/`create`.
- `ArchiveQueryService` instantiated once in the route factory (`createProjectsRoutes`).
- Unit test (`archives.test.ts`) covers the wiring (correct service calls) + the input-validation/404 guards.

## Scope
Closes **#4025** — the read surface is live and tested. A board "Archived" filter/section (the optional UI half) is a small follow-up; the capability is now reachable via the API.

Local env has no built deps; typecheck/tests run in CI.

Closes #4025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two new archival API endpoints: one to list archived features with optional date filtering, and another to retrieve detailed information about specific archived features.

* **Tests**
  * Added comprehensive unit tests for archival endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/4034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->