### PR TITLE
fix(docker): install @protolabsai/proto agent CLI in image (#4039)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -150,6 +150,12 @@ RUN ln -s /opt/rh/dist/index.js /usr/local/bin/rh && chmod +x /opt/rh/dist/index
 # Install Claude CLI globally (available to all users via npm global bin)
 RUN npm install -g @anthropic-ai/claude-code
 
+# Install the protoLabs agent CLI — the executor the `proto` provider spawns for
+# the default protolabs/* model tiers. Without it, feature execution dies with
+# "CLI process exited with code 1" (#4039). Public on npmjs.org; pinned for
+# reproducibility — keep in step with the gateway.
+RUN npm install -g @protolabsai/proto@0.55.3
+
 # Install agent-browser CLI globally (binary available to all users via npm global bin)
 # Chrome download is deferred to the automaker user step below so it lands in the correct cache
 RUN npm install -g agent-browser@0.24.1

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -35,6 +35,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Claude CLI globally
 RUN npm install -g @anthropic-ai/claude-code
 
+# Install the protoLabs agent CLI — executor for the `proto` provider (default
+# protolabs/* tiers). Missing it = feature execution exits 1 (#4039).
+RUN npm install -g @protolabsai/proto@0.55.3
+
 # Install agent-browser CLI globally (binary available to all users via npm global bin)
 # Chrome download is deferred to the automaker user step below so it lands in the correct cache
 RUN npm install -g agent-browser@0.24.1

--- a/docker/dev-server/Dockerfile
+++ b/docker/dev-server/Dockerfile
@@ -79,6 +79,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install Claude CLI globally (needed for agent execution)
 RUN npm install -g @anthropic-ai/claude-code
 
+# Install the protoLabs agent CLI — executor for the `proto` provider (default
+# protolabs/* tiers). Missing it = feature execution exits 1 (#4039).
+RUN npm install -g @protolabsai/proto@0.55.3
+
 # Create non-root user with stable UID/GID
 RUN groupadd -g 1001 automaker && \
     useradd -u 1001 -g automaker -m -d /home/automaker -s /bin/bash automaker && \

--- a/scripts/launch-protomaker.sh
+++ b/scripts/launch-protomaker.sh
@@ -17,7 +17,7 @@
 
 set -uo pipefail
 
-REPO="$HOME/dev/protomaker"
+REPO="$HOME/dev/protoMaker"
 cd "$REPO" || {
   echo "[launch-protomaker] FATAL: $REPO not found"
   exit 1


### PR DESCRIPTION
## Summary

The deployed studio **can't execute features** — every dispatch dies with `CLI process exited with code 1` and reverts to backlog. Root cause (found by dogfooding a feature end-to-end through the studio): the Docker image installs `claude-code`, `cursor`, `opencode`, `agent-browser` — but **not `@protolabsai/proto`**, which is the CLI the **`proto` provider** spawns for the default `protolabs/*` model tiers (`provider-factory.ts:357` → `proto-provider.ts`). `GET /api/setup/proto-status` on the running container confirms `installed: false`.

## Changes
- **`Dockerfile`, `Dockerfile.dev`, `docker/dev-server/Dockerfile`** — `RUN npm install -g @protolabsai/proto@0.55.3` next to `claude-code` (public on npmjs.org, no registry auth needed; pinned for reproducibility).
- **`scripts/launch-protomaker.sh`** — `REPO` `protomaker` → `protoMaker`; the bare-metal LaunchAgent launch FATALed on case-sensitive Linux (separate latent bug, also in #4039).

## Deploy + verify
Code-only change to the image definition — **requires an image rebuild + redeploy** to take effect (can't be validated in CI's image build alone). After redeploy: `proto-status` should report `installed: true`, and re-dispatching the parked test feature should actually run → produce a PR. This is the confirmed fix for the #4007/#4014 "proto agent broken" surface.

Closes #4039.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added proto CLI (v0.55.3) installation to production and development Docker images to support the proto provider's executor functionality.
  * Updated launch script path configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/protoLabsAI/protoMaker/pull/4040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->