### PR TITLE
fix(proto): seed proto auth-type in container so feature execution works (#4042)

### DIFF
--- a/apps/server/src/routes/setup/routes/proto-status.ts
+++ b/apps/server/src/routes/setup/routes/proto-status.ts
@@ -25,7 +25,10 @@ const execFileAsync = promisify(execFile);
 const DISCONNECTED_MARKER_FILE = '.proto-disconnected';
 
 const INSTALL_COMMAND = 'npm install -g @protolabsai/proto';
-const LOGIN_COMMAND = '# proto reads GATEWAY_API_KEY / OPENAI_API_KEY from env';
+const LOGIN_COMMAND =
+  '# proto reads GATEWAY_API_KEY / OPENAI_API_KEY from env; the OpenAI-compatible ' +
+  'auth-type (→ gateway) is seeded in ~/.proto/settings.json at container start (#4042). ' +
+  'Standalone: `proto qwen setup` or set security.auth.selectedType=openai in ~/.proto/settings.json.';
 const DEFAULT_GATEWAY_BASE_URL = 'https://api.proto-labs.ai/v1';
 /**
  * Cap the `proto --version` probe so a misbehaving install can't hang the

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -29,6 +29,15 @@ EOF
         chmod 600 "$CURSOR_CONFIG_DIR/auth.json"
     fi
 
+    # Seed proto agent CLI auth-type (#4042). proto requires an explicit auth-type
+    # for non-interactive runs; the OpenAI-compatible client routes to OUR gateway
+    # via the OPENAI_API_KEY/OPENAI_BASE_URL the server injects (not OpenAI the
+    # vendor). Idempotent — never clobbers an existing settings file.
+    if [ ! -f "/home/automaker/.proto/settings.json" ]; then
+        mkdir -p /home/automaker/.proto 2>/dev/null || true
+        printf '%s\n' '{"security":{"auth":{"selectedType":"openai"}},"selectedAuthType":"openai"}' > /home/automaker/.proto/settings.json 2>/dev/null || true
+    fi
+
     exec "$@"
 fi
 
@@ -102,6 +111,16 @@ EOF
     chmod 600 "$CURSOR_CONFIG_DIR/auth.json"
     chown -R automaker:automaker /home/automaker/.config
 fi
+
+# Seed proto agent CLI auth-type (#4042). proto requires an explicit auth-type
+# for non-interactive runs; the OpenAI-compatible client routes to OUR gateway via
+# the OPENAI_API_KEY/OPENAI_BASE_URL the server injects (not OpenAI the vendor).
+# Idempotent — never clobbers an existing settings file.
+if [ ! -f "/home/automaker/.proto/settings.json" ]; then
+    mkdir -p /home/automaker/.proto
+    printf '%s\n' '{"security":{"auth":{"selectedType":"openai"}},"selectedAuthType":"openai"}' > /home/automaker/.proto/settings.json
+fi
+chown -R automaker:automaker /home/automaker/.proto
 
 # Switch to automaker user and execute the command
 exec gosu automaker "$@"

--- a/docs/internal/server/proto-sdk-smoke-test.md
+++ b/docs/internal/server/proto-sdk-smoke-test.md
@@ -38,12 +38,14 @@ Exit code is `0` only if every iteration passed (`1` on any failure, `2` if misc
 
 ## Interpreting a FAIL
 
-| Symptom                                 | Likely cause                                                                      |
-| --------------------------------------- | --------------------------------------------------------------------------------- |
-| `toolUses=0`, `file=false`, low `turns` | Loop stopped after planning — the protoCLI#307 regression. Check the SDK version. |
-| `error=...` mentioning 401 / auth       | Gateway key not reaching the SDK. Confirm `GATEWAY_API_KEY` in `.env`.            |
-| `error=...` 529 / overloaded            | Transient gateway load — re-run; intermittent, not an SDK regression.             |
-| `result=error_*` with tools fired       | Task-level failure, not a loop failure — inspect the run.                         |
+| Symptom                                                                    | Likely cause                                                                                                                                                                                                                                                                                                     |
+| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `toolUses=0`, `file=false`, low `turns`                                    | Loop stopped after planning — the protoCLI#307 regression. Check the SDK version.                                                                                                                                                                                                                                |
+| `CLI process exited with code 1` on every run / `No auth type is selected` | proto has no auth-type configured. Seed `~/.proto/settings.json` with `{"security":{"auth":{"selectedType":"openai"}}}` — done automatically by `docker-entrypoint.sh` (#4042); standalone, run `proto qwen setup`. proto **0.55.3+** requires this even with the gateway env set (0.37.x inferred it from env). |
+| `400 Invalid model name model=qwen3.5-plus`                                | proto's default model isn't on the gateway. Pass a gateway model (`-m protolabs/fast`); protoMaker supplies the `protolabs/*` tier per-run, so this only bites bare `proto -p` calls.                                                                                                                            |
+| `error=...` mentioning 401 / auth                                          | Gateway key not reaching the SDK. Confirm `GATEWAY_API_KEY` in `.env`.                                                                                                                                                                                                                                           |
+| `error=...` 529 / overloaded                                               | Transient gateway load — re-run; intermittent, not an SDK regression.                                                                                                                                                                                                                                            |
+| `result=error_*` with tools fired                                          | Task-level failure, not a loop failure — inspect the run.                                                                                                                                                                                                                                                        |
 
 ## How this maps to protoMaker
 


### PR DESCRIPTION
## Summary
Final blocker to the studio executing features. proto **0.55.3** requires an explicit auth-type for non-interactive runs, but `proto-provider.ts` only injects the gateway env (`OPENAI_API_KEY`/`OPENAI_BASE_URL`) — so proto errored `No auth type is selected` → `CLI process exited with code 1` → circuit breaker → feature `interrupted`. (The host's old 0.37.x inferred it from env; pinning 0.55.3 in #4040 surfaced this.)

**It's a setting, not protoMaker code.** `docker-entrypoint.sh` now seeds `~/.proto/settings.json` with the OpenAI-compatible auth-type (idempotent, both root + non-root branches). The `openai` auth-type is the *protocol* — it routes to **our gateway** via the `OPENAI_BASE_URL` the server already injects (not OpenAI the vendor).

## Validated live (no guesswork)
In the running container, with the seed + a real gateway model: `proto -m protolabs/fast -p "..."` → returned a clean completion through `gateway:4000`. Auth ✅, gateway ✅, generation ✅. (The `qwen3.5-plus` default-model 400 only bites bare `proto -p` — protoMaker supplies the `protolabs/*` tier per-run.)

## Docs (per request)
- `proto-status` `loginCommand` hint updated (auth-type seed + standalone `proto qwen setup`).
- `docs/internal/server/proto-sdk-smoke-test.md`: troubleshooting rows for the auth-type exit-1 and the default-model 400.

## Deploy
Code-only image/entrypoint change → **rebuild + redeploy (Watchtower)** to take effect; then a dispatched feature executes end-to-end.

Closes #4042.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Automated OpenAI authentication configuration during Docker setup initialization
  * Enhanced setup guidance for environment variable configuration and authentication selection

* **Documentation**
  * Expanded troubleshooting guide with additional authentication failure diagnostics and resolution steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->