### PR TITLE
fix(docker): wire git push auth via gh credential helper (homelab-iac#126)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,6 +38,13 @@ EOF
         printf '%s\n' '{"security":{"auth":{"selectedType":"openai"}},"selectedAuthType":"openai"}' > /home/automaker/.proto/settings.json 2>/dev/null || true
     fi
 
+    # Wire git to authenticate pushes via the gh credential helper, using
+    # GH_TOKEN (homelab-iac#126). git-workflow-service does bare `git push origin`,
+    # which otherwise has no creds for github.com → 403. gh reads GH_TOKEN.
+    if [ -n "$GH_TOKEN" ] || [ -n "$GITHUB_TOKEN" ]; then
+        gh auth setup-git 2>/dev/null || true
+    fi
+
     exec "$@"
 fi
 
@@ -121,6 +128,14 @@ if [ ! -f "/home/automaker/.proto/settings.json" ]; then
     printf '%s\n' '{"security":{"auth":{"selectedType":"openai"}},"selectedAuthType":"openai"}' > /home/automaker/.proto/settings.json
 fi
 chown -R automaker:automaker /home/automaker/.proto
+
+# Wire git to authenticate pushes via the gh credential helper, using GH_TOKEN
+# (homelab-iac#126). Run as automaker so it lands in /home/automaker/.gitconfig.
+# git-workflow-service does bare `git push origin`, which otherwise has no creds
+# for github.com → 403. gh reads GH_TOKEN.
+if [ -n "$GH_TOKEN" ] || [ -n "$GITHUB_TOKEN" ]; then
+    gosu automaker gh auth setup-git 2>/dev/null || true
+fi
 
 # Switch to automaker user and execute the command
 exec gosu automaker "$@"


### PR DESCRIPTION
## Summary
The studio executes and commits code, but `git push` 403'd because the container had **no git credentials wired** — `git-workflow-service` does bare `git push origin`, which doesn't read env tokens. Adds `gh auth setup-git` to `docker-entrypoint.sh` (both root + non-root branches, as the `automaker` runtime user) so git authenticates github.com via the gh credential helper using `GH_TOKEN`/`GITHUB_TOKEN`.

## Validated live
With the scoped token now in the container (homelab-iac#126 provisioned a push-capable PAT) + this wiring, the studio's autonomously-committed branch **pushed successfully** (`* [new branch] feature/archived-features-board-view-ui-...`). This makes that wiring durable across container recreates (the live `gh auth setup-git` I ran is otherwise lost on the next roll).

Pairs with homelab-iac#126 (token scope + GITHUB_TOKEN export). After this image rebuilds + redeploys, the full chain works without manual steps: execute → commit → **push** → `gh pr create`.

Refs homelab-iac#126, #4044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)