### PR TITLE
Doc: CLI dispatch quickstart

### DIFF
--- a/docs/internal/dev/operator-tooling.md
+++ b/docs/internal/dev/operator-tooling.md
@@ -57,6 +57,15 @@ Global flags: `--json`, `--quiet`, `--project <path>` (defaults to cwd).
 
 > Note: command handlers are async — the CLI uses `parseAsync` so output is produced before exit (a prior sync `parse()` + `process.exit(0)` made every command silently produce nothing; fixed in #3909).
 
+### Dispatch a feature
+
+```bash
+protomaker feature create --title "…" --description "…" --complexity small
+protomaker agent start <feature-id>
+protomaker agent list                          # running agents
+protomaker agent output <agent-run-id>         # live agent logs
+```
+
 ## `br` (beads) — the task-list surface
 
 `br` is the canonical local issue tracker (see the `## Local Issue Tracker` section in `CLAUDE.md`). It's what both operators and agents use for cross-session work; the in-app TODO view is a thin wrapper over the same `.beads/` store. Dogfood it for planning:


### PR DESCRIPTION
## Summary

Add a short subsection to docs/internal/dev/operator-tooling.md, under the existing '## The protomaker CLI' section, titled '### Dispatch a feature'. Document the 3 commands: (1) 'protomaker feature create --title <t> --description <d> --complexity small' to add a feature, (2) 'protomaker agent start <featureId>' to dispatch its agent, (3) 'protomaker agent list' and 'protomaker agent output <featureId>' to monitor. Keep it to ~6-8 lines with a fenced bash block. Do not modify anything else.

---
*Created automatically by Automaker*

<!-- automaker:owner instance=transient-8ab4beac team= created=2026-06-01T06:54:13.560Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on dispatching features and managing agent operations, including command sequences for feature creation, agent startup, agent listing, and live output monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->