### PR TITLE
fix(merge): stop enabling GitHub native auto-merge — platform owns the merge gate

### DIFF
--- a/apps/server/src/routes/worktree/routes/create-pr.ts
+++ b/apps/server/src/routes/worktree/routes/create-pr.ts
@@ -449,19 +449,9 @@ export function createCreatePRHandler(settingsService?: SettingsService) {
                   logger.error('Failed to store PR metadata:', metadataError);
                 }
 
-                // Enable auto-merge so PRs don't sit BLOCKED waiting for manual intervention
-                if (!draft) {
-                  try {
-                    await execFileAsync(
-                      'gh',
-                      ['pr', 'merge', String(prNumber), '--auto', '--squash'],
-                      { cwd: worktreePath, env: execEnv }
-                    );
-                    logger.info(`Auto-merge enabled on PR #${prNumber}`);
-                  } catch (autoMergeError) {
-                    logger.warn(`Failed to enable auto-merge on PR #${prNumber}:`, autoMergeError);
-                  }
-                }
+                // Intentionally do NOT enable GitHub auto-merge. The platform owns the
+                // merge decision via the REVIEW → MERGE flow (an approving review +
+                // green CI gate the explicit merge); GitHub auto-merge would bypass it.
               }
             }
           } catch (ghError: unknown) {

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -2014,19 +2014,11 @@ export class GitWorkflowService {
           }
         }
 
-        // Enable auto-merge so PRs don't sit BLOCKED waiting for manual intervention
-        // Use --merge for epic PRs to preserve DAG integrity
-        const mergeFlag =
-          baseBranch === 'main' || baseBranch.startsWith('epic/') ? '--merge' : '--squash';
-        try {
-          await execFileAsync('gh', ['pr', 'merge', String(prNumber), '--auto', mergeFlag], {
-            cwd: workDir,
-            env: execEnv,
-          });
-          logger.info(`Auto-merge enabled on PR #${prNumber} (${mergeFlag})`);
-        } catch (autoMergeError) {
-          logger.warn(`Failed to enable auto-merge on PR #${prNumber}:`, autoMergeError);
-        }
+        // Intentionally do NOT enable GitHub auto-merge here. The platform owns the
+        // merge decision: the REVIEW gate (getPRReviewState) requires an approving
+        // review AND green CI before MergeProcessor merges explicitly. GitHub
+        // auto-merge honors only *required* branch-protection checks and would merge
+        // past that gate the moment required checks pass.
       }
 
       return { prUrl, prNumber, prAlreadyExisted: false, prCreatedAt };

--- a/apps/server/src/services/lead-engineer-action-executor.ts
+++ b/apps/server/src/services/lead-engineer-action-executor.ts
@@ -18,7 +18,6 @@ import type {
   ActionProposal,
 } from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
-import { resolveMergeStrategy } from '../lib/merge-strategy.js';
 import type { FeatureLoader } from './feature-loader.js';
 import type { AutoModeService } from './auto-mode-service.js';
 import type { CodeRabbitResolverService } from './coderabbit-resolver-service.js';
@@ -153,22 +152,6 @@ export class ActionExecutor {
           logger.info(`Unblocked feature ${action.featureId}`);
         } catch (err) {
           logger.error(`Failed to unblock feature ${action.featureId}:`, err);
-        }
-        break;
-      }
-
-      case 'enable_auto_merge': {
-        try {
-          const mergeFlag = await resolveMergeStrategy(action.prNumber, session.projectPath);
-          await execAsync(`gh pr merge ${action.prNumber} --auto ${mergeFlag}`, {
-            cwd: session.projectPath,
-            timeout: 30000,
-          });
-          const pr = session.worldState.openPRs.find((p) => p.featureId === action.featureId);
-          if (pr) pr.autoMergeEnabled = true;
-          logger.info(`Enabled auto-merge on PR #${action.prNumber} (${mergeFlag})`);
-        } catch (err) {
-          logger.warn(`Failed to enable auto-merge on PR #${action.prNumber}:`, err);
         }
         break;
       }
@@ -493,15 +476,6 @@ function buildProposalForAction(
         justification: 'Lead engineer rule: unblock feature',
         risk: 'low',
         statusTransition: { from: 'blocked', to: 'backlog' },
-      };
-
-    case 'enable_auto_merge':
-      return {
-        who,
-        what: 'merge_pr',
-        target: `PR #${action.prNumber}`,
-        justification: 'Lead engineer rule: enable auto-merge on approved PR',
-        risk: 'medium',
       };
 
     case 'stop_agent':

--- a/apps/server/src/services/lead-engineer-rules.ts
+++ b/apps/server/src/services/lead-engineer-rules.ts
@@ -16,7 +16,6 @@ import type {
 
 const ORPHANED_IN_PROGRESS_MS = 4 * 60 * 60 * 1000; // 4 hours (backstop)
 const STUCK_AGENT_MS = 2 * 60 * 60 * 1000; // 2 hours
-const STALE_REVIEW_MS = 30 * 60 * 1000; // 30 minutes
 // Escalation thresholds for stale in_progress detection (faster than the 4h backstop)
 const FAILURE_STALE_MS = 30 * 60 * 1000; // 30 min: trigger when failureCount > 0 + no agent
 const UNPUSHED_BRANCH_STALE_MS = 45 * 60 * 1000; // 45 min: trigger when worktree created but branch never pushed
@@ -246,47 +245,6 @@ export const autoModeHealth: LeadFastPathRule = {
 };
 
 /**
- * staleReview — In review >30min with no auto-merge → enable auto-merge.
- * Absorbed from: pr-maintainer
- */
-export const staleReview: LeadFastPathRule = {
-  name: 'staleReview',
-  description: 'In review >30min + no auto-merge → enable auto-merge',
-  triggers: ['feature:status-changed', 'lead-engineer:rule-evaluated'],
-  ruleType: 'mechanical',
-
-  evaluate(worldState, _eventType, payload): LeadRuleAction[] {
-    const actions: LeadRuleAction[] = [];
-    const now = Date.now();
-
-    const feature = featureFromPayload(worldState, payload);
-    const candidates = feature ? [feature] : Object.values(worldState.features);
-
-    for (const f of candidates) {
-      if (f.status !== 'review') continue;
-      if (!f.prNumber) continue;
-
-      // Check if PR already has auto-merge
-      const pr = worldState.openPRs.find((p) => p.featureId === f.id);
-      if (pr?.autoMergeEnabled) continue;
-
-      // Check age
-      const reviewStart = f.prCreatedAt;
-      if (!reviewStart) continue;
-      const age = now - new Date(reviewStart).getTime();
-      if (age > STALE_REVIEW_MS) {
-        actions.push({
-          type: 'enable_auto_merge',
-          featureId: f.id,
-          prNumber: f.prNumber,
-        });
-      }
-    }
-    return actions;
-  },
-};
-
-/**
  * stuckAgent — Agent running >2h → send "wrap up" message.
  * Absorbed from: ava-check
  */
@@ -370,11 +328,17 @@ export const projectCompleting: LeadFastPathRule = {
 };
 
 /**
- * prApproved — PR approved → enable auto-merge + resolve threads directly.
+ * prApproved — PR approved → resolve any unresolved threads directly.
+ *
+ * Does NOT enable GitHub auto-merge: the platform owns the merge decision via the
+ * REVIEW → MERGE flow (getPRReviewState requires an approving review + green CI,
+ * then MergeProcessor merges explicitly). Handing the merge to GitHub auto-merge
+ * would bypass that gate, since GitHub honors only *required* branch-protection
+ * checks.
  */
 export const prApproved: LeadFastPathRule = {
   name: 'prApproved',
-  description: 'PR approved → enable auto-merge + resolve unresolved threads',
+  description: 'PR approved → resolve unresolved threads',
   triggers: ['pr:approved', 'github:pr:approved'],
   ruleType: 'mechanical',
 
@@ -385,15 +349,6 @@ export const prApproved: LeadFastPathRule = {
     if (!feature.prNumber) return [];
 
     const pr = worldState.openPRs.find((p) => p.featureId === feature.id);
-
-    // Enable auto-merge if not already enabled
-    if (!pr?.autoMergeEnabled) {
-      actions.push({
-        type: 'enable_auto_merge',
-        featureId: feature.id,
-        prNumber: feature.prNumber,
-      });
-    }
 
     // Resolve threads directly if any are unresolved
     if (pr && (pr.unresolvedThreads ?? 0) > 0) {
@@ -708,7 +663,6 @@ export const DEFAULT_RULES: LeadFastPathRule[] = [
   orphanedInProgress,
   staleDeps,
   autoModeHealth,
-  staleReview,
   stuckAgent,
   capacityRestart,
   projectCompleting,

--- a/apps/server/tests/unit/services/lead-engineer-rules.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-rules.test.ts
@@ -5,7 +5,6 @@ import {
   orphanedInProgress,
   staleDeps,
   autoModeHealth,
-  staleReview,
   stuckAgent,
   capacityRestart,
   projectCompleting,
@@ -372,65 +371,6 @@ describe('autoModeHealth', () => {
   });
 });
 
-// ────────────────────────── staleReview ──────────────────────────
-
-describe('staleReview', () => {
-  it('enables auto-merge for review feature >30min without auto-merge', () => {
-    const fortyMinAgo = new Date(Date.now() - 40 * 60 * 1000).toISOString();
-    const feature = createFeature({
-      id: 'f1',
-      status: 'review',
-      prNumber: 42,
-      prCreatedAt: fortyMinAgo,
-    });
-    const ws = createMockWorldState({ features: { f1: feature } });
-    const actions = staleReview.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
-    expect(actions).toHaveLength(1);
-    expect(actions[0]).toEqual({ type: 'enable_auto_merge', featureId: 'f1', prNumber: 42 });
-  });
-
-  it('no-ops when auto-merge is already enabled', () => {
-    const fortyMinAgo = new Date(Date.now() - 40 * 60 * 1000).toISOString();
-    const feature = createFeature({
-      id: 'f1',
-      status: 'review',
-      prNumber: 42,
-      prCreatedAt: fortyMinAgo,
-    });
-    const ws = createMockWorldState({
-      features: { f1: feature },
-      openPRs: [{ featureId: 'f1', prNumber: 42, autoMergeEnabled: true }],
-    });
-    const actions = staleReview.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
-    expect(actions).toHaveLength(0);
-  });
-
-  it('no-ops when review is < 30min', () => {
-    const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000).toISOString();
-    const feature = createFeature({
-      id: 'f1',
-      status: 'review',
-      prNumber: 42,
-      prCreatedAt: tenMinAgo,
-    });
-    const ws = createMockWorldState({ features: { f1: feature } });
-    const actions = staleReview.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
-    expect(actions).toHaveLength(0);
-  });
-
-  it('no-ops when feature has no PR number', () => {
-    const fortyMinAgo = new Date(Date.now() - 40 * 60 * 1000).toISOString();
-    const feature = createFeature({
-      id: 'f1',
-      status: 'review',
-      prCreatedAt: fortyMinAgo,
-    });
-    const ws = createMockWorldState({ features: { f1: feature } });
-    const actions = staleReview.evaluate(ws, 'feature:status-changed', { featureId: 'f1' });
-    expect(actions).toHaveLength(0);
-  });
-});
-
 // ────────────────────────── stuckAgent ──────────────────────────
 
 describe('stuckAgent', () => {
@@ -557,7 +497,7 @@ describe('projectCompleting', () => {
 // ────────────────────────── prApproved ──────────────────────────
 
 describe('prApproved', () => {
-  it('enables auto-merge when PR is approved and auto-merge not enabled', () => {
+  it('never hands the merge to GitHub auto-merge (platform owns merge)', () => {
     const feature = createFeature({
       id: 'f1',
       status: 'review',
@@ -565,10 +505,11 @@ describe('prApproved', () => {
     });
     const ws = createMockWorldState({
       features: { f1: feature },
-      openPRs: [{ featureId: 'f1', prNumber: 50, autoMergeEnabled: false }],
+      openPRs: [{ featureId: 'f1', prNumber: 50, unresolvedThreads: 3 }],
     });
     const actions = prApproved.evaluate(ws, 'pr:approved', { featureId: 'f1' });
-    expect(actions.some((a) => a.type === 'enable_auto_merge')).toBe(true);
+    // No 'enable_auto_merge' action exists anymore — the REVIEW → MERGE flow merges.
+    expect(actions.some((a) => (a as { type: string }).type === 'enable_auto_merge')).toBe(false);
   });
 
   it('resolves threads when PR is approved and has unresolved threads', () => {
@@ -585,7 +526,7 @@ describe('prApproved', () => {
     expect(actions.some((a) => a.type === 'resolve_threads_direct')).toBe(true);
   });
 
-  it('skips auto-merge when already enabled', () => {
+  it('emits no actions when approved with no unresolved threads', () => {
     const feature = createFeature({
       id: 'f1',
       status: 'review',
@@ -593,7 +534,7 @@ describe('prApproved', () => {
     });
     const ws = createMockWorldState({
       features: { f1: feature },
-      openPRs: [{ featureId: 'f1', prNumber: 50, autoMergeEnabled: true, unresolvedThreads: 0 }],
+      openPRs: [{ featureId: 'f1', prNumber: 50, unresolvedThreads: 0 }],
     });
     const actions = prApproved.evaluate(ws, 'pr:approved', { featureId: 'f1' });
     expect(actions).toHaveLength(0);
@@ -1123,8 +1064,8 @@ describe('LeadFastPathRule.ruleType', () => {
     expect(MECHANICAL_RULES.length).toBeGreaterThan(REASONING_RULES.length);
   });
 
-  it('MECHANICAL_RULES count is at least 13', () => {
-    expect(MECHANICAL_RULES.length).toBeGreaterThanOrEqual(13);
+  it('MECHANICAL_RULES count is at least 12', () => {
+    expect(MECHANICAL_RULES.length).toBeGreaterThanOrEqual(12);
   });
 
   it('REASONING_RULES count is exactly 1 (classifiedRecovery)', () => {

--- a/apps/server/tests/unit/services/lead-engineer-service.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-service.test.ts
@@ -997,9 +997,9 @@ describe('Two-tier rule routing', () => {
     }
   });
 
-  it('MECHANICAL_RULES count is at least 13', async () => {
+  it('MECHANICAL_RULES count is at least 12', async () => {
     const { MECHANICAL_RULES } = await import('@/services/lead-engineer-rules.js');
-    expect(MECHANICAL_RULES.length).toBeGreaterThanOrEqual(13);
+    expect(MECHANICAL_RULES.length).toBeGreaterThanOrEqual(12);
   });
 
   it('REASONING_RULES count is exactly 1 (classifiedRecovery)', async () => {

--- a/libs/types/src/lead-engineer.ts
+++ b/libs/types/src/lead-engineer.ts
@@ -218,7 +218,6 @@ export type LeadRuleAction =
   | { type: 'move_feature'; featureId: string; toStatus: FeatureStatus }
   | { type: 'reset_feature'; featureId: string; reason: string }
   | { type: 'unblock_feature'; featureId: string }
-  | { type: 'enable_auto_merge'; featureId: string; prNumber: number }
   | { type: 'resolve_threads'; featureId: string; prNumber: number }
   | { type: 'resolve_threads_direct'; featureId: string; prNumber: number }
   | { type: 'restart_auto_mode'; projectPath: string; maxConcurrency?: number }


### PR DESCRIPTION
## Problem

The studio's REVIEW gate (`getPRReviewState`) already requires **an approving review AND green CI** before `MergeProcessor` merges explicitly (`lead-engineer-review-merge-processors.ts:1359` — "CI passing alone is not sufficient"). But three code paths handed the merge to **GitHub's native auto-merge** (`gh pr merge --auto`), which honors only *required* branch-protection checks. With the `Protect main` ruleset at `required_approving_review_count: 0` (CI-only gate), GitHub auto-merged PRs the moment CI went green — **bypassing the studio's approving-review gate entirely**.

### Evidence (PR #4046)
- `autoMergeRequest` was enabled; `mergedBy` = the studio token identity.
- Its only review was `protoquinn` `state: COMMENTED` — "VERDICT: PASS (provisional)". `reviewDecision: ""`, `approvedCount: 0`.
- By the studio's own `getPRReviewState` that is `'pending'`, not `'approved'` — yet GitHub auto-merge landed it on CI-green.

## Fix

Remove all three auto-merge enablers so the platform's `MergeProcessor` is the **sole merge path** (aligning with the intent already documented in `github-merge-service` and `normalizePR`, both of which explicitly avoid `--auto`):

- **`staleReview` rule** — enabled auto-merge purely on age (>30min in review), *regardless of approval*. Removed (sole purpose was the bypass).
- **`prApproved` rule** — drops the `enable_auto_merge` action; keeps thread resolution. Merge after approval flows through REVIEW → MERGE.
- **`enable_auto_merge` action type** + both executor cases — removed.
- **`git-workflow-service`** PR-creation `--auto` — removed.
- **`create-pr` route** `--auto --squash` — removed.

## Consequence (follow-up required)

With this in place, a PR will **not merge until it has an approving review** (`approvedCount > 0`). `protoquinn` currently submits only `COMMENTED` reviews, so the QA bot must be upgraded to emit a final `APPROVED` verdict on terminal-green CI (or a human approves) — otherwise PRs stall in REVIEW until timeout. Tracked separately.

## Test plan
- [x] `lead-engineer-rules` unit tests updated — 93 pass
- [x] action-executor / github-merge / review-merge-processors / merge-eligibility tests — 47 pass
- [x] `tsc` clean (server), `build:packages` clean, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)