### PR TITLE
fix(auto-mode): detect & retry gateway empty-stream timeouts (#4044 A)

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -3603,6 +3603,31 @@ After generating the revised spec, output:
         );
       }
 
+      // Empty-stream detection (gateway timeout).
+      // The gateway / proto SDK transport can kill the stream at a fixed idle/total timeout
+      // (~5 min) with no meaningful content. Unlike the degenerate-success guard above,
+      // this catches long-running streams that produced an empty or near-empty response —
+      // a transient gateway-level timeout that should be retried, not hard-blocked.
+      const EMPTY_STREAM_MIN_RUNTIME_MS = 3 * 60 * 1000; // 3 min — below this is normal init
+      const EMPTY_STREAM_MAX_CHARS = 500;
+      const EMPTY_STREAM_MIN_COST_USD = 0.001; // must have spent money (real API call)
+      if (
+        !process.env.AUTOMAKER_MOCK_AGENT &&
+        elapsedRuntimeMs > EMPTY_STREAM_MIN_RUNTIME_MS &&
+        responseText.trim().length < EMPTY_STREAM_MAX_CHARS &&
+        runCostUsd >= EMPTY_STREAM_MIN_COST_USD
+      ) {
+        logger.warn(
+          `[EmptyStream] Feature ${featureId}: stream ran for ${Math.round(elapsedRuntimeMs / 1000)}s ` +
+            `but produced only ${responseText.trim().length} chars (cost: $${runCostUsd.toFixed(4)}). ` +
+            `Likely gateway timeout. Throwing retryable error.`
+        );
+        throw new Error(
+          `error_empty_stream: Model stream ended with minimal response after ${Math.round(elapsedRuntimeMs / 1000)}s. ` +
+            `This is likely a gateway timeout — retryable.`
+        );
+      }
+
       // Flush remaining raw output (only if enabled, on success path)
       if (enableRawOutput && rawOutputLines.length > 0) {
         try {

--- a/apps/server/src/services/recovery-service.ts
+++ b/apps/server/src/services/recovery-service.ts
@@ -400,6 +400,11 @@ ${this.generateCategoryGuidance(category, successRate, strategies)}
       return 'rate_limit';
     }
 
+    // Empty stream (gateway timeout) — transient, retryable
+    if (errorInfo.isEmptyStream || errorInfo.type === 'empty_stream') {
+      return 'transient';
+    }
+
     // Check for test failures
     if (
       message.includes('test failed') ||

--- a/apps/server/tests/unit/services/recovery-service.test.ts
+++ b/apps/server/tests/unit/services/recovery-service.test.ts
@@ -59,6 +59,7 @@ describe('recovery-service.ts', () => {
     isCancellation: false,
     isRateLimit: false,
     isQuotaExhausted: false,
+    isEmptyStream: false,
     originalError: new Error('Test error'),
     ...overrides,
   });
@@ -100,6 +101,22 @@ describe('recovery-service.ts', () => {
     it('should analyze transient errors and recommend retry', async () => {
       const error = new Error('connection timeout');
       const errorInfo = makeErrorInfo({ message: 'connection timeout' });
+      const context = makeContext();
+
+      const analysis = await service.analyzeFailure(error, errorInfo, context);
+
+      expect(analysis.category).toBe('transient');
+      expect(analysis.recoveryStrategy.type).toBe('retry');
+      expect(analysis.isRetryable).toBe(true);
+    });
+
+    it('should treat empty-stream (gateway timeout) errors as transient and retry', async () => {
+      const error = new Error('error_empty_stream: Model stream ended with minimal response');
+      const errorInfo = makeErrorInfo({
+        message: 'error_empty_stream: Model stream ended with minimal response',
+        type: 'empty_stream',
+        isEmptyStream: true,
+      });
       const context = makeContext();
 
       const analysis = await service.analyzeFailure(error, errorInfo, context);

--- a/libs/types/src/error.ts
+++ b/libs/types/src/error.ts
@@ -11,6 +11,7 @@ export type ErrorType =
   | 'quota_exhausted'
   | 'max_turns'
   | 'network'
+  | 'empty_stream'
   | 'unknown';
 
 /**
@@ -26,6 +27,7 @@ export interface ErrorInfo {
   isRateLimit: boolean;
   isQuotaExhausted: boolean; // Session/weekly usage limit reached
   isMaxTurns: boolean; // Agent exceeded max turn limit
+  isEmptyStream: boolean; // Model stream ended with empty/minimal response (gateway timeout)
   retryAfter?: number; // Seconds to wait before retrying (for rate limit errors)
   originalError: unknown;
 }

--- a/libs/utils/src/error-handler.ts
+++ b/libs/utils/src/error-handler.ts
@@ -206,10 +206,17 @@ export function classifyError(error: unknown): ErrorInfo {
 
   // Check for SDK-specific error subtypes
   const isMaxTurns = message.startsWith('error_max_turns:');
+  const isEmptyStream =
+    message.startsWith('error_empty_stream:') ||
+    message.includes('Model stream ended with empty') ||
+    message.includes('stream ended with empty response');
 
   let type: ErrorType;
   if (isMaxTurns) {
     type = 'max_turns';
+  } else if (isEmptyStream) {
+    // Gateway timeout: stream ended empty after a long run — transient, retryable
+    type = 'empty_stream';
   } else if (isConfigCorrupted) {
     // Priority over authentication: a truncated credentials file surfaces as an
     // auth error too, but the real failure is disk/config, not the key (#3564).
@@ -244,6 +251,7 @@ export function classifyError(error: unknown): ErrorInfo {
     isRateLimit,
     isQuotaExhausted,
     isMaxTurns,
+    isEmptyStream,
     retryAfter,
     originalError: error,
   };

--- a/libs/utils/tests/error-handler.test.ts
+++ b/libs/utils/tests/error-handler.test.ts
@@ -307,6 +307,25 @@ describe('error-handler.ts', () => {
       expect(result.isAuth).toBe(false);
       expect(result.isAbort).toBe(false);
       expect(result.isCancellation).toBe(false);
+      expect(result.isEmptyStream).toBe(false);
+    });
+
+    it("should classify empty-stream errors from the 'error_empty_stream:' prefix", () => {
+      const error = new Error(
+        'error_empty_stream: Model stream ended with minimal response after 312s. This is likely a gateway timeout — retryable.'
+      );
+      const result = classifyError(error);
+
+      expect(result.type).toBe('empty_stream');
+      expect(result.isEmptyStream).toBe(true);
+    });
+
+    it("should classify empty-stream errors from the 'Model stream ended with empty' message", () => {
+      const error = new Error('Model stream ended with empty response text');
+      const result = classifyError(error);
+
+      expect(result.type).toBe('empty_stream');
+      expect(result.isEmptyStream).toBe(true);
     });
 
     it('should classify unknown errors (non-Error)', () => {


### PR DESCRIPTION
## Problem

Part **(A)** of #4044. The protoLabs gateway / proto SDK transport kills long-running streams at a fixed (~5 min) idle/total timeout with little or no content. This surfaced as a feature that ran for minutes, produced an empty/near-empty response, and was **hard-failed instead of retried** — capping any long agent run. (LiteLLM `request_timeout` is 600s, so the cutoff is deeper in the serving stack; this PR makes the studio resilient to it regardless of root cause.)

## Fix — detect → classify → retry

**Detection** (`auto-mode/execution-service.ts`): after the stream ends, if it ran past a minimum runtime (3 min), produced `< 500` chars, **and** actually spent money (`cost > 0` — a real API call that returned nothing), throw a retryable `error_empty_stream:` error. The runtime + cost floors keep it from firing on normal fast/cheap runs or `AUTOMAKER_MOCK_AGENT` mode. Sits right beside the existing degenerate-success guard and reuses the same in-scope counters (`elapsedRuntimeMs`, `responseText`, `runCostUsd`).

**Classification** (`libs/types/error.ts` + `libs/utils/error-handler.ts`): new `empty_stream` `ErrorType` + `isEmptyStream` flag, matched from the `error_empty_stream:` prefix or a `"Model stream ended with empty…"` message.

**Recovery** (`recovery-service.ts`): `empty_stream` categorizes as `transient` → `{ type: 'retry' }` with backoff (`maxTransientRetries`) — so the feature retries instead of blocking. (Typed check placed before the generic message-match so it takes priority.)

## Test plan
- [x] `classifyError` empty_stream cases (prefix + message) — `error-handler.test.ts` 73 pass
- [x] `analyzeFailure` → `transient` / `retry` for empty_stream — `recovery-service.test.ts` 42 pass
- [x] server `tsc` clean (new required `isEmptyStream` field compiles across all `ErrorInfo` constructors), `build:packages` clean, prettier clean

## Notes
- This was uncommitted WIP on the working tree (no branch/author); reviewed, verified the full detect→classify→categorize→retry chain is wired, added tests, and carried it forward.
- Part **(B)** of #4044 (container git push 403) is handled separately via the `gh auth setup-git` entrypoint wiring.

Closes #4044 (part A; B tracked there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced detection and handling of incomplete model responses that consume API resources while producing minimal output. The system now properly identifies these edge cases and treats them as transient, retryable errors for improved reliability and cost optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->