### PR TITLE
fix(plugin): stop hooks leaking project identity across sessions

### DIFF
--- a/packages/mcp-server/plugins/automaker/.claude-plugin/plugin.json
+++ b/packages/mcp-server/plugins/automaker/.claude-plugin/plugin.json
@@ -10,7 +10,7 @@
     "studio": {
       "command": "bash",
       "args": [
-        "${AUTOMAKER_ROOT}/packages/mcp-server/plugins/automaker/hooks/start-mcp.sh"
+        "${CLAUDE_PLUGIN_ROOT}/hooks/start-mcp.sh"
       ],
       "env": {
         "AUTOMAKER_API_URL": "http://localhost:3008",

--- a/packages/mcp-server/plugins/automaker/.env.example
+++ b/packages/mcp-server/plugins/automaker/.env.example
@@ -1,9 +1,12 @@
 # Automaker Plugin Environment Variables
-# Copy this file to .env and fill in your actual values
+# Copy this file to .env and fill in your actual values.
+# This .env is sourced by hooks/start-mcp.sh — do NOT export these into your shell
+# profile (~/.zshrc, ~/.zshenv). Exporting AUTOMAKER_ROOT globally leaked the
+# project's identity into unrelated Claude Code sessions via the plugin hooks.
 
-# Automaker Root Directory (absolute path to your automaker repo)
-# Required for MCP server to locate dist/index.js
-AUTOMAKER_ROOT=/path/to/your/automaker
+# Automaker Root Directory — normally AUTO-DERIVED from start-mcp.sh's own location,
+# so you do not need to set it. Uncomment only to override for an unusual layout.
+# AUTOMAKER_ROOT=/path/to/your/automaker
 
 # Automaker API Key (for localhost:3008 auth)
 # Use "automaker-staging-key-2026" for local dev

--- a/packages/mcp-server/plugins/automaker/hooks/compaction-prime-directive.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/compaction-prime-directive.sh
@@ -6,13 +6,23 @@
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STATE_FILE="${PLUGIN_DIR}/data/ava-session-state.json"
 
-# Resolve project path: saved state > AUTOMAKER_ROOT > git root
-PROJECT_PATH=""
-if [ -f "$STATE_FILE" ]; then
-  PROJECT_PATH=$(jq -r '.projectPath // empty' "$STATE_FILE" 2>/dev/null)
+# Resolve the project from THIS session's cwd (hook stdin JSON .cwd) > git toplevel.
+# Deliberately NO AUTOMAKER_ROOT fallback and NO trust in the saved state file:
+# AUTOMAKER_ROOT is exported globally (~/.zshenv, launchctl) pinned to one project
+# for the MCP server, and the state file is a single shared blob (last project to
+# compact wins) — either would make this directive fire in unrelated sessions.
+if [ -t 0 ]; then
+  INPUT=""
+else
+  INPUT="$(cat 2>/dev/null || true)"
 fi
-if [ -z "$PROJECT_PATH" ]; then
-  PROJECT_PATH="${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || echo 'unknown')}"
+HOOK_CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)"
+PROJECT_PATH="${HOOK_CWD:-$(git -C "${HOOK_CWD:-.}" rev-parse --show-toplevel 2>/dev/null)}"
+PROJECT_PATH="${PROJECT_PATH:-$(git rev-parse --show-toplevel 2>/dev/null)}"
+
+# Guard: only fire when THIS session is actually inside an automaker-managed project.
+if [ -z "$PROJECT_PATH" ] || [ ! -d "$PROJECT_PATH/.automaker/features" ]; then
+  exit 0
 fi
 
 echo "## POST-COMPACTION: MANDATORY OPERATOR RESTORATION"
@@ -25,8 +35,11 @@ echo ""
 echo "### Saved State"
 echo "- **Project path:** ${PROJECT_PATH}"
 
-# Include saved board state if available
-if [ -f "$STATE_FILE" ]; then
+# Include saved board state only if it belongs to THIS project (otherwise a stale
+# blob from another project would print the wrong board into this session).
+SAVED_PATH=""
+[ -f "$STATE_FILE" ] && SAVED_PATH=$(jq -r '.projectPath // empty' "$STATE_FILE" 2>/dev/null)
+if [ -f "$STATE_FILE" ] && [ "$SAVED_PATH" = "$PROJECT_PATH" ]; then
   BOARD_SUMMARY=$(jq -r '"- **Board:** \(.board.total) features (\(.board.backlog) backlog, \(.board.in_progress) active, \(.board.review) review, \(.board.blocked) blocked, \(.board.done) done)"' "$STATE_FILE" 2>/dev/null)
   BRANCH=$(jq -r '"- **Branch:** \(.branch)"' "$STATE_FILE" 2>/dev/null)
   PR_COUNT=$(jq -r '"- **Open PRs:** \(.prPipeline.count)"' "$STATE_FILE" 2>/dev/null)

--- a/packages/mcp-server/plugins/automaker/hooks/pre-compact-save-state.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/pre-compact-save-state.sh
@@ -7,7 +7,10 @@
 
 set -euo pipefail
 
-# Resolve project path: session cwd (from stdin JSON) > git toplevel > AUTOMAKER_ROOT
+# Resolve project path from THIS session's cwd (stdin JSON) > git toplevel.
+# Deliberately NO AUTOMAKER_ROOT fallback: that var is exported globally
+# (~/.zshenv, launchctl) and pinned to one project for the MCP server, so using
+# it here saves the wrong project's state on every unrelated session's compaction.
 if [ -t 0 ]; then
   INPUT=""
 else
@@ -15,7 +18,7 @@ else
 fi
 HOOK_CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)"
 PROJECT_ROOT="${HOOK_CWD:-$(git -C "${HOOK_CWD:-.}" rev-parse --show-toplevel 2>/dev/null)}"
-PROJECT_ROOT="${PROJECT_ROOT:-${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}}"
+PROJECT_ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 FEATURES_DIR="$PROJECT_ROOT/.automaker/features"
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DATA_DIR="${PLUGIN_DIR}/data"

--- a/packages/mcp-server/plugins/automaker/hooks/session-context.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/session-context.sh
@@ -3,7 +3,11 @@
 # Injects board summary so Roxy/Claude starts with awareness of current state.
 # Output goes to stdout and is added to Claude's context.
 
-# Resolve project path: session cwd (from stdin JSON) > git toplevel > AUTOMAKER_ROOT
+# Resolve project path from THIS session's cwd (stdin JSON) > git toplevel.
+# Deliberately NO AUTOMAKER_ROOT fallback: that var is exported globally
+# (~/.zshenv, launchctl) and pinned to one project for the MCP server, so using
+# it here injects that project's board into every unrelated session. If we can't
+# determine the session dir, no-op (FEATURES_DIR check below) rather than leak.
 if [ -t 0 ]; then
   INPUT=""
 else
@@ -11,7 +15,7 @@ else
 fi
 HOOK_CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)"
 PROJECT_ROOT="${HOOK_CWD:-$(git -C "${HOOK_CWD:-.}" rev-parse --show-toplevel 2>/dev/null)}"
-PROJECT_ROOT="${PROJECT_ROOT:-${AUTOMAKER_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}}"
+PROJECT_ROOT="${PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 FEATURES_DIR="$PROJECT_ROOT/.automaker/features"
 
 # Get the plugin directory to access saved state

--- a/packages/mcp-server/plugins/automaker/hooks/start-mcp.sh
+++ b/packages/mcp-server/plugins/automaker/hooks/start-mcp.sh
@@ -1,17 +1,29 @@
 #!/usr/bin/env bash
 # start-mcp.sh — startup wrapper for the Automaker MCP server.
-# Validates required env vars before launching node.
+#
+# Self-locating: the repo root is derived from this script's own path, so the
+# plugin needs NO globally-exported AUTOMAKER_ROOT. (Exporting it globally leaked
+# the project's identity into every shell + Claude Code session via the plugin
+# hooks — see git history.) Secrets/overrides come from the local .env beside the
+# plugin, not the ambient environment.
 
 set -euo pipefail
 
-if [[ -z "${AUTOMAKER_ROOT:-}" ]]; then
-  echo "[automaker] AUTOMAKER_ROOT is not set." >&2
-  echo "[automaker] To fix this, create the plugin .env file:" >&2
-  echo "[automaker]   cp \"${BASH_SOURCE[0]%/hooks/*}/.env.example\" \"${BASH_SOURCE[0]%/hooks/*}/.env\"" >&2
-  echo "[automaker] Then set AUTOMAKER_ROOT to the absolute path of your protomaker clone." >&2
-  echo "[automaker] See docs/integrations/claude-plugin.md for full setup instructions." >&2
-  exit 1
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)" # packages/mcp-server/plugins/automaker
+
+# Load local secrets/overrides if present (AUTOMAKER_API_KEY, GH_TOKEN, tokens…).
+if [[ -f "$PLUGIN_DIR/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$PLUGIN_DIR/.env"
+  set +a
 fi
+
+# Repo root is authoritative from this script's location — not ambient env, not a
+# hardcoded path in .env. Layout: <root>/packages/mcp-server/plugins/automaker/hooks
+AUTOMAKER_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
+export AUTOMAKER_ROOT
 
 DIST="${AUTOMAKER_ROOT}/packages/mcp-server/dist/index.js"
 


### PR DESCRIPTION
## Problem

The plugin's `SessionStart`/`PreCompact` hooks resolved *"which project am I in"* from the globally-exported `AUTOMAKER_ROOT` plus a single shared `data/ava-session-state.json` blob. Because `AUTOMAKER_ROOT` was exported in `~/.zshenv` **and** via `launchctl setenv`, it was present in **every** shell and Claude Code session — so after any compaction, unrelated projects were told to restore the operator identity pointed at whichever project last ran. The shared state blob made it worse (last-project-to-compact wins), e.g. leaking `ORBIS` into a `protoPen` session as a "MANDATORY restore Roxy" directive.

`compaction-prime-directive.sh` had **no project guard at all**, unlike its siblings.

## Fix — root the hooks in the *session*, not the ambient env

- **`compaction-prime-directive.sh`** — add the missing guard; resolve the project from the hook stdin `.cwd` (falling back to git toplevel), never `AUTOMAKER_ROOT` or the shared state file. No-ops outside an automaker-managed project.
- **`session-context.sh` / `pre-compact-save-state.sh`** — drop the `AUTOMAKER_ROOT` fallback so they key purely off the session cwd.

## Fix — make the MCP server self-contained so `AUTOMAKER_ROOT` never needs global export

- **`plugin.json`** — launch via `${CLAUDE_PLUGIN_ROOT}/hooks/start-mcp.sh` (matches the hooks block and the rabbit-hole plugin) instead of `${AUTOMAKER_ROOT}/packages/...`.
- **`start-mcp.sh`** — derive the repo root from its own path and `source` the local `.env` for secrets; no longer requires an ambient `AUTOMAKER_ROOT`.
- **`.env.example`** — document that `AUTOMAKER_ROOT` is auto-derived and must not be exported into shell profiles.

## Out-of-repo cleanup (already applied on the maintainer machine)

`AUTOMAKER_ROOT` removed from `~/.zshenv`, `launchctl unsetenv AUTOMAKER_ROOT`, stale `~/.claude/plugins/cache/protolabs/{0.107.1,0.83.5}` copies and stale `ava-session-state.json` deleted.

## Verification

- Hooks: with a real stdin `{"cwd": "/Users/kj/dev/protoPen"}` payload they exit 0 with no output (clean); with `cwd` = protomaker they fire correctly.
- Launch chain with `AUTOMAKER_ROOT` stripped from the env: `start-mcp.sh` self-derives `/Users/kj/dev/protomaker`, finds `dist/index.js`, and `.env` provides `AUTOMAKER_API_KEY` — server launches.

The `${CLAUDE_PLUGIN_ROOT}` change takes effect on the next Claude Code restart (running MCP servers keep their old config until then); the hook changes are live immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)