### PR TITLE
fix(auto-mode): require real merge evidence for completion (#4041, #4051, #4052)

### DIFF
--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -1425,6 +1425,24 @@ Output the branch name only.`,
             projectPrBaseBranch
           );
           if (gitWorkflowResult) {
+            // #4052: the worktree was on the base branch — the agent's work was NOT
+            // committed to a feature branch, nothing was pushed, and there is no PR.
+            // This must never reach 'done'. Block so it's surfaced (friction tracker
+            // records it) and the work is preserved in the worktree for manual rescue.
+            if (gitWorkflowResult.strandedOnBase) {
+              const reason =
+                gitWorkflowResult.error ??
+                'Agent worked on the base branch; no feature-branch commit or PR was produced.';
+              logger.error(
+                `[AutoMode] Feature ${featureId} stranded on base branch — blocking (no PR; work preserved for rescue). ${reason}`
+              );
+              await this.featureLoader.update(projectPath, featureId, {
+                status: 'blocked',
+                statusChangeReason: `Work landed on the base branch instead of an isolated feature branch — nothing was pushed or opened as a PR (#4052). Changes are preserved in the worktree for rescue. ${reason}`,
+              });
+              return;
+            }
+
             // Check if git workflow encountered conflicts
             if (gitWorkflowResult.error && gitWorkflowResult.error.includes('conflict')) {
               this.typedEventBus.emitAutoModeEvent('auto_mode_progress', {
@@ -1555,23 +1573,54 @@ Output the branch name only.`,
           finalStatus = 'verified';
           await this.callbacks.updateFeatureStatus(projectPath, featureId, finalStatus);
         } else {
-          // No PR evidence after the git workflow. With committed-work detection
-          // fixed (#3845), this now genuinely means the agent produced nothing —
-          // an "empty execution", typically the SDK terminating after the
-          // planning turn (protoCLI#307). It's intermittent and usually succeeds
-          // on retry, so auto-retry up to a cap before parking for a human (#3860)
-          // instead of silently dropping the feature into review.
+          // No PR evidence after the git workflow — two very different causes that must
+          // NOT be conflated (#4051):
+          //   (a) the agent ran to completion but produced NO diff vs base — the work is
+          //       already present (merged via another branch, or a duplicate feature).
+          //       Re-dispatching is DETERMINISTIC: the agent re-finds the same already-done
+          //       state and loops, burning retries. Surface it instead — but never auto-mark
+          //       `done` without merge evidence (that's the #4041/#4052 anti-pattern).
+          //   (b) the agent terminated early (SDK planning-turn termination, protoCLI#307) —
+          //       intermittent, usually succeeds on retry.
+          // Discriminate by whether the agent produced substantial output this run.
+          let agentOutputLen = 0;
+          try {
+            const outputPath = path.join(getFeatureDir(projectPath, featureId), 'agent-output.md');
+            const content = await secureFs.readFile(outputPath, 'utf-8');
+            agentOutputLen = (typeof content === 'string' ? content : content.toString()).trim()
+              .length;
+          } catch {
+            // No output file → treat as no output (early-termination case).
+          }
+          const NO_DIFF_OUTPUT_THRESHOLD = 500; // chars; below this looks like early termination
           const MAX_EMPTY_RETRIES = 3;
           const fc = postGitFeature?.failureCount ?? 0;
-          if (fc < MAX_EMPTY_RETRIES) {
+
+          if (agentOutputLen >= NO_DIFF_OUTPUT_THRESHOLD) {
+            // (a) Ran to completion, no diff vs base — deterministic. Don't loop; surface.
+            finalStatus = 'blocked';
+            await this.featureLoader.update(projectPath, featureId, {
+              status: 'blocked',
+              statusChangeReason:
+                `Agent ran to completion but produced no diff vs base and no PR (#4051). The work is ` +
+                `likely already merged via another branch, or this duplicates completed work. ` +
+                `Re-dispatching would be a deterministic no-op, so it is NOT retried — verify and close ` +
+                `if already done, or re-scope the feature.`,
+            });
+            logger.warn(
+              `[AutoVerify] Feature ${featureId}: substantial output (${agentOutputLen} chars) but no diff/PR — ` +
+                `blocking as likely already-merged/duplicate (no retry loop, #4051).`
+            );
+          } else if (fc < MAX_EMPTY_RETRIES) {
+            // (b) Early termination — intermittent, retry.
             finalStatus = 'backlog';
             await this.featureLoader.update(projectPath, featureId, {
               status: 'backlog',
               failureCount: fc + 1,
-              statusChangeReason: `Empty execution (no PR/commits) — auto-retry ${fc + 1}/${MAX_EMPTY_RETRIES} (agent terminated early; protoCLI#307)`,
+              statusChangeReason: `Empty execution (no output/PR/commits) — auto-retry ${fc + 1}/${MAX_EMPTY_RETRIES} (agent terminated early; protoCLI#307)`,
             });
             logger.warn(
-              `[AutoVerify] No PR evidence for ${featureId} — auto-retrying (${fc + 1}/${MAX_EMPTY_RETRIES})`
+              `[AutoVerify] No output/PR evidence for ${featureId} — auto-retrying (${fc + 1}/${MAX_EMPTY_RETRIES})`
             );
           } else {
             finalStatus = 'blocked';

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -510,6 +510,34 @@ export class GitWorkflowService {
       return null;
     }
 
+    // Isolation guard (#4052): the worktree must be on the feature branch. If HEAD is
+    // on the base branch, the agent worked/committed on base (e.g. ran `git checkout
+    // main`, or executed in the main checkout because no worktree materialized).
+    // Committing/pushing now would either strand work on a local base branch with no
+    // PR or push straight to base — both are completion theater. Refuse: leave the work
+    // in place (uncommitted, recoverable) and signal the caller to BLOCK, never `done`.
+    try {
+      const { stdout: headBranch } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+        cwd: workDir,
+        env: execEnv,
+      });
+      if (headBranch.trim() === prBaseBranch) {
+        logger.error(
+          `[GitWorkflow] Feature ${featureId}: worktree HEAD is on base branch "${prBaseBranch}", ` +
+            `not feature branch "${branchName}" — refusing to commit/push to base. Work is preserved ` +
+            `in the worktree for rescue; blocking feature (isolation failure, #4052).`
+        );
+        result.strandedOnBase = true;
+        result.error = `Worktree was on base branch "${prBaseBranch}" instead of feature branch "${branchName}" — work not committed to base (isolation failure).`;
+        this.activeWorkflows--;
+        return result;
+      }
+    } catch (headErr) {
+      logger.warn(
+        `[GitWorkflow] Could not resolve HEAD branch for ${featureId} (continuing): ${headErr instanceof Error ? headErr.message : String(headErr)}`
+      );
+    }
+
     try {
       // Step 1: Commit changes
       let commitHash: string | null;

--- a/apps/server/src/services/lead-engineer-deploy-processor.ts
+++ b/apps/server/src/services/lead-engineer-deploy-processor.ts
@@ -44,6 +44,24 @@ export class DeployProcessor implements StateProcessor {
     if (fresh) ctx.feature = fresh;
 
     if (fresh && fresh.status !== 'done') {
+      // `done` means "PR merged". Never infer it from merely reaching DEPLOY — require
+      // real merge evidence (#4052). DEPLOY is normally entered only after MergeProcessor
+      // confirms the merge (which sets prMergedAt), so this guard is a no-op on the happy
+      // path; it only fires on an anomalous arrival with no merged PR, where silently
+      // marking done would be completion theater. Escalate instead.
+      const hasMergeEvidence = !!(fresh.prMergedAt && (fresh.prNumber ?? ctx.prNumber));
+      if (!hasMergeEvidence) {
+        ctx.escalationReason =
+          `Reached DEPLOY for feature ${ctx.feature.id} without merge evidence ` +
+          `(prMergedAt=${fresh.prMergedAt ?? 'none'}, prNumber=${fresh.prNumber ?? ctx.prNumber ?? 'none'}) — ` +
+          `refusing to mark done (#4052).`;
+        logger.error(`[DEPLOY] ${ctx.escalationReason}`);
+        return {
+          nextState: 'ESCALATE',
+          shouldContinue: true,
+          reason: ctx.escalationReason,
+        };
+      }
       await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
         status: 'done',
       });

--- a/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
+++ b/apps/server/src/services/maintenance/checks/post-merge-reconciler-check.ts
@@ -44,6 +44,7 @@ interface PRListItem {
   number: number;
   url: string;
   mergedAt: string | null;
+  createdAt: string | null;
 }
 
 /** Statuses that indicate the feature is already done — skip reconciliation. */
@@ -198,7 +199,7 @@ export class PostMergeReconcilerCheck {
               '--state',
               'merged',
               '--json',
-              'number,url,mergedAt',
+              'number,url,mergedAt,createdAt',
               '--limit',
               '1',
             ],
@@ -214,6 +215,29 @@ export class PostMergeReconcilerCheck {
           }
 
           const merged = matches[0];
+
+          // Evidence guard (#4041): a branch name is not a unique key — a *new* feature
+          // can reuse/collide with the branch name of an *older* already-merged PR (e.g.
+          // two "feature/board-archived-*" attempts). Matching the stale PR would mark a
+          // feature `done` that never ran. Only reconcile when the merged PR is at least
+          // as new as the feature itself; a PR created before the feature existed cannot
+          // be that feature's output. When either timestamp is missing we cannot prove
+          // staleness, so we preserve the original recovery behaviour and proceed.
+          const prCreatedMs = merged.createdAt ? Date.parse(merged.createdAt) : NaN;
+          const featureCreatedMs = feature.createdAt ? Date.parse(feature.createdAt) : NaN;
+          if (
+            Number.isFinite(prCreatedMs) &&
+            Number.isFinite(featureCreatedMs) &&
+            prCreatedMs < featureCreatedMs
+          ) {
+            logger.warn(
+              `[reconciler] Skipping branch-fallback for feature ${feature.id} ("${feature.title}"): ` +
+                `merged PR #${merged.number} was created ${merged.createdAt} — before the feature was created ` +
+                `(${feature.createdAt}). Stale branch-name collision; not a real completion. Leaving status ${feature.status}.`
+            );
+            continue;
+          }
+
           logger.info(
             `[reconciler] Merged PR #${merged.number} (${merged.url}) found for branch "${feature.branchName}" — transitioning feature "${feature.title}" (${feature.id}) from ${feature.status} → done (branch-fallback path)`
           );

--- a/apps/server/tests/unit/services/lead-engineer-deploy-processor.test.ts
+++ b/apps/server/tests/unit/services/lead-engineer-deploy-processor.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for DeployProcessor — the DEPLOY state's merge-evidence guard (#4052).
+ *
+ * `done` means "PR merged". DEPLOY must never infer `done` from merely arriving in
+ * the state; it requires real merge evidence (prMergedAt + a PR number). Without it,
+ * DEPLOY escalates instead of marking a feature done with no shipped output.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@protolabsai/utils', () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+import { DeployProcessor } from '@/services/lead-engineer-deploy-processor.js';
+import type { ProcessorServiceContext, StateContext } from '@/services/lead-engineer-types.js';
+
+function makeServiceContext(freshFeature: Record<string, unknown>): {
+  ctxDeps: ProcessorServiceContext;
+  update: ReturnType<typeof vi.fn>;
+} {
+  const update = vi.fn().mockResolvedValue(undefined);
+  const ctxDeps = {
+    featureLoader: {
+      get: vi.fn().mockResolvedValue(freshFeature),
+      update,
+    },
+    events: { emit: vi.fn(), subscribe: vi.fn(), on: vi.fn() },
+    settingsService: { getGlobalSettings: vi.fn().mockResolvedValue({}) },
+  } as unknown as ProcessorServiceContext;
+  return { ctxDeps, update };
+}
+
+function makeProcessor(freshFeature: Record<string, unknown>) {
+  const { ctxDeps, update } = makeServiceContext(freshFeature);
+  const processor = new DeployProcessor(ctxDeps);
+  // Neutralize post-promotion side-effects (typecheck/build, reflection, goal
+  // verification) — not under test here; we only assert the status decision.
+  vi.spyOn(processor as never, 'runPostMergeVerification').mockResolvedValue(undefined as never);
+  vi.spyOn(processor as never, 'generateReflection').mockResolvedValue(undefined as never);
+  vi.spyOn(processor as never, 'runGoalVerification').mockResolvedValue(undefined as never);
+  return { processor, update };
+}
+
+function makeCtx(feature: Record<string, unknown>, prNumber?: number): StateContext {
+  return {
+    feature: feature as never,
+    projectPath: '/test/project',
+    prNumber,
+  } as StateContext;
+}
+
+function doneWriteOf(update: ReturnType<typeof vi.fn>) {
+  return update.mock.calls.find(
+    (c) => (c[2] as { status?: string } | undefined)?.status === 'done'
+  );
+}
+
+describe('DeployProcessor — merge-evidence guard (#4052)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('escalates (does NOT mark done) when reaching DEPLOY without merge evidence', async () => {
+    // Feature is not done and has no prMergedAt — the #4052 stranded-work shape.
+    const fresh = { id: 'f1', status: 'review', prNumber: undefined, prMergedAt: undefined };
+    const { processor, update } = makeProcessor(fresh);
+
+    const result = await processor.process(makeCtx(fresh, undefined));
+
+    expect(result.nextState).toBe('ESCALATE');
+    expect(doneWriteOf(update)).toBeUndefined();
+  });
+
+  it('promotes to done when merge evidence (prMergedAt + prNumber) is present', async () => {
+    const fresh = {
+      id: 'f1',
+      status: 'review',
+      prNumber: 123,
+      prMergedAt: '2026-06-02T10:00:00Z',
+    };
+    const { processor, update } = makeProcessor(fresh);
+
+    const result = await processor.process(makeCtx(fresh, 123));
+
+    expect(result.nextState).toBe('DONE');
+    expect(doneWriteOf(update)).toBeDefined();
+  });
+
+  it('does not re-mark or escalate when the feature is already done', async () => {
+    const fresh = {
+      id: 'f1',
+      status: 'done',
+      prNumber: 123,
+      prMergedAt: '2026-06-02T10:00:00Z',
+    };
+    const { processor, update } = makeProcessor(fresh);
+
+    const result = await processor.process(makeCtx(fresh, 123));
+
+    expect(result.nextState).toBe('DONE');
+    expect(doneWriteOf(update)).toBeUndefined();
+  });
+});

--- a/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
+++ b/apps/server/tests/unit/services/post-merge-reconciler-check.test.ts
@@ -219,6 +219,86 @@ describe('PostMergeReconcilerCheck', () => {
     expect(result.reconciled).toBe(1);
   });
 
+  // ── #4041: branch-fallback evidence guard (stale branch-name collision) ──
+
+  it('Phase 2 does NOT reconcile when the merged PR predates the feature (stale collision, #4041)', async () => {
+    // A new feature reuses a branch name (e.g. feature/board-archived-*) whose OLDER
+    // merged PR belongs to a prior attempt. Matching it would mark a feature `done`
+    // that never produced work. The PR was created before the feature existed.
+    const feature = makeFeature({
+      prNumber: undefined,
+      prUrl: undefined,
+      status: 'backlog',
+      branchName: 'feature/board-archived-view',
+      createdAt: '2026-05-30T10:00:00Z',
+    });
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+
+    const execFileAsync = vi.fn(async (_file: string, args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'list') {
+        return {
+          stdout: JSON.stringify([
+            {
+              number: 99,
+              url: 'https://github.com/protoLabsAI/protoMaker/pull/99',
+              mergedAt: '2026-05-20T12:00:00Z',
+              createdAt: '2026-05-20T09:00:00Z', // 10 days BEFORE the feature was created
+            },
+          ]),
+          stderr: '',
+        };
+      }
+      throw new Error(`Unexpected gh invocation: ${args.join(' ')}`);
+    });
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync as any);
+    const emitted: unknown[] = [];
+    events.on('feature:pr-merged', (e) => emitted.push(e));
+
+    const result = await check.run('/project');
+
+    expect(result.reconciled).toBe(0);
+    expect(mockFeatureLoaderUpdate).not.toHaveBeenCalled();
+    expect(emitted).toHaveLength(0);
+  });
+
+  it('Phase 2 DOES reconcile when the merged PR post-dates the feature (#4041)', async () => {
+    const feature = makeFeature({
+      prNumber: undefined,
+      prUrl: undefined,
+      status: 'backlog',
+      branchName: 'feature/board-archived-view',
+      createdAt: '2026-05-20T08:00:00Z',
+    });
+    mockFeatureLoaderGetAll.mockResolvedValue([feature]);
+
+    const execFileAsync = vi.fn(async (_file: string, args: string[]) => {
+      if (args[0] === 'pr' && args[1] === 'list') {
+        return {
+          stdout: JSON.stringify([
+            {
+              number: 200,
+              url: 'https://github.com/protoLabsAI/protoMaker/pull/200',
+              mergedAt: '2026-05-22T12:00:00Z',
+              createdAt: '2026-05-22T09:00:00Z', // created AFTER the feature → legitimate
+            },
+          ]),
+          stderr: '',
+        };
+      }
+      throw new Error(`Unexpected gh invocation: ${args.join(' ')}`);
+    });
+    const check = new PostMergeReconcilerCheck(makeLoader(), events as any, execFileAsync as any);
+
+    const result = await check.run('/project');
+
+    expect(result.reconciled).toBe(1);
+    expect(mockFeatureLoaderUpdate).toHaveBeenCalledWith(
+      '/project',
+      'feature-001',
+      expect.objectContaining({ status: 'done', prNumber: 200 })
+    );
+  });
+
   it('does not transition a feature whose PR is still open', async () => {
     const feature = makeFeature();
     mockFeatureLoaderGetAll.mockResolvedValue([feature]);

--- a/libs/types/src/git-settings.ts
+++ b/libs/types/src/git-settings.ts
@@ -147,4 +147,11 @@ export interface GitWorkflowResult {
   rebaseConflicts?: boolean;
   /** Files that had rebase conflicts (populated when rebaseConflicts is true) */
   conflictingFiles?: string[];
+  /**
+   * True when the worktree's HEAD was on the base branch (not the feature branch)
+   * at workflow time — an isolation failure. Committing/pushing here would strand
+   * work on a local base branch with no PR (#4052). The caller must block the
+   * feature (work is preserved, not committed to base) rather than mark it done.
+   */
+  strandedOnBase?: boolean;
 }


### PR DESCRIPTION
## The unifying defect

Three auto-mode completion bugs share one root cause: the **done / dispatch logic trusted weak signals** — a leftover branch, a created-but-unmerged PR, a 0-diff branch — instead of **real merge evidence**. The result was completion theater (features `done` with nothing shipped) and no-op loops on already-merged work.

This PR enforces one invariant across every path:

> **A feature becomes `done` only with real merge evidence; otherwise it is surfaced — never silently done, never looped.**

## Fixes

### #4041 — false `done` on restart
`post-merge-reconciler-check.ts` branch-fallback marked a feature `done` on a branch-**name** match without confirming the PR belonged to the feature. A new feature reusing an older merged PR's branch name (e.g. `feature/board-archived-*`) got falsely reconciled.
**Fix:** added `createdAt` to the `gh pr list` query + a recency guard — reject a matched PR created **before** the feature existed. When timestamps are absent, the original recovery behaviour is preserved (no regression to #3613's fix).

### #4052 — stranded work / `done` without a PR
- **Prevention** (`git-workflow-service.ts`): refuse to commit when the worktree HEAD is on the **base branch** (isolation failure) — return `strandedOnBase` instead of stranding a commit on local `main`. `execution-service.ts` then **blocks** the feature (work preserved in the worktree for rescue), never `done`.
- **Defense-in-depth** (`lead-engineer-deploy-processor.ts`): DEPLOY requires merge evidence (`prMergedAt` + PR number) before promoting to `done`; otherwise it **escalates**. No-op on the happy path (MergeProcessor sets `prMergedAt` before DEPLOY).

### #4051 — no-op re-dispatch loop
A feature already merged via a **different** branch (0-diff vs base, no own-branch PR) re-dispatched repeatedly, burning retries.
**Fix:** when a run yields no diff + no PR, `execution-service.ts` discriminates by agent output — **substantial output + no diff** = a deterministic "already merged elsewhere / duplicate" → block with an actionable reason (no wasted retries, and **never auto-`done` without evidence**); **minimal output** = early termination → retry as before. (The git state alone can't tell "already landed" from "empty execution"; agent-output presence is the honest discriminator.)

## Tests
- **post-merge-reconciler** (#4041): stale-collision PR (older than feature) → **not** reconciled; recent PR → reconciled. (+2)
- **DeployProcessor** (#4052): no merge evidence → ESCALATE (not done); evidence present → DONE; already-done → no-op. (new file, +3)
- Full affected suite green: **93 tests** across reconciler / deploy / review-merge / lead-engineer-service / git-workflow. `tsc` + `build:packages` clean.

**Coverage note:** the two integration-path guards (git-workflow base-branch refusal; execution-service no-diff discrimination) live inside large integration functions without isolated unit harnesses — they're small, clearly-correct guards verified by `tsc` and exercised by the existing integration tests, rather than via fragile order-dependent exec-queue mocks.

Closes #4041, #4051, #4052.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Features are no longer incorrectly marked as complete when merge confirmation is missing.
  * Improved handling of failed git operations to prevent features from being stuck in incomplete states.
  * Enhanced detection to prevent stale branch-name collisions from affecting feature status transitions.
  * Added safety guards during automatic execution to properly handle edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->