### PR TITLE
feat(ui): board 'Archived' view over the archive read endpoints (#4035)

### DIFF
--- a/apps/ui/src/components/views/board-view.tsx
+++ b/apps/ui/src/components/views/board-view.tsx
@@ -50,6 +50,7 @@ import {
   AgentOutputModal,
   BacklogPlanDialog,
   CompletedFeaturesModal,
+  ArchivedFeaturesModal,
   ArchiveAllVerifiedDialog,
   DeleteCompletedFeatureDialog,
   DependencyLinkDialog,
@@ -165,6 +166,7 @@ export function BoardView() {
   const [showArchiveAllVerifiedDialog, setShowArchiveAllVerifiedDialog] = useState(false);
   const [showBoardBackgroundModal, setShowBoardBackgroundModal] = useState(false);
   const [showCompletedModal, setShowCompletedModal] = useState(false);
+  const [showArchivedModal, setShowArchivedModal] = useState(false);
   const [deleteCompletedFeature, setDeleteCompletedFeature] = useState<Feature | null>(null);
   // PRD Review Modal state
   const [prdModalOpen, setPrdModalOpen] = useState(false);
@@ -1533,6 +1535,7 @@ export function BoardView() {
               onArchiveAllVerified={() => setShowArchiveAllVerifiedDialog(true)}
               onAddFeature={() => setShowAddDialog(true)}
               onShowCompletedModal={() => setShowCompletedModal(true)}
+              onShowArchivedModal={() => setShowArchivedModal(true)}
               completedCount={completedFeatures.length}
               isSelectionMode={isSelectionMode}
               selectionTarget={selectionTarget}
@@ -1631,6 +1634,13 @@ export function BoardView() {
         completedFeatures={completedFeatures}
         onUnarchive={handleUnarchiveFeature}
         onDelete={(feature) => setDeleteCompletedFeature(feature)}
+      />
+
+      {/* Archived Features Modal (#4035) — read-only over the archive API */}
+      <ArchivedFeaturesModal
+        open={showArchivedModal}
+        onOpenChange={setShowArchivedModal}
+        projectPath={currentProject?.path}
       />
 
       {/* Delete Completed Feature Confirmation Dialog */}

--- a/apps/ui/src/components/views/board-view/dialogs/archived-features-modal.tsx
+++ b/apps/ui/src/components/views/board-view/dialogs/archived-features-modal.tsx
@@ -1,0 +1,184 @@
+/**
+ * Archived Features modal (#4035)
+ *
+ * Read-only view over the archive API: lists a project's archived features
+ * (POST /api/projects/archives/list) and opens a read-only detail panel for one
+ * (POST /api/projects/archives/detail → feature.json + agent output + meta).
+ *
+ * Self-contained: fetches its own data via the archive query hooks while open.
+ */
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@protolabsai/ui/atoms';
+import { Button, Card, CardHeader, CardTitle, CardDescription } from '@protolabsai/ui/atoms';
+import { Archive, ArrowLeft, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import {
+  useArchivedFeatures,
+  useArchivedFeatureDetail,
+} from '@/hooks/queries/use-archived-features';
+
+interface ArchivedFeaturesModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectPath: string | undefined;
+}
+
+function formatTimestamp(iso: string): string {
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? new Date(t).toLocaleString() : iso;
+}
+
+export function ArchivedFeaturesModal({
+  open,
+  onOpenChange,
+  projectPath,
+}: ArchivedFeaturesModalProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const { data: archives = [], isLoading, isError, error } = useArchivedFeatures(projectPath, open);
+
+  const detail = useArchivedFeatureDetail(projectPath, selectedId ?? undefined);
+
+  // Reset selection whenever the modal closes so it reopens on the list.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setSelectedId(null);
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="max-w-6xl max-h-[90vh] flex flex-col"
+        data-testid="archived-features-modal"
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {selectedId && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 w-6 p-0"
+                onClick={() => setSelectedId(null)}
+                data-testid="archived-detail-back"
+                title="Back to list"
+              >
+                <ArrowLeft className="w-4 h-4" />
+              </Button>
+            )}
+            Archived Features
+          </DialogTitle>
+          <DialogDescription>
+            {selectedId
+              ? 'Read-only archived feature detail.'
+              : isLoading
+                ? 'Loading…'
+                : `${archives.length} archived feature${archives.length === 1 ? '' : 's'}`}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto py-4">
+          {/* List view */}
+          {!selectedId &&
+            (isLoading ? (
+              <div className="flex items-center justify-center py-12 text-muted-foreground">
+                <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading archived features…
+              </div>
+            ) : isError ? (
+              <div className="text-center text-destructive py-8" data-testid="archived-error">
+                Failed to load archived features: {(error as Error)?.message ?? 'unknown error'}
+              </div>
+            ) : archives.length === 0 ? (
+              <div className="text-center text-muted-foreground py-8">
+                <Archive className="w-12 h-12 mx-auto mb-4 opacity-50" />
+                <p>No archived features</p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {archives.map((a) => (
+                  <Card
+                    key={a.featureId}
+                    className="flex flex-col cursor-pointer hover:border-brand-500 transition-colors"
+                    onClick={() => setSelectedId(a.featureId)}
+                    data-testid={`archived-card-${a.featureId}`}
+                  >
+                    <CardHeader className="p-3 pb-2 flex-1">
+                      <CardTitle className="text-sm leading-tight line-clamp-3">
+                        {a.title || a.featureId}
+                      </CardTitle>
+                      <CardDescription className="text-xs mt-1 flex items-center justify-between gap-2">
+                        <span className="truncate">{a.isEpic ? 'Epic' : a.status}</span>
+                        <span className="shrink-0 opacity-70">{formatTimestamp(a.archivedAt)}</span>
+                      </CardDescription>
+                    </CardHeader>
+                  </Card>
+                ))}
+              </div>
+            ))}
+
+          {/* Detail view */}
+          {selectedId &&
+            (detail.isLoading ? (
+              <div className="flex items-center justify-center py-12 text-muted-foreground">
+                <Loader2 className="w-5 h-5 animate-spin mr-2" /> Loading detail…
+              </div>
+            ) : detail.isError || !detail.data ? (
+              <div
+                className="text-center text-destructive py-8"
+                data-testid="archived-detail-error"
+              >
+                Failed to load detail: {(detail.error as Error)?.message ?? 'not found'}
+              </div>
+            ) : (
+              <div className="space-y-4" data-testid="archived-detail">
+                <div>
+                  <h3 className="text-base font-semibold">
+                    {detail.data.feature.title || detail.data.featureId}
+                  </h3>
+                  <div className="text-xs text-muted-foreground mt-1 flex flex-wrap gap-x-4 gap-y-1">
+                    <span>Status: {detail.data.feature.status}</span>
+                    <span>Archived: {formatTimestamp(detail.data.meta.archivedAt)}</span>
+                    {detail.data.feature.category && (
+                      <span>Category: {detail.data.feature.category}</span>
+                    )}
+                  </div>
+                </div>
+                {detail.data.feature.description && (
+                  <div>
+                    <div className="text-xs font-medium text-muted-foreground mb-1">
+                      Description
+                    </div>
+                    <p className="text-sm whitespace-pre-wrap">{detail.data.feature.description}</p>
+                  </div>
+                )}
+                <div>
+                  <div className="text-xs font-medium text-muted-foreground mb-1">Agent output</div>
+                  {detail.data.agentOutput ? (
+                    <pre className="text-xs bg-muted rounded-md p-3 overflow-x-auto whitespace-pre-wrap max-h-[50vh]">
+                      {detail.data.agentOutput}
+                    </pre>
+                  ) : (
+                    <p className="text-sm text-muted-foreground italic">
+                      No agent output recorded.
+                    </p>
+                  )}
+                </div>
+              </div>
+            ))}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => handleOpenChange(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/ui/src/components/views/board-view/dialogs/index.ts
+++ b/apps/ui/src/components/views/board-view/dialogs/index.ts
@@ -2,6 +2,7 @@ export { AddFeatureDialog } from './add-feature-dialog';
 export { AgentOutputModal } from './agent-output-modal';
 export { BacklogPlanDialog } from './backlog-plan-dialog';
 export { CompletedFeaturesModal } from './completed-features-modal';
+export { ArchivedFeaturesModal } from './archived-features-modal';
 export { ArchiveAllVerifiedDialog } from './archive-all-verified-dialog';
 export { DeleteCompletedFeatureDialog } from './delete-completed-feature-dialog';
 export { DependencyLinkDialog, type DependencyLinkType } from './dependency-link-dialog';

--- a/apps/ui/src/components/views/board-view/kanban-board.tsx
+++ b/apps/ui/src/components/views/board-view/kanban-board.tsx
@@ -12,7 +12,7 @@ import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { Button } from '@protolabsai/ui/atoms';
 import { KanbanColumn, KanbanCard, EmptyStateCard } from './components';
 import { Feature, useAppStore, formatShortcut } from '@/store/app-store';
-import { Archive, CheckSquare, GripVertical, Plus } from 'lucide-react';
+import { Archive, CheckSquare, GripVertical, History, Plus } from 'lucide-react';
 import { useResponsiveKanban } from '@/hooks/use-responsive-kanban';
 import { COLUMNS, type ColumnId } from './constants';
 import { cn } from '@/lib/utils';
@@ -49,6 +49,7 @@ interface KanbanBoardProps {
   onArchiveAllVerified: () => void;
   onAddFeature: () => void;
   onShowCompletedModal: () => void;
+  onShowArchivedModal: () => void;
   completedCount: number;
   // Selection mode props
   isSelectionMode?: boolean;
@@ -284,6 +285,7 @@ export function KanbanBoard({
   onArchiveAllVerified,
   onAddFeature,
   onShowCompletedModal,
+  onShowArchivedModal,
   completedCount,
   isSelectionMode = false,
   selectionTarget = null,
@@ -380,6 +382,16 @@ export function KanbanBoard({
                               {completedCount > 99 ? '99+' : completedCount}
                             </span>
                           )}
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 w-6 p-0"
+                          onClick={onShowArchivedModal}
+                          title="Archived Features"
+                          data-testid="archived-features-button"
+                        >
+                          <History className="w-3.5 h-3.5 text-muted-foreground" />
                         </Button>
                       </div>
                     ) : column.id === 'backlog' ? (

--- a/apps/ui/src/hooks/queries/use-archived-features.ts
+++ b/apps/ui/src/hooks/queries/use-archived-features.ts
@@ -1,0 +1,56 @@
+/**
+ * Archived-feature query hooks (#4035)
+ *
+ * React Query hooks over the archive read API
+ * (POST /api/projects/archives/{list,detail}). Archived features are immutable
+ * once written, so a relaxed stale time is fine.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { getHttpApiClient } from '@/lib/http-api-client';
+import { queryKeys } from '@/lib/query-keys';
+import { STALE_TIMES } from '@/lib/query-client';
+import type { ArchivedFeatureSummary, ArchivedFeatureDetail } from '@/lib/clients/system-client';
+
+/**
+ * List archived features for a project. Disabled when no projectPath or `enabled` is false
+ * (so the request only fires while the Archived view is open).
+ */
+export function useArchivedFeatures(projectPath: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.archives.list(projectPath ?? ''),
+    enabled: enabled && !!projectPath,
+    staleTime: STALE_TIMES.SESSIONS,
+    queryFn: async (): Promise<ArchivedFeatureSummary[]> => {
+      const api = getHttpApiClient();
+      const result = await api.archives.list(projectPath!);
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to list archived features');
+      }
+      return result.archives ?? [];
+    },
+  });
+}
+
+/**
+ * Fetch the full archived-feature detail (feature.json + agent output). Disabled until a
+ * featureId is selected.
+ */
+export function useArchivedFeatureDetail(
+  projectPath: string | undefined,
+  featureId: string | undefined
+) {
+  return useQuery({
+    queryKey: queryKeys.archives.detail(projectPath ?? '', featureId ?? ''),
+    enabled: !!projectPath && !!featureId,
+    staleTime: STALE_TIMES.SESSIONS,
+    queryFn: async (): Promise<ArchivedFeatureDetail> => {
+      const api = getHttpApiClient();
+      const result = await api.archives.detail(projectPath!, featureId!);
+      if (!result.success || !result.archive) {
+        throw new Error(result.error || 'Failed to load archived feature detail');
+      }
+      return result.archive;
+    },
+  });
+}

--- a/apps/ui/src/lib/clients/system-client.ts
+++ b/apps/ui/src/lib/clients/system-client.ts
@@ -31,8 +31,29 @@ import type {
   DeployEnvironment,
   Project,
   ProjectHealth,
+  Feature,
 } from '@protolabsai/types';
 import { BaseHttpClient, type Constructor } from './base-http-client';
+
+/** A single archived feature as returned by POST /api/projects/archives/list (#4025/#4035). */
+export interface ArchivedFeatureSummary {
+  featureId: string;
+  title: string;
+  status: string;
+  archivedAt: string;
+  projectPath: string;
+  projectSlug?: string;
+  epicId?: string;
+  isEpic?: boolean;
+}
+
+/** Full archived-feature record from POST /api/projects/archives/detail. */
+export interface ArchivedFeatureDetail {
+  featureId: string;
+  feature: Feature;
+  agentOutput: string | null;
+  meta: { archivedAt: string; projectPath: string; projectSlug?: string };
+}
 
 export const withSystemClient = <TBase extends Constructor<BaseHttpClient>>(Base: TBase) =>
   class extends Base {
@@ -315,6 +336,20 @@ export const withSystemClient = <TBase extends Constructor<BaseHttpClient>>(Base
     analytics = {
       getAgentPerformance: (projectPath: string) =>
         this.post('/api/analytics/agent-performance', { projectPath }),
+    };
+
+    // Archived-feature read API (#4035) — read-back over the archive write side.
+    archives = {
+      list: (
+        projectPath: string,
+        opts?: { projectSlug?: string; dateFrom?: string; dateTo?: string }
+      ): Promise<{ success: boolean; archives?: ArchivedFeatureSummary[]; error?: string }> =>
+        this.post('/api/projects/archives/list', { projectPath, ...opts }),
+      detail: (
+        projectPath: string,
+        featureId: string
+      ): Promise<{ success: boolean; archive?: ArchivedFeatureDetail; error?: string }> =>
+        this.post('/api/projects/archives/detail', { projectPath, featureId }),
     };
 
     // Project Lifecycle API

--- a/apps/ui/src/lib/query-keys.ts
+++ b/apps/ui/src/lib/query-keys.ts
@@ -130,6 +130,17 @@ export const queryKeys = {
   },
 
   // ============================================
+  // Archived features (#4035)
+  // ============================================
+  archives: {
+    /** Archived features for a project */
+    list: (projectPath: string) => ['archives', 'list', projectPath] as const,
+    /** Full detail (feature.json + agent output) for one archived feature */
+    detail: (projectPath: string, featureId: string) =>
+      ['archives', 'detail', projectPath, featureId] as const,
+  },
+
+  // ============================================
   // Running Agents
   // ============================================
   runningAgents: {


### PR DESCRIPTION
## What

Follow-up to #4025 / PR #4034. The archive **read API** (`POST /api/projects/archives/{list,detail}`) was live but had no UI consumer — archived features were only reachable via the API. This adds the **UI half**: an "Archived" view reachable from the board.

## Change (small, self-contained `apps/ui` slice)

- **`system-client.ts`** — new `archives` namespace: `archives.list(projectPath, opts?)` → `/archives/list`, `archives.detail(projectPath, featureId)` → `/archives/detail`, plus the `ArchivedFeatureSummary` / `ArchivedFeatureDetail` response types.
- **`use-archived-features.ts`** — React Query hooks: `useArchivedFeatures` (gated on the modal being open) and `useArchivedFeatureDetail` (gated on a selected feature). Archives are immutable, so a relaxed stale time is used.
- **`ArchivedFeaturesModal`** — self-contained master/detail: lists archived features (title, status, archived-at); clicking one opens a **read-only** detail panel (feature fields + agent output + archived timestamp) with a back button.
- **`kanban-board.tsx`** — a `History`-icon "Archived Features" trigger button beside the existing "Completed" button; **`board-view.tsx`** owns the modal state and passes `currentProject.path`.

Read-only — no mutation of archived data.

## Conventions
Mirrors existing patterns: the completed-features modal (styling), `use-workspace` (hook + `getHttpApiClient`), and the system-client namespace shape. The badge/button sits in the done-column header next to "Completed".

## Verification
- Full `npm run typecheck` green (22/22).
- UI is Playwright-E2E'd (the repo has no jsdom component-test harness — only 2 logic unit tests — so a rendering unit test would be off-convention here); the feature mirrors the proven completed-features modal + hook patterns.

Closes #4035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)