### PR TITLE
fix(projects): save-milestones returns 404, not 500, for a missing project (#4060)

### DIFF
--- a/apps/server/src/routes/projects/lifecycle/index.ts
+++ b/apps/server/src/routes/projects/lifecycle/index.ts
@@ -64,7 +64,7 @@ export function createLifecycleRoutes(
     '/save-milestones',
     validatePathParams('projectPath'),
     validateSlugs('projectSlug'),
-    createSaveMilestonesHandler(lifecycleService)
+    createSaveMilestonesHandler(lifecycleService, projectService)
   );
 
   router.post(

--- a/apps/server/src/routes/projects/lifecycle/save-milestones.ts
+++ b/apps/server/src/routes/projects/lifecycle/save-milestones.ts
@@ -8,9 +8,13 @@
 
 import type { Request, Response } from 'express';
 import type { ProjectLifecycleService } from '../../../services/project-lifecycle-service.js';
+import type { ProjectService } from '../../../services/project-service.js';
 import { getErrorMessage, logError } from '../common.js';
 
-export function createSaveMilestonesHandler(lifecycleService: ProjectLifecycleService) {
+export function createSaveMilestonesHandler(
+  lifecycleService: ProjectLifecycleService,
+  projectService: ProjectService
+) {
   return async (req: Request, res: Response): Promise<void> => {
     try {
       const { projectPath, projectSlug, milestones } = req.body as {
@@ -26,6 +30,12 @@ export function createSaveMilestonesHandler(lifecycleService: ProjectLifecycleSe
 
       if (!Array.isArray(milestones) || milestones.length === 0) {
         res.status(400).json({ success: false, error: 'milestones must be a non-empty array' });
+        return;
+      }
+
+      const existing = await projectService.getProject(projectPath, projectSlug);
+      if (!existing) {
+        res.status(404).json({ success: false, error: `Project "${projectSlug}" not found` });
         return;
       }
 

--- a/apps/server/tests/unit/routes/projects/save-milestones.test.ts
+++ b/apps/server/tests/unit/routes/projects/save-milestones.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for the save-milestones handler (#4060).
+ *
+ * Focus: a non-existent project must return 404 (not 500), so callers can tell
+ * "create the project first" apart from a genuine server error. Also covers the
+ * 400 input guards and the success path.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Request, Response } from 'express';
+import { createSaveMilestonesHandler } from '@/routes/projects/lifecycle/save-milestones.js';
+
+function makeRes() {
+  const res: Partial<Response> & { statusCode: number; body: unknown } = {
+    statusCode: 200,
+    body: undefined,
+  };
+  res.status = vi.fn((c: number) => {
+    res.statusCode = c;
+    return res as Response;
+  }) as unknown as Response['status'];
+  res.json = vi.fn((b: unknown) => {
+    res.body = b;
+    return res as Response;
+  }) as unknown as Response['json'];
+  return res;
+}
+
+type LifecycleArg = Parameters<typeof createSaveMilestonesHandler>[0];
+type ProjectServiceArg = Parameters<typeof createSaveMilestonesHandler>[1];
+
+describe('save-milestones handler (#4060)', () => {
+  it('returns 404 (not 500) when the project does not exist', async () => {
+    const saveMilestones = vi.fn();
+    const lifecycleService = { saveMilestones } as unknown as LifecycleArg;
+    const projectService = {
+      getProject: vi.fn().mockResolvedValue(null),
+    } as unknown as ProjectServiceArg;
+
+    const handler = createSaveMilestonesHandler(lifecycleService, projectService);
+    const res = makeRes();
+    await handler(
+      {
+        body: { projectPath: '/p', projectSlug: 'ghost', milestones: [{ title: 'M1' }] },
+      } as Request,
+      res as Response
+    );
+
+    expect(res.statusCode).toBe(404);
+    expect((res.body as { success: boolean }).success).toBe(false);
+    expect((res.body as { error: string }).error).toContain('ghost');
+    // Must short-circuit before touching the lifecycle service.
+    expect(saveMilestones).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when required params are missing', async () => {
+    const lifecycleService = { saveMilestones: vi.fn() } as unknown as LifecycleArg;
+    const projectService = { getProject: vi.fn() } as unknown as ProjectServiceArg;
+
+    const handler = createSaveMilestonesHandler(lifecycleService, projectService);
+    const res = makeRes();
+    await handler(
+      { body: { projectSlug: 's', milestones: [{ title: 'M1' }] } } as Request,
+      res as Response
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(projectService.getProject as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when milestones is empty', async () => {
+    const lifecycleService = { saveMilestones: vi.fn() } as unknown as LifecycleArg;
+    const projectService = { getProject: vi.fn() } as unknown as ProjectServiceArg;
+
+    const handler = createSaveMilestonesHandler(lifecycleService, projectService);
+    const res = makeRes();
+    await handler(
+      { body: { projectPath: '/p', projectSlug: 's', milestones: [] } } as Request,
+      res as Response
+    );
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('saves milestones and returns success when the project exists', async () => {
+    const saved = {
+      slug: 's',
+      milestones: [{ title: 'M1' }, { title: 'M2' }],
+      status: 'scaffolded',
+    };
+    const saveMilestones = vi.fn().mockResolvedValue(saved);
+    const lifecycleService = { saveMilestones } as unknown as LifecycleArg;
+    const projectService = {
+      getProject: vi.fn().mockResolvedValue({ slug: 's' }),
+    } as unknown as ProjectServiceArg;
+
+    const handler = createSaveMilestonesHandler(lifecycleService, projectService);
+    const res = makeRes();
+    await handler(
+      {
+        body: {
+          projectPath: '/p',
+          projectSlug: 's',
+          milestones: [{ title: 'M1' }, { title: 'M2' }],
+        },
+      } as Request,
+      res as Response
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      success: true,
+      projectSlug: 's',
+      milestonesCount: 2,
+      status: 'scaffolded',
+    });
+    expect(saveMilestones).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Problem (#4060)

`POST /lifecycle/save-milestones` returned **HTTP 500** when the target project didn't exist, making a recoverable "create the project first" condition indistinguishable from a genuine server error — and breaking agent/MCP callers that branch on the status code.

## Fix

Thread `ProjectService` into `createSaveMilestonesHandler` and return **404** when `getProject()` returns null, before touching the lifecycle service. Mirrors the existing-project guard already used by the sibling lifecycle handlers.

## Tests

New handler unit tests (`tests/unit/routes/projects/save-milestones.test.ts`):
- **404** when the project doesn't exist (and the lifecycle service is *not* called)
- **400** input guards (missing params, empty milestones)
- **200** success path

Closes #4060

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The save-milestones endpoint now properly validates that the target project exists before processing requests. Users attempting to save milestones for non-existent projects will receive a clear error response.

* **Tests**
  * Added comprehensive test coverage for the save-milestones endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->