### PR TITLE
chore(release): add manual re-post path to auto-release (workflow_dispatch)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -63,18 +63,22 @@ jobs:
 
       - name: Get version
         id: version
+        # Pass event/inputs via env (never interpolate ${{ }} into the script body
+        # — zizmor template-injection / CWE-94).
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_PREV: ${{ inputs.previous_version }}
         run: |
           # Manual re-post mode: workflow_dispatch with an explicit `version`.
           # Skips tagging and just re-posts notes for the given range.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
-            RAW="${{ inputs.version }}"
-            VERSION="${RAW#v}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_VERSION" ]; then
+            VERSION="${INPUT_VERSION#v}"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "repost=true" >> $GITHUB_OUTPUT
             echo "already_tagged=true" >> $GITHUB_OUTPUT
-            PREV="${{ inputs.previous_version }}"
-            echo "prev=$PREV" >> $GITHUB_OUTPUT
-            echo "Re-post mode: notes for v${VERSION} (previous: ${PREV:-<unset>})"
+            echo "prev=$INPUT_PREV" >> $GITHUB_OUTPUT
+            echo "Re-post mode: notes for v${VERSION} (previous: ${INPUT_PREV:-<unset>})"
             exit 0
           fi
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,6 +6,10 @@ name: Auto Release
 # gateway-themed release notes to Discord via @protolabsai/release-tools.
 # No GitHub Release is created. If the version is already tagged, the workflow
 # no-ops — bump the version in a PR before merging if you want a new release.
+#
+# Manual re-post: run via workflow_dispatch with `version` (e.g. v0.109.0) set to
+# re-generate + re-post notes for an already-tagged release (bypasses the tag
+# guard, never tags). Useful to backfill notes after a transient gateway failure.
 
 on:
   push:
@@ -17,6 +21,15 @@ on:
       - '**.md'
       - '.automaker/**'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Re-post notes for this tag (e.g. v0.109.0). Blank = normal version-detect from libs/types.'
+        required: false
+        default: ''
+      previous_version:
+        description: 'Previous tag for the diff range (e.g. v0.108.0). Required when version is set.'
+        required: false
+        default: ''
 
 permissions: read-all
 
@@ -51,8 +64,23 @@ jobs:
       - name: Get version
         id: version
         run: |
+          # Manual re-post mode: workflow_dispatch with an explicit `version`.
+          # Skips tagging and just re-posts notes for the given range.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            RAW="${{ inputs.version }}"
+            VERSION="${RAW#v}"
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "repost=true" >> $GITHUB_OUTPUT
+            echo "already_tagged=true" >> $GITHUB_OUTPUT
+            PREV="${{ inputs.previous_version }}"
+            echo "prev=$PREV" >> $GITHUB_OUTPUT
+            echo "Re-post mode: notes for v${VERSION} (previous: ${PREV:-<unset>})"
+            exit 0
+          fi
+
           VERSION=$(node -p "require('./libs/types/package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "repost=false" >> $GITHUB_OUTPUT
           echo "Detected version: v${VERSION}"
 
           if git tag -l "v${VERSION}" | grep -q "v${VERSION}"; then
@@ -63,7 +91,7 @@ jobs:
           fi
 
       - name: Create tag
-        if: steps.version.outputs.already_tagged != 'true'
+        if: steps.version.outputs.repost != 'true' && steps.version.outputs.already_tagged != 'true'
         run: |
           VERSION="v${{ steps.version.outputs.version }}"
           git tag -a "$VERSION" -m "$VERSION"
@@ -71,24 +99,24 @@ jobs:
 
       - name: Resolve previous tag
         id: prev
-        if: steps.version.outputs.already_tagged != 'true' && env.DISCORD_RELEASE_WEBHOOK != ''
+        if: steps.version.outputs.repost != 'true' && steps.version.outputs.already_tagged != 'true' && env.DISCORD_RELEASE_WEBHOOK != ''
         run: |
           VERSION="v${{ steps.version.outputs.version }}"
           PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${VERSION}$" | head -1)
           echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
 
       - name: Rewrite and post release notes to Discord
-        if: steps.version.outputs.already_tagged != 'true' && env.DISCORD_RELEASE_WEBHOOK != ''
+        if: (steps.version.outputs.repost == 'true' || steps.version.outputs.already_tagged != 'true') && env.DISCORD_RELEASE_WEBHOOK != ''
         uses: protoLabsAI/release-tools@fac24459b61aa7ab44c423b103a524d5c9f9e6ee # v1
         with:
           version: v${{ steps.version.outputs.version }}
-          previous-version: ${{ steps.prev.outputs.tag }}
+          previous-version: ${{ steps.version.outputs.repost == 'true' && steps.version.outputs.prev || steps.prev.outputs.tag }}
         env:
           GATEWAY_API_KEY: ${{ secrets.GATEWAY_API_KEY }}
           DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
 
       - name: Alert on release failure
-        if: failure() && steps.version.outputs.already_tagged != 'true'
+        if: failure() && (steps.version.outputs.repost == 'true' || steps.version.outputs.already_tagged != 'true')
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           MSG="ALERT: Auto-release FAILED. Tag or release-notes post may be incomplete. ${RUN_URL}"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -73,6 +73,10 @@ jobs:
           # Manual re-post mode: workflow_dispatch with an explicit `version`.
           # Skips tagging and just re-posts notes for the given range.
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$INPUT_VERSION" ]; then
+            if [ -z "$INPUT_PREV" ]; then
+              echo "::error::Re-post mode requires previous_version (the diff range start, e.g. v0.108.0)."
+              exit 1
+            fi
             VERSION="${INPUT_VERSION#v}"
             echo "version=$VERSION" >> $GITHUB_OUTPUT
             echo "repost=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Why

When the v0.109.0 release-notes post failed (stale gateway key → 401), the tag was already created — so re-running `auto-release` was a **no-op**: the `already_tagged` guard skipped every step. There was no way to backfill notes for an already-tagged release.

## What

Adds a **manual re-post mode** to `auto-release.yml`:
- `workflow_dispatch` now takes `version` (e.g. `v0.109.0`) and `previous_version` (e.g. `v0.108.0`).
- When `version` is set, the run **skips tagging** and just regenerates + re-posts notes for that range via release-tools (bypasses the `already_tagged` guard).
- Normal push / auto behavior is unchanged (`repost=false` path).

```
workflow_dispatch(version=v0.109.0, previous_version=v0.108.0)
  -> no tag, no version-detect
  -> rewrite-release-notes v0.109.0 v0.108.0 --post-discord  -> DISCORD_RELEASE_WEBHOOK
```

## Follow-up after merge

Dispatch it for `v0.109.0` / `v0.108.0` to (a) validate the now-org-scoped `GATEWAY_API_KEY` and (b) backfill v0.109.0's notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual re-post mode to the release workflow, allowing custom version and previous-version inputs to republish release notes without the standard tagging flow.
  * Release notifications now post correctly when re-posting or when a release tag already exists.

* **Bug Fixes**
  * Improved release failure alerts to trigger appropriately for re-post and already-tagged scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->