### PR TITLE
feat(projects): first-class per-project pause/resume (#4062)

### DIFF
--- a/apps/server/src/routes/projects/index.ts
+++ b/apps/server/src/routes/projects/index.ts
@@ -31,7 +31,10 @@ import {
 } from './routes/ceremony-timeline.js';
 import { createLifecycleRoutes } from './lifecycle/index.js';
 import { createResearchHandler } from './lifecycle/research.js';
+import { createPauseHandler } from './routes/pause.js';
+import { createResumeHandler } from './routes/resume.js';
 import type { ProjectLifecycleService } from '../../services/project-lifecycle-service.js';
+import type { ProjectPauseService } from '../../services/project-pause-service.js';
 import { createProjectTools, toExpressRouter } from '@protolabsai/tools';
 import type { EventLedgerService } from '../../services/event-ledger-service.js';
 
@@ -40,7 +43,8 @@ export function createProjectsRoutes(
   events: EventEmitter,
   projectService: ProjectService,
   lifecycleService?: ProjectLifecycleService,
-  eventLedgerService?: EventLedgerService
+  eventLedgerService?: EventLedgerService,
+  pauseService?: ProjectPauseService
 ): Router {
   const router = Router();
 
@@ -99,6 +103,12 @@ export function createProjectsRoutes(
     validateSlugs('projectSlug'),
     createArchiveHandler(projectService)
   );
+
+  // App-level pause/resume (keyed by projectPath) — first-class per-project pause
+  if (pauseService) {
+    router.post('/pause', validatePathParams('projectPath'), createPauseHandler(pauseService));
+    router.post('/resume', validatePathParams('projectPath'), createResumeHandler(pauseService));
+  }
 
   // Timeline route — GET /api/projects/:slug/timeline
   if (eventLedgerService) {

--- a/apps/server/src/routes/projects/routes/pause.ts
+++ b/apps/server/src/routes/projects/routes/pause.ts
@@ -1,0 +1,33 @@
+/**
+ * POST /pause endpoint - Pause an app/projectPath (app-level pause).
+ *
+ * Records the app in the durable `pausedProjects` registry, reflects
+ * `status: 'paused'` on every non-terminal project slug, and stops any running
+ * auto-mode loop for the projectPath.
+ */
+
+import type { Request, Response } from 'express';
+import { getErrorMessage, logError } from '../common.js';
+import type { ProjectPauseService } from '../../../services/project-pause-service.js';
+
+export function createPauseHandler(pauseService: ProjectPauseService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath, reason } = req.body ?? {};
+      if (!projectPath || typeof projectPath !== 'string') {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      const result = await pauseService.pauseProject(
+        projectPath,
+        typeof reason === 'string' ? reason : undefined
+      );
+
+      res.json({ success: true, ...result });
+    } catch (error) {
+      logError(error, 'Pause project failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/routes/projects/routes/resume.ts
+++ b/apps/server/src/routes/projects/routes/resume.ts
@@ -1,0 +1,29 @@
+/**
+ * POST /resume endpoint - Resume an app/projectPath (app-level resume).
+ *
+ * Removes the app from the durable `pausedProjects` registry and restores each
+ * paused project slug's prior status. Does NOT restart auto-mode.
+ */
+
+import type { Request, Response } from 'express';
+import { getErrorMessage, logError } from '../common.js';
+import type { ProjectPauseService } from '../../../services/project-pause-service.js';
+
+export function createResumeHandler(pauseService: ProjectPauseService) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { projectPath } = req.body ?? {};
+      if (!projectPath || typeof projectPath !== 'string') {
+        res.status(400).json({ success: false, error: 'projectPath is required' });
+        return;
+      }
+
+      const result = await pauseService.resumeProject(projectPath);
+
+      res.json({ success: true, ...result });
+    } catch (error) {
+      logError(error, 'Resume project failed');
+      res.status(500).json({ success: false, error: getErrorMessage(error) });
+    }
+  };
+}

--- a/apps/server/src/server/routes.ts
+++ b/apps/server/src/server/routes.ts
@@ -25,6 +25,7 @@ import { createSessionsRoutes } from '../routes/sessions/index.js';
 import { createFeaturesRoutes } from '../routes/features/index.js';
 import { createBackfillProjectSlugHandler } from '../routes/features/routes/backfill-project-slug.js';
 import { createProjectsRoutes } from '../routes/projects/index.js';
+import { ProjectPauseService } from '../services/project-pause-service.js';
 import { createAutoModeRoutes } from '../routes/auto-mode/index.js';
 import { createEnhancePromptRoutes } from '../routes/enhance-prompt/index.js';
 import { createWorktreeRoutes } from '../routes/worktree/index.js';
@@ -319,9 +320,21 @@ export function registerRoutes(app: Express, services: ServiceContainer): void {
     authMiddleware,
     createBriefingRoutes(eventHistoryService, briefingCursorService)
   );
+  const projectPauseService = new ProjectPauseService(
+    projectService,
+    autoModeService,
+    settingsService
+  );
   app.use(
     '/api/projects',
-    createProjectsRoutes(featureLoader, events, projectService, projectLifecycleService)
+    createProjectsRoutes(
+      featureLoader,
+      events,
+      projectService,
+      projectLifecycleService,
+      undefined,
+      projectPauseService
+    )
   );
   app.use('/api/automations', createAutomationsRoutes(automationService));
   app.use('/api/ava', createAvaRoutes());

--- a/apps/server/src/server/startup.ts
+++ b/apps/server/src/server/startup.ts
@@ -3,6 +3,7 @@
 import { access, unlink, rename, mkdir } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { createLogger, setLogLevel, LogLevel } from '@protolabsai/utils';
+import { isProjectPathPaused } from '@protolabsai/types';
 
 import type { ServiceContainer } from './services.js';
 import { initOtel } from '../lib/otel.js';
@@ -357,6 +358,15 @@ export async function runStartup(
         const { projectPath, branchName, maxConcurrency, reason } = target;
         const worktreeDesc = branchName ? `worktree ${branchName}` : 'main worktree';
         try {
+          // Guard: never re-arm a paused app. The durable `pausedProjects`
+          // registry is the enforced source of truth — resume is required first.
+          if (isProjectPathPaused(settings, projectPath)) {
+            logger.info(
+              `[AUTO-START] ${projectPath} is paused — skipping auto-mode start (resume to re-arm)`
+            );
+            continue;
+          }
+
           // Guard: skip start if the project has no ready backlog features.
           // Starting loops for idle projects wastes memory and contributes to OOM on
           // restart when multiple apps are configured. The loop can be started later

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -799,6 +799,19 @@ export class AutoModeService {
   }
 
   /**
+   * Whether the given app/projectPath is currently paused per the durable
+   * `pausedProjects` registry in global settings. Shared guard used by every
+   * loop start/resume entry point so a paused app cannot be revived. Returns
+   * false when no settingsService is wired (pause is unenforceable without it).
+   * @param projectPath - The project path to check
+   */
+  private async isProjectPathPausedNow(projectPath: string): Promise<boolean> {
+    if (!this.settingsService) return false;
+    const settings = await this.settingsService.getGlobalSettings();
+    return isProjectPathPaused(settings, projectPath);
+  }
+
+  /**
    * Start the auto mode loop for a specific project/worktree (supports multiple concurrent projects and worktrees)
    * @param projectPath - The project to start auto mode for
    * @param branchName - The branch name for worktree scoping, null for main worktree
@@ -822,11 +835,8 @@ export class AutoModeService {
 
     // App-level pause gate. The durable `pausedProjects` registry is the enforced
     // source of truth — refuse to start a loop for a paused app until it is resumed.
-    if (this.settingsService) {
-      const settings = await this.settingsService.getGlobalSettings();
-      if (isProjectPathPaused(settings, projectPath)) {
-        throw new Error(`Project is paused: ${projectPath}. Resume it before starting auto-mode.`);
-      }
+    if (await this.isProjectPathPausedNow(projectPath)) {
+      throw new Error(`Project is paused: ${projectPath}. Resume it before starting auto-mode.`);
     }
 
     // Compute key early so we can synchronously claim it before any await.
@@ -1050,7 +1060,19 @@ export class AutoModeService {
    * @param branchName - The branch name, or null for main worktree
    * @returns true if the loop was resumed, false if no paused loop was found
    */
-  resumeAutoLoopForProject(projectPath: string, branchName: string | null = null): boolean {
+  async resumeAutoLoopForProject(
+    projectPath: string,
+    branchName: string | null = null
+  ): Promise<boolean> {
+    // App-level pause gate. A paused app must not have its loop revived until
+    // it is resumed through ProjectPauseService.
+    if (await this.isProjectPathPausedNow(projectPath)) {
+      logger.info(
+        `[AutoLoop] Refusing to resume loop — app is paused: ${projectPath}. Resume it before restarting auto-mode.`
+      );
+      return false;
+    }
+
     const worktreeKey = this.coordinator.makeKey(projectPath, branchName);
     const existingState = this.coordinator.getState(worktreeKey);
     if (!existingState) {
@@ -3992,6 +4014,15 @@ You can use the Read tool to view these images at any time during implementation
    * This should be called during server initialization
    */
   async resumeInterruptedFeatures(projectPath: string): Promise<void> {
+    // App-level pause gate. A paused app must not have interrupted features
+    // revived — that would silently restart work the user explicitly halted.
+    if (await this.isProjectPathPausedNow(projectPath)) {
+      logger.info(
+        `Skipping interrupted-feature resume — app is paused: ${projectPath}. Resume it before restarting auto-mode.`
+      );
+      return;
+    }
+
     // Only run once per project per server lifecycle.
     // The UI calls this on every board mount — subsequent calls are no-ops.
     if (this.resumeCheckedProjects.has(projectPath)) {

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -49,6 +49,7 @@ import {
   isClaudeModel,
   stripProviderPrefix,
   deriveVerificationTier,
+  isProjectPathPaused,
 } from '@protolabsai/types';
 import { getVerificationTierInstructions } from '@protolabsai/prompts';
 import {
@@ -817,6 +818,15 @@ export class AutoModeService {
       const message = buildComplianceRefusalMessage(projectPath, compliance.violations);
       logger.warn(`[compliance] ${message}`);
       throw new Error(message);
+    }
+
+    // App-level pause gate. The durable `pausedProjects` registry is the enforced
+    // source of truth — refuse to start a loop for a paused app until it is resumed.
+    if (this.settingsService) {
+      const settings = await this.settingsService.getGlobalSettings();
+      if (isProjectPathPaused(settings, projectPath)) {
+        throw new Error(`Project is paused: ${projectPath}. Resume it before starting auto-mode.`);
+      }
     }
 
     // Compute key early so we can synchronously claim it before any await.

--- a/apps/server/src/services/project-pause-service.ts
+++ b/apps/server/src/services/project-pause-service.ts
@@ -93,8 +93,26 @@ export class ProjectPauseService {
       slugsPaused.push(slug);
     }
 
-    // (f) stop the running loop (best-effort — durable state already recorded)
-    const loopsStopped = await this.autoModeService.stopAutoLoopForProject(projectPath);
+    // (f) stop EVERY active loop for the app (best-effort — durable state already
+    // recorded). An app may run concurrent worktree loops, each keyed by branch;
+    // stopping only the null-branch loop would leave worktree loops alive on a
+    // paused app. Enumerate active worktrees for this app and stop each. If none
+    // are active, fall back to a single null-branch stop (covers the main loop).
+    const activeForApp = this.autoModeService
+      .getActiveAutoLoopWorktrees()
+      .filter((w) => w.projectPath === projectPath);
+
+    let loopsStopped = 0;
+    if (activeForApp.length > 0) {
+      for (const w of activeForApp) {
+        loopsStopped += await this.autoModeService.stopAutoLoopForProject(
+          projectPath,
+          w.branchName
+        );
+      }
+    } else {
+      loopsStopped = await this.autoModeService.stopAutoLoopForProject(projectPath);
+    }
 
     logger.info(
       `Paused app ${projectPath}: ${slugsPaused.length} slug(s) paused, ${loopsStopped} loop(s) stopped${

--- a/apps/server/src/services/project-pause-service.ts
+++ b/apps/server/src/services/project-pause-service.ts
@@ -1,0 +1,155 @@
+/**
+ * Project Pause Service - App-level pause/resume
+ *
+ * Pause is keyed by `projectPath` (one app/projectPath may hold many project
+ * slugs under `.automaker/projects/`). The durable, enforced source of truth is
+ * the `pausedProjects` list in global settings; while paused, auto-mode refuses
+ * to start a loop for the projectPath. We also reflect `status: 'paused'` on
+ * every non-terminal project slug in the app for board visibility.
+ *
+ * Resume restores each slug's prior status (`pausedFrom`) and removes the app
+ * from the pause registry. It does NOT auto-restart auto-mode.
+ */
+
+import type { GlobalSettings, ProjectStatus } from '@protolabsai/types';
+import { isProjectPathPaused } from '@protolabsai/types';
+import { createLogger } from '@protolabsai/utils';
+import type { ProjectService } from './project-service.js';
+import type { AutoModeService } from './auto-mode-service.js';
+import type { SettingsService } from './settings-service.js';
+
+const logger = createLogger('ProjectPauseService');
+
+/** Statuses that are terminal/already-paused and must not be overwritten by pause. */
+const NON_PAUSABLE_STATUSES: ReadonlySet<ProjectStatus> = new Set<ProjectStatus>([
+  'completed',
+  'cancelled',
+  'paused',
+]);
+
+export interface PauseProjectResult {
+  projectPath: string;
+  slugsPaused: string[];
+  loopsStopped: number;
+  alreadyPaused: boolean;
+}
+
+export interface ResumeProjectResult {
+  projectPath: string;
+  slugsResumed: string[];
+  wasPaused: boolean;
+}
+
+export class ProjectPauseService {
+  constructor(
+    private readonly projectService: ProjectService,
+    private readonly autoModeService: AutoModeService,
+    private readonly settingsService: SettingsService
+  ) {}
+
+  /**
+   * Pause an app/projectPath. Idempotent: re-pausing an already-paused app still
+   * re-enforces the paused state. Settings are written first (durable intent),
+   * then the loop is stopped — so a stop failure still leaves the paused state.
+   */
+  async pauseProject(projectPath: string, reason?: string): Promise<PauseProjectResult> {
+    const settings = await this.settingsService.getGlobalSettings();
+
+    const existingPaused = settings.pausedProjects ?? [];
+    const alreadyPaused = existingPaused.some((p) => p.projectPath === projectPath);
+    const pausedAt = new Date().toISOString();
+
+    // (b) add to pausedProjects, deduped by projectPath
+    const pausedProjects = [
+      ...existingPaused.filter((p) => p.projectPath !== projectPath),
+      { projectPath, reason, pausedAt },
+    ];
+
+    // (c) remove from autoModeAlwaysOn.projects so it won't re-arm on restart
+    const autoModeAlwaysOn = settings.autoModeAlwaysOn
+      ? {
+          ...settings.autoModeAlwaysOn,
+          projects: settings.autoModeAlwaysOn.projects.filter((p) => p.projectPath !== projectPath),
+        }
+      : settings.autoModeAlwaysOn;
+
+    // (d) persist intent durably before touching the loop
+    await this.settingsService.updateGlobalSettings({ pausedProjects, autoModeAlwaysOn });
+
+    // (e) reflect status='paused' on every non-terminal project slug
+    const slugsPaused: string[] = [];
+    const slugs = await this.projectService.listProjects(projectPath);
+    for (const slug of slugs) {
+      const project = await this.projectService.getProject(projectPath, slug);
+      if (!project) continue;
+      if (NON_PAUSABLE_STATUSES.has(project.status)) continue;
+
+      await this.projectService.updateProject(projectPath, slug, {
+        status: 'paused',
+        pausedFrom: project.status,
+        pauseReason: reason,
+        pausedAt,
+      });
+      slugsPaused.push(slug);
+    }
+
+    // (f) stop the running loop (best-effort — durable state already recorded)
+    const loopsStopped = await this.autoModeService.stopAutoLoopForProject(projectPath);
+
+    logger.info(
+      `Paused app ${projectPath}: ${slugsPaused.length} slug(s) paused, ${loopsStopped} loop(s) stopped${
+        alreadyPaused ? ' (was already paused)' : ''
+      }`
+    );
+
+    return { projectPath, slugsPaused, loopsStopped, alreadyPaused };
+  }
+
+  /**
+   * Resume an app/projectPath. Removes it from the pause registry and restores
+   * each paused slug's prior status. Does NOT restart auto-mode.
+   */
+  async resumeProject(projectPath: string): Promise<ResumeProjectResult> {
+    const settings = await this.settingsService.getGlobalSettings();
+
+    const existingPaused = settings.pausedProjects ?? [];
+    const wasPaused = existingPaused.some((p) => p.projectPath === projectPath);
+
+    // (a) remove from pausedProjects registry
+    const pausedProjects = existingPaused.filter((p) => p.projectPath !== projectPath);
+    await this.settingsService.updateGlobalSettings({ pausedProjects });
+
+    // (b) restore prior status on every currently-paused slug
+    const slugsResumed: string[] = [];
+    const slugs = await this.projectService.listProjects(projectPath);
+    for (const slug of slugs) {
+      const project = await this.projectService.getProject(projectPath, slug);
+      if (!project) continue;
+      if (project.status !== 'paused') continue;
+
+      const restoredStatus: ProjectStatus = project.pausedFrom ?? 'active';
+      await this.projectService.updateProject(projectPath, slug, {
+        status: restoredStatus,
+        pausedFrom: undefined,
+        pauseReason: undefined,
+        pausedAt: undefined,
+      });
+      slugsResumed.push(slug);
+    }
+
+    // (c) do NOT restart auto-mode — resume is intentionally inert on loops.
+    logger.info(
+      `Resumed app ${projectPath}: ${slugsResumed.length} slug(s) restored${
+        wasPaused ? '' : ' (was not in pause registry)'
+      }`
+    );
+
+    return { projectPath, slugsResumed, wasPaused };
+  }
+
+  /** Whether the given app/projectPath is currently paused per global settings. */
+  async isPaused(projectPath: string): Promise<boolean> {
+    const settings: GlobalSettings = await this.settingsService.getGlobalSettings();
+    return isProjectPathPaused(settings, projectPath);
+  }
+}

--- a/apps/server/tests/integration/routes/projects/pause.integration.test.ts
+++ b/apps/server/tests/integration/routes/projects/pause.integration.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Integration test for the app-level pause/resume routes (#4062).
+ *
+ * Unlike the unit test (which calls the handlers directly), this test builds the
+ * REAL `createProjectsRoutes(...)` router with a real `ProjectPauseService`
+ * wired to lightweight test doubles, mounts it on an Express app exactly as the
+ * server does (under `/api/projects`), and drives it over real HTTP. The point
+ * is to catch a broken route wiring — a regression where `/pause` or `/resume`
+ * is not registered, mounted at the wrong path, or detached from the service —
+ * which a direct-handler unit test cannot detect (per CLAUDE.md: every new
+ * service must have an integration test covering its wiring point).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import type { AddressInfo } from 'node:net';
+import type { Server } from 'node:http';
+import { createProjectsRoutes } from '@/routes/projects/index.js';
+import { ProjectPauseService } from '@/services/project-pause-service.js';
+import type { ProjectService } from '@/services/project-service.js';
+import type { AutoModeService } from '@/services/auto-mode-service.js';
+import type { SettingsService } from '@/services/settings-service.js';
+import type { FeatureLoader } from '@/services/feature-loader.js';
+import type { EventEmitter } from '@/lib/events.js';
+import type { GlobalSettings } from '@protolabsai/types';
+
+describe('projects pause/resume routes — real wiring (#4062)', () => {
+  let server: Server;
+  let baseUrl: string;
+
+  // In-memory settings the fake SettingsService reads/writes.
+  let settings: GlobalSettings;
+
+  // Spies so we can assert the service side effects fire end-to-end.
+  const stopAutoLoopForProject = vi.fn(async () => 1);
+  const getActiveAutoLoopWorktrees = vi.fn(
+    (): Array<{ projectPath: string; branchName: string | null }> => []
+  );
+  const listProjects = vi.fn(async (_projectPath: string): Promise<string[]> => []);
+
+  beforeAll(async () => {
+    settings = { pausedProjects: [] } as unknown as GlobalSettings;
+
+    const settingsService = {
+      getGlobalSettings: vi.fn(async () => settings),
+      updateGlobalSettings: vi.fn(async (patch: Partial<GlobalSettings>) => {
+        settings = { ...settings, ...patch };
+        return settings;
+      }),
+    } as unknown as SettingsService;
+
+    const projectService = {
+      listProjects,
+      getProject: vi.fn(async () => null),
+      updateProject: vi.fn(async () => undefined),
+    } as unknown as ProjectService;
+
+    const autoModeService = {
+      stopAutoLoopForProject,
+      getActiveAutoLoopWorktrees,
+    } as unknown as AutoModeService;
+
+    const pauseService = new ProjectPauseService(projectService, autoModeService, settingsService);
+
+    // Build the real router exactly as the server does, then mount under
+    // /api/projects to mirror apps/server/src/server/routes.ts.
+    const router = createProjectsRoutes(
+      {} as unknown as FeatureLoader,
+      {} as unknown as EventEmitter,
+      projectService,
+      undefined,
+      undefined,
+      pauseService
+    );
+
+    const app = express();
+    app.use(express.json());
+    app.use('/api/projects', router);
+
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, '127.0.0.1', () => resolve());
+    });
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  async function post(path: string, body: unknown) {
+    const res = await fetch(`${baseUrl}${path}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+    return { status: res.status, json };
+  }
+
+  it('POST /api/projects/pause records the app and stops loops (200)', async () => {
+    getActiveAutoLoopWorktrees.mockReturnValueOnce([
+      { projectPath: '/app/x', branchName: null },
+      { projectPath: '/app/x', branchName: 'feature/a' },
+      { projectPath: '/app/other', branchName: null }, // different app — must be ignored
+    ]);
+
+    const { status, json } = await post('/api/projects/pause', {
+      projectPath: '/app/x',
+      reason: 'maintenance',
+    });
+
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.projectPath).toBe('/app/x');
+    expect(json.alreadyPaused).toBe(false);
+
+    // Side effect: the app is now durably recorded as paused.
+    expect(settings.pausedProjects?.some((p) => p.projectPath === '/app/x')).toBe(true);
+
+    // Side effect: every active loop for THIS app was stopped (both branches),
+    // and the other app's loop was left alone.
+    expect(stopAutoLoopForProject).toHaveBeenCalledWith('/app/x', null);
+    expect(stopAutoLoopForProject).toHaveBeenCalledWith('/app/x', 'feature/a');
+    expect(stopAutoLoopForProject).not.toHaveBeenCalledWith('/app/other', expect.anything());
+    // 2 loops stopped, 1 each.
+    expect(json.loopsStopped).toBe(2);
+  });
+
+  it('POST /api/projects/resume clears the pause registry (200)', async () => {
+    // Precondition from the previous test: /app/x is paused.
+    expect(settings.pausedProjects?.some((p) => p.projectPath === '/app/x')).toBe(true);
+
+    const { status, json } = await post('/api/projects/resume', { projectPath: '/app/x' });
+
+    expect(status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.projectPath).toBe('/app/x');
+    expect(json.wasPaused).toBe(true);
+
+    // Side effect: the app is removed from the durable pause registry.
+    expect(settings.pausedProjects?.some((p) => p.projectPath === '/app/x')).toBe(false);
+  });
+
+  it('POST /api/projects/pause returns 400 when projectPath is missing', async () => {
+    const { status, json } = await post('/api/projects/pause', { reason: 'no path' });
+
+    expect(status).toBe(400);
+    expect(json.success).toBe(false);
+  });
+
+  it('POST /api/projects/resume returns 400 when projectPath is missing', async () => {
+    const { status, json } = await post('/api/projects/resume', {});
+
+    expect(status).toBe(400);
+    expect(json.success).toBe(false);
+  });
+});

--- a/apps/server/tests/unit/routes/projects/pause.test.ts
+++ b/apps/server/tests/unit/routes/projects/pause.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for the pause/resume project route handlers (#4062).
+ *
+ * Verifies request validation (projectPath required) and that the handlers
+ * delegate to ProjectPauseService and surface its result.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Request, Response } from 'express';
+import { createPauseHandler } from '@/routes/projects/routes/pause.js';
+import { createResumeHandler } from '@/routes/projects/routes/resume.js';
+import type { ProjectPauseService } from '@/services/project-pause-service.js';
+
+function makeRes() {
+  const res: Partial<Response> & { statusCode: number; body: unknown } = {
+    statusCode: 200,
+    body: undefined,
+  };
+  res.status = vi.fn((c: number) => {
+    res.statusCode = c;
+    return res as Response;
+  }) as unknown as Response['status'];
+  res.json = vi.fn((b: unknown) => {
+    res.body = b;
+    return res as Response;
+  }) as unknown as Response['json'];
+  return res;
+}
+
+function makeReq(body: unknown): Request {
+  return { body } as Request;
+}
+
+describe('pause/resume project route handlers (#4062)', () => {
+  let pauseService: {
+    pauseProject: ReturnType<typeof vi.fn>;
+    resumeProject: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    pauseService = {
+      pauseProject: vi.fn(),
+      resumeProject: vi.fn(),
+    };
+  });
+
+  describe('createPauseHandler', () => {
+    it('returns 400 when projectPath is missing', async () => {
+      const handler = createPauseHandler(pauseService as unknown as ProjectPauseService);
+      const res = makeRes();
+      await handler(makeReq({ reason: 'maintenance' }), res as Response);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ success: false, error: 'projectPath is required' });
+      expect(pauseService.pauseProject).not.toHaveBeenCalled();
+    });
+
+    it('delegates to the service and returns the result on success', async () => {
+      pauseService.pauseProject.mockResolvedValue({
+        projectPath: '/app/a',
+        slugsPaused: ['svc'],
+        loopsStopped: 1,
+        alreadyPaused: false,
+      });
+      const handler = createPauseHandler(pauseService as unknown as ProjectPauseService);
+      const res = makeRes();
+      await handler(makeReq({ projectPath: '/app/a', reason: 'maintenance' }), res as Response);
+
+      expect(pauseService.pauseProject).toHaveBeenCalledWith('/app/a', 'maintenance');
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        projectPath: '/app/a',
+        slugsPaused: ['svc'],
+        loopsStopped: 1,
+        alreadyPaused: false,
+      });
+    });
+
+    it('returns 500 when the service throws', async () => {
+      pauseService.pauseProject.mockRejectedValue(new Error('boom'));
+      const handler = createPauseHandler(pauseService as unknown as ProjectPauseService);
+      const res = makeRes();
+      await handler(makeReq({ projectPath: '/app/a' }), res as Response);
+
+      expect(res.statusCode).toBe(500);
+      expect(res.body).toMatchObject({ success: false });
+    });
+  });
+
+  describe('createResumeHandler', () => {
+    it('returns 400 when projectPath is missing', async () => {
+      const handler = createResumeHandler(pauseService as unknown as ProjectPauseService);
+      const res = makeRes();
+      await handler(makeReq({}), res as Response);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toEqual({ success: false, error: 'projectPath is required' });
+      expect(pauseService.resumeProject).not.toHaveBeenCalled();
+    });
+
+    it('delegates to the service and returns the result on success', async () => {
+      pauseService.resumeProject.mockResolvedValue({
+        projectPath: '/app/a',
+        slugsResumed: ['svc'],
+        wasPaused: true,
+      });
+      const handler = createResumeHandler(pauseService as unknown as ProjectPauseService);
+      const res = makeRes();
+      await handler(makeReq({ projectPath: '/app/a' }), res as Response);
+
+      expect(pauseService.resumeProject).toHaveBeenCalledWith('/app/a');
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        projectPath: '/app/a',
+        slugsResumed: ['svc'],
+        wasPaused: true,
+      });
+    });
+  });
+});

--- a/apps/server/tests/unit/services/project-pause-service.test.ts
+++ b/apps/server/tests/unit/services/project-pause-service.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Unit tests for ProjectPauseService (#4062) — app-level pause/resume.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DEFAULT_GLOBAL_SETTINGS, isProjectPathPaused } from '@protolabsai/types';
+import type { GlobalSettings, Project, ProjectStatus } from '@protolabsai/types';
+import { ProjectPauseService } from '@/services/project-pause-service.js';
+import type { ProjectService } from '@/services/project-service.js';
+import type { AutoModeService } from '@/services/auto-mode-service.js';
+import type { SettingsService } from '@/services/settings-service.js';
+
+const PROJECT_PATH = '/app/alpha';
+
+function makeProject(slug: string, status: ProjectStatus, extra: Partial<Project> = {}): Project {
+  return {
+    slug,
+    title: slug,
+    goal: 'goal',
+    status,
+    milestones: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...extra,
+  };
+}
+
+/**
+ * Builds a stateful settings stub whose getGlobalSettings reflects prior
+ * updateGlobalSettings calls (shallow merge), mirroring the real service.
+ */
+function makeSettingsService(initial?: Partial<GlobalSettings>) {
+  let current: GlobalSettings = {
+    ...DEFAULT_GLOBAL_SETTINGS,
+    ...initial,
+  };
+  return {
+    getGlobalSettings: vi.fn(async () => current),
+    updateGlobalSettings: vi.fn(async (updates: Partial<GlobalSettings>) => {
+      current = { ...current, ...updates };
+      return current;
+    }),
+    _peek: () => current,
+  };
+}
+
+function makeProjectService(projects: Project[]) {
+  const bySlug = new Map(projects.map((p) => [p.slug, structuredClone(p)]));
+  return {
+    listProjects: vi.fn(async () => [...bySlug.keys()].sort()),
+    getProject: vi.fn(async (_path: string, slug: string) => bySlug.get(slug) ?? null),
+    updateProject: vi.fn(async (_path: string, slug: string, updates: Partial<Project>) => {
+      const existing = bySlug.get(slug);
+      if (!existing) return null;
+      const updated = { ...existing, ...updates } as Project;
+      bySlug.set(slug, updated);
+      return updated;
+    }),
+    _peek: (slug: string) => bySlug.get(slug),
+  };
+}
+
+describe('ProjectPauseService (#4062)', () => {
+  let autoModeService: { stopAutoLoopForProject: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    autoModeService = { stopAutoLoopForProject: vi.fn(async () => 1) };
+  });
+
+  it('pause records pausedProjects, strips autoModeAlwaysOn, pauses non-terminal slugs, and stops the loop', async () => {
+    const settings = makeSettingsService({
+      autoModeAlwaysOn: {
+        enabled: true,
+        projects: [
+          { projectPath: PROJECT_PATH, branchName: null },
+          { projectPath: '/app/other', branchName: null },
+        ],
+      },
+    });
+    const projectService = makeProjectService([
+      makeProject('active-one', 'active'),
+      makeProject('approved-one', 'approved'),
+      makeProject('done-one', 'completed'),
+      makeProject('cancelled-one', 'cancelled'),
+    ]);
+
+    const service = new ProjectPauseService(
+      projectService as unknown as ProjectService,
+      autoModeService as unknown as AutoModeService,
+      settings as unknown as SettingsService
+    );
+
+    const result = await service.pauseProject(PROJECT_PATH, 'maintenance');
+
+    // pausedProjects updated + autoModeAlwaysOn stripped of this projectPath
+    const saved = settings._peek();
+    expect(isProjectPathPaused(saved, PROJECT_PATH)).toBe(true);
+    expect(saved.pausedProjects?.find((p) => p.projectPath === PROJECT_PATH)?.reason).toBe(
+      'maintenance'
+    );
+    expect(saved.autoModeAlwaysOn?.projects.map((p) => p.projectPath)).toEqual(['/app/other']);
+
+    // non-terminal slugs flipped to paused with pausedFrom recorded
+    expect(result.slugsPaused.sort()).toEqual(['active-one', 'approved-one']);
+    expect(projectService._peek('active-one')?.status).toBe('paused');
+    expect(projectService._peek('active-one')?.pausedFrom).toBe('active');
+    expect(projectService._peek('approved-one')?.pausedFrom).toBe('approved');
+
+    // terminal slugs untouched
+    expect(projectService._peek('done-one')?.status).toBe('completed');
+    expect(projectService._peek('cancelled-one')?.status).toBe('cancelled');
+
+    // loop stopped, count surfaced
+    expect(autoModeService.stopAutoLoopForProject).toHaveBeenCalledWith(PROJECT_PATH);
+    expect(result.loopsStopped).toBe(1);
+    expect(result.alreadyPaused).toBe(false);
+  });
+
+  it('persists paused intent before stopping the loop (durable even if stop fails)', async () => {
+    const settings = makeSettingsService();
+    const projectService = makeProjectService([makeProject('active-one', 'active')]);
+    autoModeService.stopAutoLoopForProject.mockRejectedValueOnce(new Error('stop failed'));
+
+    const service = new ProjectPauseService(
+      projectService as unknown as ProjectService,
+      autoModeService as unknown as AutoModeService,
+      settings as unknown as SettingsService
+    );
+
+    await expect(service.pauseProject(PROJECT_PATH)).rejects.toThrow('stop failed');
+
+    // settings write happened before the loop stop threw
+    expect(isProjectPathPaused(settings._peek(), PROJECT_PATH)).toBe(true);
+  });
+
+  it('pause is idempotent: re-pausing an already-paused app reports alreadyPaused and dedupes', async () => {
+    const settings = makeSettingsService({
+      pausedProjects: [{ projectPath: PROJECT_PATH, pausedAt: '2026-01-01T00:00:00.000Z' }],
+    });
+    const projectService = makeProjectService([makeProject('paused-one', 'paused')]);
+
+    const service = new ProjectPauseService(
+      projectService as unknown as ProjectService,
+      autoModeService as unknown as AutoModeService,
+      settings as unknown as SettingsService
+    );
+
+    const result = await service.pauseProject(PROJECT_PATH);
+
+    expect(result.alreadyPaused).toBe(true);
+    // already-paused slug is not re-paused
+    expect(result.slugsPaused).toEqual([]);
+    // dedupe: still exactly one entry
+    const entries = settings._peek().pausedProjects?.filter((p) => p.projectPath === PROJECT_PATH);
+    expect(entries).toHaveLength(1);
+  });
+
+  it('resume removes from pausedProjects and restores pausedFrom status', async () => {
+    const settings = makeSettingsService({
+      pausedProjects: [{ projectPath: PROJECT_PATH, pausedAt: '2026-01-01T00:00:00.000Z' }],
+    });
+    const projectService = makeProjectService([
+      makeProject('one', 'paused', { pausedFrom: 'active', pauseReason: 'x', pausedAt: 't' }),
+      makeProject('two', 'paused', { pausedFrom: 'approved' }),
+      makeProject('untouched', 'completed'),
+    ]);
+
+    const service = new ProjectPauseService(
+      projectService as unknown as ProjectService,
+      autoModeService as unknown as AutoModeService,
+      settings as unknown as SettingsService
+    );
+
+    const result = await service.resumeProject(PROJECT_PATH);
+
+    expect(result.wasPaused).toBe(true);
+    expect(isProjectPathPaused(settings._peek(), PROJECT_PATH)).toBe(false);
+
+    expect(result.slugsResumed.sort()).toEqual(['one', 'two']);
+    expect(projectService._peek('one')?.status).toBe('active');
+    expect(projectService._peek('one')?.pausedFrom).toBeUndefined();
+    expect(projectService._peek('one')?.pauseReason).toBeUndefined();
+    expect(projectService._peek('two')?.status).toBe('approved');
+    expect(projectService._peek('untouched')?.status).toBe('completed');
+
+    // resume must NOT restart auto-mode
+    expect(autoModeService.stopAutoLoopForProject).not.toHaveBeenCalled();
+  });
+
+  it('resume falls back to active when pausedFrom is missing', async () => {
+    const settings = makeSettingsService({
+      pausedProjects: [{ projectPath: PROJECT_PATH, pausedAt: 't' }],
+    });
+    const projectService = makeProjectService([makeProject('one', 'paused')]);
+
+    const service = new ProjectPauseService(
+      projectService as unknown as ProjectService,
+      autoModeService as unknown as AutoModeService,
+      settings as unknown as SettingsService
+    );
+
+    await service.resumeProject(PROJECT_PATH);
+    expect(projectService._peek('one')?.status).toBe('active');
+  });
+
+  it('isPaused reflects the durable registry', async () => {
+    const settings = makeSettingsService({
+      pausedProjects: [{ projectPath: PROJECT_PATH, pausedAt: 't' }],
+    });
+    const projectService = makeProjectService([]);
+    const service = new ProjectPauseService(
+      projectService as unknown as ProjectService,
+      autoModeService as unknown as AutoModeService,
+      settings as unknown as SettingsService
+    );
+
+    expect(await service.isPaused(PROJECT_PATH)).toBe(true);
+    expect(await service.isPaused('/app/other')).toBe(false);
+  });
+});

--- a/apps/server/tests/unit/services/project-pause-service.test.ts
+++ b/apps/server/tests/unit/services/project-pause-service.test.ts
@@ -61,10 +61,18 @@ function makeProjectService(projects: Project[]) {
 }
 
 describe('ProjectPauseService (#4062)', () => {
-  let autoModeService: { stopAutoLoopForProject: ReturnType<typeof vi.fn> };
+  let autoModeService: {
+    stopAutoLoopForProject: ReturnType<typeof vi.fn>;
+    getActiveAutoLoopWorktrees: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
-    autoModeService = { stopAutoLoopForProject: vi.fn(async () => 1) };
+    autoModeService = {
+      stopAutoLoopForProject: vi.fn(async () => 1),
+      // No active worktree loops by default → pauseProject falls back to a
+      // single null-branch stop (covered by the existing assertions).
+      getActiveAutoLoopWorktrees: vi.fn(() => []),
+    };
   });
 
   it('pause records pausedProjects, strips autoModeAlwaysOn, pauses non-terminal slugs, and stops the loop', async () => {
@@ -114,6 +122,38 @@ describe('ProjectPauseService (#4062)', () => {
     expect(autoModeService.stopAutoLoopForProject).toHaveBeenCalledWith(PROJECT_PATH);
     expect(result.loopsStopped).toBe(1);
     expect(result.alreadyPaused).toBe(false);
+  });
+
+  it('pause stops EVERY active worktree loop for the app and ignores other apps', async () => {
+    const settings = makeSettingsService();
+    const projectService = makeProjectService([makeProject('active-one', 'active')]);
+
+    autoModeService.getActiveAutoLoopWorktrees.mockReturnValue([
+      { projectPath: PROJECT_PATH, branchName: null },
+      { projectPath: PROJECT_PATH, branchName: 'feature/a' },
+      { projectPath: '/app/other', branchName: null },
+    ]);
+    // Two loops for our app, 1 each.
+    autoModeService.stopAutoLoopForProject.mockResolvedValue(1);
+
+    const service = new ProjectPauseService(
+      projectService as unknown as ProjectService,
+      autoModeService as unknown as AutoModeService,
+      settings as unknown as SettingsService
+    );
+
+    const result = await service.pauseProject(PROJECT_PATH);
+
+    // Both loops for this app stopped, with their respective branch names.
+    expect(autoModeService.stopAutoLoopForProject).toHaveBeenCalledWith(PROJECT_PATH, null);
+    expect(autoModeService.stopAutoLoopForProject).toHaveBeenCalledWith(PROJECT_PATH, 'feature/a');
+    // The other app's loop is left alone.
+    expect(autoModeService.stopAutoLoopForProject).not.toHaveBeenCalledWith(
+      '/app/other',
+      expect.anything()
+    );
+    expect(autoModeService.stopAutoLoopForProject).toHaveBeenCalledTimes(2);
+    expect(result.loopsStopped).toBe(2);
   });
 
   it('persists paused intent before stopping the loop (durable even if stop fails)', async () => {

--- a/apps/ui/src/components/views/projects-view/lib/status-variants.ts
+++ b/apps/ui/src/components/views/projects-view/lib/status-variants.ts
@@ -30,6 +30,8 @@ export function getProjectStatusVariant(status: string): BadgeVariant {
       return 'info';
     case 'active':
       return 'warning';
+    case 'paused':
+      return 'muted';
     case 'completed':
       return 'success';
     case 'cancelled':

--- a/libs/types/src/global-settings.ts
+++ b/libs/types/src/global-settings.ts
@@ -584,6 +584,21 @@ export interface GlobalSettings {
   };
 
   /**
+   * App-level pause registry. Keyed by `projectPath` (one app/projectPath may
+   * hold many project slugs under `.automaker/projects/`). The durable,
+   * enforced source of truth for whether an app is paused. While paused,
+   * auto-mode refuses to start a loop for the projectPath.
+   */
+  pausedProjects?: Array<{
+    /** Absolute path to the paused app/project directory */
+    projectPath: string;
+    /** Optional human-supplied reason for the pause */
+    reason?: string;
+    /** ISO timestamp of when the pause was recorded */
+    pausedAt: string;
+  }>;
+
+  /**
    * Discord integration settings.
    * @see DiscordSettings
    */
@@ -779,6 +794,8 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
     enabled: false,
     projects: [],
   },
+  // App-level pause registry (empty by default)
+  pausedProjects: [],
   // Feature flags — all on in development by default
   featureFlags: DEFAULT_FEATURE_FLAGS,
   // Scheduler settings — no task overrides by default
@@ -790,3 +807,11 @@ export const DEFAULT_GLOBAL_SETTINGS: GlobalSettings = {
     requiredLabel: 'board-intake',
   },
 };
+
+/**
+ * Pure helper: returns true if the given app/projectPath is currently paused
+ * according to the durable `pausedProjects` registry in global settings.
+ */
+export function isProjectPathPaused(settings: GlobalSettings, projectPath: string): boolean {
+  return (settings.pausedProjects ?? []).some((p) => p.projectPath === projectPath);
+}

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -395,6 +395,8 @@ export {
   // Environment presets
   ENVIRONMENT_PRESETS,
   getDeploymentEnvironment,
+  // App-level pause registry helper
+  isProjectPathPaused,
 } from './settings.js';
 
 // Model display constants

--- a/libs/types/src/project.ts
+++ b/libs/types/src/project.ts
@@ -21,6 +21,7 @@ export type ProjectStatus =
   | 'approved' // PRD approved, ready to scaffold
   | 'scaffolded' // Project structure created
   | 'active' // Features created, work in progress
+  | 'paused' // App-level pause; work halted, prior status preserved in pausedFrom
   | 'completed' // All features done
   | 'cancelled'; // Project abandoned or killed at any gate
 
@@ -241,6 +242,15 @@ export interface Project {
   /** Current status in the orchestration pipeline */
   status: ProjectStatus;
 
+  /** Status this project held before being paused (restored on resume) */
+  pausedFrom?: ProjectStatus;
+
+  /** Optional reason supplied when the project's app was paused */
+  pauseReason?: string;
+
+  /** ISO timestamp of when the project was paused */
+  pausedAt?: string;
+
   /** Milestones within this project */
   milestones: Milestone[];
 
@@ -453,6 +463,15 @@ export interface UpdateProjectInput {
 
   /** Update status */
   status?: ProjectStatus;
+
+  /** Status this project held before being paused (restored on resume) */
+  pausedFrom?: ProjectStatus;
+
+  /** Optional reason supplied when the project's app was paused */
+  pauseReason?: string;
+
+  /** ISO timestamp of when the project was paused */
+  pausedAt?: string;
 
   /** ISO timestamp of when the project was completed */
   completedAt?: string;

--- a/libs/types/tests/project-pause.test.ts
+++ b/libs/types/tests/project-pause.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for the app-level pause registry helper (#4062).
+ *
+ * `isProjectPathPaused` is the pure predicate auto-mode and startup use to
+ * enforce/skip paused apps; cover it directly rather than instantiating the
+ * heavy AutoModeService.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_GLOBAL_SETTINGS, isProjectPathPaused } from '../src/global-settings.js';
+import type { GlobalSettings } from '../src/global-settings.js';
+
+describe('isProjectPathPaused (#4062)', () => {
+  it('returns false when pausedProjects is undefined', () => {
+    const settings = { ...DEFAULT_GLOBAL_SETTINGS, pausedProjects: undefined } as GlobalSettings;
+    expect(isProjectPathPaused(settings, '/app/a')).toBe(false);
+  });
+
+  it('returns false by default (empty registry)', () => {
+    expect(isProjectPathPaused(DEFAULT_GLOBAL_SETTINGS, '/app/a')).toBe(false);
+  });
+
+  it('returns true when the projectPath is in the registry', () => {
+    const settings: GlobalSettings = {
+      ...DEFAULT_GLOBAL_SETTINGS,
+      pausedProjects: [
+        { projectPath: '/app/a', pausedAt: '2026-01-01T00:00:00.000Z' },
+        { projectPath: '/app/b', reason: 'x', pausedAt: '2026-01-01T00:00:00.000Z' },
+      ],
+    };
+    expect(isProjectPathPaused(settings, '/app/a')).toBe(true);
+    expect(isProjectPathPaused(settings, '/app/b')).toBe(true);
+  });
+
+  it('returns false for a projectPath not in the registry', () => {
+    const settings: GlobalSettings = {
+      ...DEFAULT_GLOBAL_SETTINGS,
+      pausedProjects: [{ projectPath: '/app/a', pausedAt: '2026-01-01T00:00:00.000Z' }],
+    };
+    expect(isProjectPathPaused(settings, '/app/zzz')).toBe(false);
+  });
+});

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -525,6 +525,17 @@ async function handleTool(name: string, args: Record<string, unknown>): Promise<
         projectPath: args.projectPath,
       });
 
+    case 'pause_project':
+      return apiCall('/projects/pause', {
+        projectPath: args.projectPath,
+        reason: args.reason,
+      });
+
+    case 'resume_project':
+      return apiCall('/projects/resume', {
+        projectPath: args.projectPath,
+      });
+
     case 'get_execution_order': {
       const result = (await apiCall('/features/list', {
         projectPath: args.projectPath,

--- a/packages/mcp-server/src/tools/orchestration-tools.ts
+++ b/packages/mcp-server/src/tools/orchestration-tools.ts
@@ -116,6 +116,42 @@ export const orchestrationTools: Tool[] = [
     },
   },
   {
+    name: 'pause_project',
+    description:
+      'Pause an app/project (keyed by projectPath). Records the app as paused, marks every non-terminal project slug as paused for board visibility, and stops any running auto-mode loop. Auto-mode refuses to start while paused until resumed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          minLength: 1,
+          description: 'Absolute path to the project directory',
+        },
+        reason: {
+          type: 'string',
+          description: 'Optional human-readable reason for the pause',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
+    name: 'resume_project',
+    description:
+      "Resume a paused app/project (keyed by projectPath). Removes it from the pause registry and restores each paused slug's prior status. Does NOT auto-restart auto-mode.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        projectPath: {
+          type: 'string',
+          minLength: 1,
+          description: 'Absolute path to the project directory',
+        },
+      },
+      required: ['projectPath'],
+    },
+  },
+  {
     name: 'get_execution_order',
     description:
       'Get the resolved execution order for features based on dependencies. Useful for planning.',


### PR DESCRIPTION
Closes #4062.

## What

A first-class, one-call **pause/resume** primitive for a project, so "pause this app and leave it alone until I come back" is durable, visible, and enforced — no more docker-exec + `stop` + manual `autoModeAlwaysOn` check.

## Scope decision

Pause is **app-level (keyed by `projectPath`)** because auto-mode and `autoModeAlwaysOn` are per-app, while one app holds many project slugs (`.automaker/projects/{slug}/`). The issue was written for the single-project case; this implementation is correct for the 1:many reality. Durable enforced state lives in a new `pausedProjects` list in global settings; `status: 'paused'` is reflected on the app's project slugs for board visibility.

## Changes

- **Types:** `paused` added to `ProjectStatus`; `pausedFrom`/`pauseReason`/`pausedAt` on `Project` + `UpdateProjectInput`; `pausedProjects` + pure `isProjectPathPaused()` helper in global settings.
- **`ProjectPauseService`:**
  - **pause** → record intent in `pausedProjects` + remove from `autoModeAlwaysOn.projects` (settings written *first*, so a stop failure still leaves the durable paused state) → set `status:'paused'` (+ `pausedFrom`) on every non-terminal slug → `stopAutoLoopForProject`.
  - **resume** → drop from registry → restore each slug's `pausedFrom` (fallback `active`) → clears pause fields. Does **not** auto-restart auto-mode (explicit `start` required).
  - idempotent.
- **API:** `POST /api/projects/pause` `{ projectPath, reason? }` and `/resume` `{ projectPath }`.
- **MCP:** `pause_project` / `resume_project`.
- **Enforcement:** `startAutoLoopForProject` refuses a paused app; startup re-arm skips paused apps (survives restart + stray `start`).
- **UI:** `paused` status variant.

## Tests
`project-pause-service` (6), pause/resume route handlers (5), `isProjectPathPaused` helper (4). typecheck 22/22, build clean, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added project pause and resume capabilities to control project execution
  * Paused projects display with updated status indicator and prevent automatic mode from starting
  * Pause operations record optional reason and timestamp for audit tracking
  * Resume operations restore the project's previous operational state

* **Bug Fixes**
  * Paused projects are now properly skipped during auto-start initialization to prevent unintended startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->