### PR TITLE
feat(lifecycle-bus): emit kinded feature.blocked to workstacean (#4067)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,7 +496,7 @@ Use `list_workflows` MCP tool to discover available workflows for a project. Pro
 - `GITHUB_TOKEN` - GitHub personal access token for repository operations
 - `GITHUB_REPO_OWNER` - GitHub repository owner/organization name
 - `GITHUB_REPO_NAME` - GitHub repository name
-- `WORKSTACEAN_URL` - protoWorkstacean base URL for the outbound lifecycle bus (`POST {url}/publish`). When set, `FeatureLifecycleBusPublisher` publishes `feature.completed`/`feature.failed` on terminal transitions (#3810). Unset = disabled (no-op).
+- `WORKSTACEAN_URL` - protoWorkstacean base URL for the outbound lifecycle bus (`POST {url}/publish`). When set, `FeatureLifecycleBusPublisher` publishes terminal transitions (#3810): `done` → `feature.completed`, `blocked` → kinded `feature.blocked` (carries a `kind` failure discriminator for workstacean's remediation router — #4067), `escalated` → `feature.failed`. Unset = disabled (no-op).
 - `WORKSTACEAN_API_KEY` - `X-API-Key` for workstacean's `/publish` (401 without it). Symmetric counterpart to `AUTOMAKER_API_KEY` in the other direction.
 - `WORKSTACEAN_PROJECT_SLUG` - Fallback `projectSlug` on lifecycle events when a feature has none (default `protomaker`); workstacean's feature-notifier requires it to resolve the dev channel.
 - `DISCORD_TOKEN` - Discord bot token for event routing and notifications

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -1869,8 +1869,10 @@ Output the branch name only.`,
           logger.info(`Feature ${featureId} failure count: ${newFailureCount}`);
 
           // Pure-executor: protoMaker does not self-spawn remediation agents.
-          // The terminal `feature.failed` lifecycle event is published for
-          // protoWorkstacean to decide on remediation. See CLAUDE.md.
+          // The terminal lifecycle event (kinded `feature.blocked` when the
+          // feature lands in `blocked`, else `feature.failed` when escalated) is
+          // published for protoWorkstacean to decide on remediation. See
+          // CLAUDE.md and FeatureLifecycleBusPublisher.
         }
 
         // Detect git commit / pre-commit hook failures. These are deterministic — retrying

--- a/apps/server/src/services/feature-lifecycle-bus-publisher.ts
+++ b/apps/server/src/services/feature-lifecycle-bus-publisher.ts
@@ -5,20 +5,28 @@
  *
  * Subscribes to the existing `feature:status-changed` event (emitted by
  * FeatureLoader.update) and, when a feature transitions into a terminal state,
- * publishes `feature.completed` (status -> done) or `feature.failed`
- * (status -> blocked / escalated) to protoWorkstacean's /publish endpoint —
- * the dotted, unprefixed topics workstacean's consumers subscribe to. The
- * payload echoes the originating
- * signal metadata so a consumer (e.g. the Linear ↔ protoMaker bridge) can
- * reconstruct lineage and post a "feature done" comment on the source issue.
- * See protoLabsAI/protoMaker#3549 and the downstream consumer
- * protoLabsAI/protoWorkstacean#482.
+ * publishes one of three dotted, unprefixed topics workstacean's consumers
+ * subscribe to:
+ *
+ *   - `done`      → `feature.completed`
+ *   - `blocked`   → `feature.blocked`   (carries a `kind` failure discriminator)
+ *   - `escalated` → `feature.failed`    (already escalated — no auto-remediation)
+ *
+ * `feature.blocked` is split out of the generic `feature.failed` so
+ * workstacean's FeatureRemediationPlugin can route a per-feature signal to
+ * ignore / HITL / dispatch-Roxy based on `kind`. See protoLabsAI/protoMaker#4067
+ * (this side) and protoLabsAI/protoWorkstacean#779 / #776 (the consumer + the
+ * flag day that depends on this emission). Greenfield: a `blocked` transition
+ * emits ONLY `feature.blocked`, never also `feature.failed`.
+ *
+ * The payload echoes the originating signal metadata so a consumer (e.g. the
+ * Linear ↔ protoMaker bridge) can reconstruct lineage and post a status comment
+ * on the source issue. See protoLabsAI/protoMaker#3549 and the downstream
+ * consumer protoLabsAI/protoWorkstacean#482.
  *
  * Opt-in: only active when WORKSTACEAN_URL is explicitly set, so installs
  * without protoWorkstacean don't attempt (and log) a publish on every feature
- * completion. The canonical board has a single terminal state (`done`); the
- * TERMINAL_STATUSES and FAILURE_STATUSES sets are the extension point if more
- * are added later.
+ * completion.
  */
 
 import { createLogger } from '@protolabsai/utils';
@@ -28,11 +36,124 @@ import { publish as workstaceanPublish } from '../client/workstacean-api.client.
 
 const logger = createLogger('FeatureLifecycleBusPublisher');
 
-/** Board statuses treated as terminal (success) for lifecycle-event purposes. */
+/** Board statuses treated as terminal (success) — emit `feature.completed`. */
 const TERMINAL_STATUSES: ReadonlySet<string> = new Set(['done']);
 
-/** Board statuses treated as terminal (failure) — emit `feature.failed`. */
-const FAILURE_STATUSES: ReadonlySet<string> = new Set(['blocked', 'escalated']);
+/** Board status that emits the kinded `feature.blocked` (remediable failure). */
+const BLOCKED_STATUSES: ReadonlySet<string> = new Set(['blocked']);
+
+/** Board status that emits `feature.failed` (already escalated — no remediation). */
+const ESCALATED_STATUSES: ReadonlySet<string> = new Set(['escalated']);
+
+/**
+ * Failure-category discriminator workstacean's router consumes to decide
+ * ignore vs HITL vs dispatch-Roxy. Mirrors the `kind` vocabulary in
+ * protoLabsAI/protoWorkstacean#779. `undefined` is safe — the router treats a
+ * missing kind as remediable (dispatches Roxy).
+ */
+export type BlockedKind =
+  | 'dependency_unsatisfied'
+  | 'external_dependency_unsatisfied'
+  | 'cost_exceeded'
+  | 'runtime_exceeded'
+  | 'quota'
+  | 'rate_limit'
+  | 'worktree_safety'
+  | 'ci_failure'
+  | 'merge_conflict'
+  | 'changes_requested'
+  | 'retries_exhausted';
+
+/**
+ * Map a human block reason to a workstacean `kind`. First match wins, ordered
+ * most-specific → least. Returns `undefined` for an unrecognized reason so the
+ * router falls back to its remediable default. This is the keyword-matching
+ * fallback described in #4067; if a structured failure category is later
+ * threaded onto the feature record, prefer it over this text match.
+ *
+ * Routing reference (protoWorkstacean#779):
+ *   dependency_unsatisfied / external_dependency_unsatisfied → ignored (self-heals)
+ *   cost_exceeded / runtime_exceeded / quota / rate_limit / worktree_safety → HITL
+ *   ci_failure / merge_conflict / changes_requested / retries_exhausted / else → Roxy
+ */
+export function deriveBlockedKind(reason: string | undefined): BlockedKind | undefined {
+  const r = (reason ?? '').toLowerCase();
+  if (!r) return undefined;
+
+  // Feature-DAG dependency not satisfied — protoMaker self-heals on staleDeps,
+  // so the router ignores it. Matched narrowly so npm/missing-module errors
+  // (which Roxy CAN fix) are NOT silently swallowed here.
+  if (
+    /stale.?dep|dependenc(?:y|ies) (?:unsatisfied|not (?:met|satisfied))|blocked by (?:its )?(?:upstream|dependenc|feature)|waiting (?:on|for) (?:its )?(?:upstream|dependenc)/.test(
+      r
+    )
+  ) {
+    return 'dependency_unsatisfied';
+  }
+
+  // Worktree safety guard (dirty / uncommitted / refusing to corrupt main). HITL.
+  if (
+    /worktree.*(?:safety|uncommitted|dirty|corrupt)|refus\w* to fall back|main working tree/.test(r)
+  ) {
+    return 'worktree_safety';
+  }
+
+  // Cost / budget ceiling. HITL.
+  if (/cost.*(?:exceed|limit|cap)|budget.*(?:exceed|exhaust|cap)|error.?budget/.test(r)) {
+    return 'cost_exceeded';
+  }
+
+  // API rate limit. HITL.
+  if (/rate.?limit|too many requests|\b429\b|throttl/.test(r)) {
+    return 'rate_limit';
+  }
+
+  // Usage quota. HITL.
+  if (/quota|usage limit/.test(r)) {
+    return 'quota';
+  }
+
+  // Retries / PR iterations exhausted. Roxy. (Before runtime: both say "exceeded".)
+  if (
+    /retr(?:y|ies).*(?:exhaust|exceed)|exhaust\w*.*retr|max.*(?:retr|attempt|iteration)\w*.*(?:exceed|reach)|max pr iterations|attempts? exceeded/.test(
+      r
+    )
+  ) {
+    return 'retries_exhausted';
+  }
+
+  // Runtime / timeout. HITL.
+  if (
+    /runtime.*exceed|run.?time exceeded|timed? ?out|timeout|deadline exceeded|took too long|execution.*(?:exceed|too long|timed)/.test(
+      r
+    )
+  ) {
+    return 'runtime_exceeded';
+  }
+
+  // PR review requested changes (either word order). Roxy.
+  if (/changes.?requested|requested changes/.test(r)) {
+    return 'changes_requested';
+  }
+
+  // Git merge conflict. Roxy.
+  if (
+    /merge conflict|unmerged files|rebase.*conflict|fix conflicts|\bconflict(?:s|ing)?\b/.test(r)
+  ) {
+    return 'merge_conflict';
+  }
+
+  // CI / checks / tests / automated review block. Roxy.
+  if (
+    /\bci\b|check(?:s)? fail|status check|test(?:s)? fail|build fail|pipeline fail|fresh-eyes review block|automated review|review block/.test(
+      r
+    )
+  ) {
+    return 'ci_failure';
+  }
+
+  return undefined;
+}
 
 /** Subset of the `feature:status-changed` payload this publisher needs. */
 interface StatusChangedPayload {
@@ -73,11 +194,11 @@ export class FeatureLifecycleBusPublisher {
   }
 
   /**
-   * Publish `feature.completed` when a feature reaches a terminal
-   * success state (done), or `feature.failed` when it reaches a
-   * terminal failure state (blocked / escalated). Loads the feature fresh to
-   * echo its source signal metadata and PR tracking fields. Never throws — a
-   * publish failure must not affect the board transition.
+   * Publish the lifecycle event for a terminal transition:
+   *   done → feature.completed, blocked → feature.blocked (kinded),
+   *   escalated → feature.failed. Loads the feature fresh to echo its source
+   *   signal metadata and PR tracking fields. Never throws — a publish failure
+   *   must not affect the board transition.
    */
   async handleStatusChange(payload: StatusChangedPayload): Promise<void> {
     const { featureId, newStatus, oldStatus, projectPath } = payload ?? {};
@@ -86,8 +207,9 @@ export class FeatureLifecycleBusPublisher {
     }
 
     const isTerminal = TERMINAL_STATUSES.has(newStatus);
-    const isFailure = FAILURE_STATUSES.has(newStatus);
-    if (!isTerminal && !isFailure) {
+    const isBlocked = BLOCKED_STATUSES.has(newStatus);
+    const isEscalated = ESCALATED_STATUSES.has(newStatus);
+    if (!isTerminal && !isBlocked && !isEscalated) {
       return;
     }
 
@@ -99,9 +221,13 @@ export class FeatureLifecycleBusPublisher {
     }
 
     // Dotted, unprefixed topics — exactly what workstacean's consumers
-    // subscribe to (`feature.completed` / `feature.failed`). The earlier
-    // `protomaker.`-prefixed names never matched, so #482 stayed silent.
-    const topic = isTerminal ? 'feature.completed' : 'feature.failed';
+    // subscribe to. `blocked` is its own remediable signal; `escalated` stays
+    // `feature.failed` (no auto-remediation); `done` is `feature.completed`.
+    const topic = isTerminal
+      ? 'feature.completed'
+      : isBlocked
+        ? 'feature.blocked'
+        : 'feature.failed';
     const owner = process.env.GITHUB_REPO_OWNER;
     const name = process.env.GITHUB_REPO_NAME;
     const repo = owner && name ? `${owner}/${name}` : undefined;
@@ -111,10 +237,12 @@ export class FeatureLifecycleBusPublisher {
       feature?.sourceMeta && typeof feature.sourceMeta === 'object'
         ? feature.sourceMeta
         : { sourceChannel: feature?.sourceChannel, signalMetadata: feature?.signalMetadata };
+    const timestampKey = isTerminal ? 'completedAt' : isBlocked ? 'blockedAt' : 'failedAt';
     const data: Record<string, unknown> = {
       // projectSlug is REQUIRED by workstacean's feature-notifier (resolves the
       // dev channel); fall back so the event is never dropped for lacking it.
       projectSlug: feature?.projectSlug ?? process.env.WORKSTACEAN_PROJECT_SLUG ?? 'protomaker',
+      projectPath,
       featureId,
       featureTitle: feature?.title,
       prNumber: feature?.prNumber,
@@ -122,11 +250,23 @@ export class FeatureLifecycleBusPublisher {
       repo,
       previousStatus: oldStatus,
       sourceMeta,
-      [isTerminal ? 'completedAt' : 'failedAt']: new Date().toISOString(),
+      [timestampKey]: new Date().toISOString(),
     };
-    if (!isTerminal) {
+
+    if (isBlocked) {
+      // feature.blocked carries the human reason + a kind discriminator the
+      // workstacean router uses to pick ignore / HITL / dispatch-Roxy.
+      const reason = (feature?.statusChangeReason ?? payload?.reason ?? 'blocked').slice(0, 400);
+      data.reason = reason;
+      const kind = deriveBlockedKind(feature?.statusChangeReason ?? payload?.reason);
+      if (kind) {
+        data.kind = kind;
+      }
+    } else if (isEscalated) {
+      // feature.failed keeps the historical `error` field for existing consumers.
       data.error = (feature?.statusChangeReason ?? payload?.reason ?? 'failed').slice(0, 400);
     }
+
     try {
       const result = await this.publishFn({ event: topic, data });
       if (!result.ok) {

--- a/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
+++ b/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
@@ -123,7 +123,7 @@ describe('FeatureLifecycleBusPublisher', () => {
     expect(onSpy).not.toHaveBeenCalled();
   });
 
-  it('publishes feature.failed with error on transition to blocked', async () => {
+  it('publishes kinded feature.blocked (not feature.failed) on transition to blocked', async () => {
     const feature = {
       id: 'f2',
       title: 'Blocked feature',
@@ -143,12 +143,54 @@ describe('FeatureLifecycleBusPublisher', () => {
 
     expect(publishFn).toHaveBeenCalledTimes(1);
     const arg = publishFn.mock.calls[0][0];
-    expect(arg.event).toBe('feature.failed');
+    // Greenfield: blocked emits ONLY feature.blocked, never feature.failed.
+    expect(arg.event).toBe('feature.blocked');
     expect(arg.data.featureId).toBe('f2');
     expect(arg.data.prNumber).toBe(42);
-    expect(arg.data.error).toBe('CI checks failed after 3 retries');
-    expect(arg.data.failedAt).toBeDefined();
+    expect(arg.data.projectPath).toBe('/p');
+    // feature.blocked carries `reason` + `kind`, not the `error` field.
+    expect(arg.data.reason).toBe('CI checks failed after 3 retries');
+    expect(arg.data.error).toBeUndefined();
+    // "CI checks failed after 3 retries" → ci_failure (the dominant signal;
+    // "3 retries" is not a retries-exhausted phrasing). Router dispatches Roxy.
+    expect(arg.data.kind).toBe('ci_failure');
+    expect(arg.data.blockedAt).toBeDefined();
+    expect(arg.data.failedAt).toBeUndefined();
     expect(arg.data.previousStatus).toBe('in_progress');
+  });
+
+  it('derives the kind discriminator from the block reason', async () => {
+    const cases: Array<[string, string | undefined]> = [
+      ['Worktree has uncommitted changes — manual review needed', 'worktree_safety'],
+      ['Refusing to fall back to main working tree', 'worktree_safety'],
+      ['Cost budget exceeded for this feature', 'cost_exceeded'],
+      ['API rate limit reached (429)', 'rate_limit'],
+      ['Usage quota exhausted', 'quota'],
+      ['Max PR iterations exceeded (5)', 'retries_exhausted'],
+      ['Execution deadline exceeded — timed out', 'runtime_exceeded'],
+      ['Reviewer requested changes on the PR', 'changes_requested'],
+      ['Worktree has unresolved merge conflicts', 'merge_conflict'],
+      ['Fresh-eyes review BLOCK: blocked by automated review', 'ci_failure'],
+      ['Blocked by its upstream dependency', 'dependency_unsatisfied'],
+      ['Some entirely novel failure nobody mapped', undefined],
+    ];
+
+    for (const [reason, expectedKind] of cases) {
+      const publishFn = vi.fn().mockResolvedValue({ ok: true });
+      const { pub } = makePublisher({
+        feature: { id: 'fk', title: 'k', projectSlug: 'proj', statusChangeReason: reason },
+        publishFn,
+      });
+      await pub.handleStatusChange({
+        featureId: 'fk',
+        projectPath: '/p',
+        oldStatus: 'in_progress',
+        newStatus: 'blocked',
+      });
+      const arg = publishFn.mock.calls[0][0];
+      expect(arg.event).toBe('feature.blocked');
+      expect(arg.data.kind, `reason="${reason}"`).toBe(expectedKind);
+    }
   });
 
   it('publishes feature.failed on transition to escalated', async () => {
@@ -185,7 +227,7 @@ describe('FeatureLifecycleBusPublisher', () => {
     expect(arg.data.error).toBeUndefined();
   });
 
-  it('falls back to payload reason for the error when feature has none', async () => {
+  it('falls back to payload reason on feature.blocked when feature has none', async () => {
     const feature = { id: 'f5', title: 'No reason on feature', projectSlug: 'proj' };
     const { pub, publishFn } = makePublisher({ feature });
 
@@ -197,6 +239,25 @@ describe('FeatureLifecycleBusPublisher', () => {
       reason: 'from payload',
     });
 
-    expect(publishFn.mock.calls[0][0].data.error).toBe('from payload');
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.event).toBe('feature.blocked');
+    expect(arg.data.reason).toBe('from payload');
+  });
+
+  it('falls back to payload reason for the error on feature.failed (escalated)', async () => {
+    const feature = { id: 'f6', title: 'No reason on feature', projectSlug: 'proj' };
+    const { pub, publishFn } = makePublisher({ feature });
+
+    await pub.handleStatusChange({
+      featureId: 'f6',
+      projectPath: '/p',
+      oldStatus: 'review',
+      newStatus: 'escalated',
+      reason: 'from payload',
+    });
+
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.event).toBe('feature.failed');
+    expect(arg.data.error).toBe('from payload');
   });
 });


### PR DESCRIPTION
Closes #4067. Coordinated merge with protoLabsAI/protoWorkstacean#779 (this unblocks that flag-day hold).

## What

Splits `blocked` out of the generic `feature.failed` lifecycle event and emits a dedicated **`feature.blocked`** topic to the workstacean `/publish` ingress, carrying a **`kind`** failure discriminator so workstacean's `FeatureRemediationPlugin` can route ignore / HITL / dispatch-Roxy per feature.

Terminal-transition mapping in `FeatureLifecycleBusPublisher`:

| transition | topic | new |
|---|---|---|
| `done` | `feature.completed` | unchanged |
| `blocked` | `feature.blocked` | **carries `kind` + `reason`** |
| `escalated` | `feature.failed` | unchanged (already escalated) |

Greenfield: a `blocked` transition emits **only** `feature.blocked`, never also `feature.failed`.

## How `kind` is derived

`deriveBlockedKind(reason)` keyword-matches the human block reason (`statusChangeReason`, falling back to the event payload reason) into the workstacean vocabulary, most-specific first:

`dependency_unsatisfied` · `worktree_safety` · `cost_exceeded` · `rate_limit` · `quota` · `retries_exhausted` · `runtime_exceeded` · `changes_requested` · `merge_conflict` · `ci_failure`

`dependency_unsatisfied` is matched **narrowly** (feature-DAG / staleDeps wording only) so npm/missing-module errors — which Roxy can fix — aren't swallowed by the router's "ignore" path. An unrecognized reason omits `kind`; the router treats missing as remediable (dispatches Roxy), so this lands incrementally and the mapping can be tightened later.

The issue suggested optionally threading a structured `failureCategory` onto the feature record for higher fidelity. That's a larger change touching every block site; deferred as a follow-up (filed) since unknown/missing `kind` is safe and the keyword map covers the common cases.

## Acceptance (#4067)

- [x] `blocked` transition publishes `feature.blocked` (not `feature.failed`) with `kind`
- [x] `kind` populated for the common cases (CI red, conflict, changes-requested, retries-exhausted, cost/runtime/quota, dependency-unsatisfied)
- [x] `escalated`/`done` unchanged
- [ ] Coordinated merge with protoLabsAI/protoWorkstacean#779

## Testing

`npm run test:server -- tests/unit/services/feature-lifecycle-bus-publisher.test.ts` — 14 passing (added a per-kind derivation matrix + split blocked/escalated payload assertions). `npm run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined feature lifecycle event publishing to correctly distinguish between completed, blocked, and escalated terminal states, ensuring downstream systems receive more accurate routing information.
  * Enhanced blocked state handling with improved failure reason classification for better system routing.

* **Documentation**
  * Updated configuration documentation to clarify terminal event mappings and state transition behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->