### PR TITLE
feat(lifecycle): prefer structured failureClassification over reason-text for feature.blocked kind (#4069)

### DIFF
--- a/apps/server/src/services/feature-lifecycle-bus-publisher.ts
+++ b/apps/server/src/services/feature-lifecycle-bus-publisher.ts
@@ -155,6 +155,39 @@ export function deriveBlockedKind(reason: string | undefined): BlockedKind | und
   return undefined;
 }
 
+/**
+ * Map protoMaker's structured `FailureClassifierService` category (persisted on
+ * `feature.failureClassification.category` by the lead-engineer ESCALATE path)
+ * to the workstacean routing `kind`. Preferred over `deriveBlockedKind`'s prose
+ * keyword match when a classification is present — it's a deterministic enum,
+ * not a regex on free text (#4069). Returns `undefined` for categories with no
+ * precise routing kind so the caller falls back to the reason text, then to the
+ * router's remediable default.
+ *
+ * NOTE: the classifier's `dependency` (a missing npm/module dep that Roxy CAN
+ * fix) is deliberately NOT mapped to `dependency_unsatisfied` (feature-DAG
+ * upstream gating that the router IGNORES) — mapping it would silently swallow a
+ * fixable failure. It falls through to the remediable default instead.
+ */
+export function failureCategoryToKind(category: string | undefined): BlockedKind | undefined {
+  switch (category) {
+    case 'rate_limit':
+      return 'rate_limit';
+    case 'quota':
+      return 'quota';
+    case 'merge_conflict':
+      return 'merge_conflict';
+    case 'test_failure':
+      return 'ci_failure';
+    case 'retry_exhausted':
+      return 'retries_exhausted';
+    default:
+      // transient / validation / tool_error / dependency / authentication /
+      // unknown → no precise kind; let the reason-text fallback decide.
+      return undefined;
+  }
+}
+
 /** Subset of the `feature:status-changed` payload this publisher needs. */
 interface StatusChangedPayload {
   featureId: string;
@@ -258,7 +291,13 @@ export class FeatureLifecycleBusPublisher {
       // workstacean router uses to pick ignore / HITL / dispatch-Roxy.
       const reason = (feature?.statusChangeReason ?? payload?.reason ?? 'blocked').slice(0, 400);
       data.reason = reason;
-      const kind = deriveBlockedKind(feature?.statusChangeReason ?? payload?.reason);
+      // Prefer the structured classification persisted by the ESCALATE path; it
+      // is a deterministic enum rather than a regex over prose. Fall back to the
+      // reason-text keyword match (#4069), then to the router's remediable
+      // default when neither yields a kind.
+      const kind =
+        failureCategoryToKind(feature?.failureClassification?.category) ??
+        deriveBlockedKind(feature?.statusChangeReason ?? payload?.reason);
       if (kind) {
         data.kind = kind;
       }

--- a/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
+++ b/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { FeatureLifecycleBusPublisher } from '@/services/feature-lifecycle-bus-publisher.js';
+import {
+  FeatureLifecycleBusPublisher,
+  failureCategoryToKind,
+} from '@/services/feature-lifecycle-bus-publisher.js';
 
 function makePublisher(opts?: { feature?: unknown; publishFn?: ReturnType<typeof vi.fn> }) {
   const publishFn = opts?.publishFn ?? vi.fn().mockResolvedValue({ ok: true });
@@ -191,6 +194,54 @@ describe('FeatureLifecycleBusPublisher', () => {
       expect(arg.event).toBe('feature.blocked');
       expect(arg.data.kind, `reason="${reason}"`).toBe(expectedKind);
     }
+  });
+
+  it('maps structured FailureCategory → routing kind (#4069)', () => {
+    expect(failureCategoryToKind('rate_limit')).toBe('rate_limit');
+    expect(failureCategoryToKind('quota')).toBe('quota');
+    expect(failureCategoryToKind('merge_conflict')).toBe('merge_conflict');
+    expect(failureCategoryToKind('test_failure')).toBe('ci_failure');
+    expect(failureCategoryToKind('retry_exhausted')).toBe('retries_exhausted');
+    // No precise routing kind → undefined (reason-text fallback / Roxy default).
+    expect(failureCategoryToKind('transient')).toBeUndefined();
+    expect(failureCategoryToKind('validation')).toBeUndefined();
+    expect(failureCategoryToKind('tool_error')).toBeUndefined();
+    expect(failureCategoryToKind('authentication')).toBeUndefined();
+    expect(failureCategoryToKind('unknown')).toBeUndefined();
+    expect(failureCategoryToKind(undefined)).toBeUndefined();
+    // CRITICAL: the classifier's `dependency` (fixable missing module) must NOT
+    // become `dependency_unsatisfied` (the IGNORE kind) or Roxy never sees it.
+    expect(failureCategoryToKind('dependency')).toBeUndefined();
+  });
+
+  it('prefers the persisted failureClassification over the reason-text match (#4069)', async () => {
+    // Reason text alone would keyword-match to ci_failure, but the structured
+    // classifier said rate_limit — the structured signal wins.
+    const feature = {
+      id: 'fc1',
+      title: 'Classified',
+      projectSlug: 'proj',
+      statusChangeReason: 'tests failed in CI',
+      failureClassification: { category: 'rate_limit', confidence: 0.9, recoveryStrategy: { type: 'retry' }, retryable: true, timestamp: 't' },
+    };
+    const { pub, publishFn } = makePublisher({ feature });
+    await pub.handleStatusChange({ featureId: 'fc1', projectPath: '/p', oldStatus: 'in_progress', newStatus: 'blocked' });
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.data.kind).toBe('rate_limit');
+  });
+
+  it('falls back to the reason-text match when the classification has no precise kind (#4069)', async () => {
+    // category 'tool_error' → undefined, so the reason text decides (merge_conflict).
+    const feature = {
+      id: 'fc2',
+      title: 'Classified-but-vague',
+      projectSlug: 'proj',
+      statusChangeReason: 'unresolved merge conflict on rebase',
+      failureClassification: { category: 'tool_error', confidence: 0.5, recoveryStrategy: { type: 'retry' }, retryable: true, timestamp: 't' },
+    };
+    const { pub, publishFn } = makePublisher({ feature });
+    await pub.handleStatusChange({ featureId: 'fc2', projectPath: '/p', oldStatus: 'in_progress', newStatus: 'blocked' });
+    expect(publishFn.mock.calls[0][0].data.kind).toBe('merge_conflict');
   });
 
   it('publishes feature.failed on transition to escalated', async () => {

--- a/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
+++ b/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
@@ -222,10 +222,21 @@ describe('FeatureLifecycleBusPublisher', () => {
       title: 'Classified',
       projectSlug: 'proj',
       statusChangeReason: 'tests failed in CI',
-      failureClassification: { category: 'rate_limit', confidence: 0.9, recoveryStrategy: { type: 'retry' }, retryable: true, timestamp: 't' },
+      failureClassification: {
+        category: 'rate_limit',
+        confidence: 0.9,
+        recoveryStrategy: { type: 'retry' },
+        retryable: true,
+        timestamp: 't',
+      },
     };
     const { pub, publishFn } = makePublisher({ feature });
-    await pub.handleStatusChange({ featureId: 'fc1', projectPath: '/p', oldStatus: 'in_progress', newStatus: 'blocked' });
+    await pub.handleStatusChange({
+      featureId: 'fc1',
+      projectPath: '/p',
+      oldStatus: 'in_progress',
+      newStatus: 'blocked',
+    });
     const arg = publishFn.mock.calls[0][0];
     expect(arg.data.kind).toBe('rate_limit');
   });
@@ -237,10 +248,21 @@ describe('FeatureLifecycleBusPublisher', () => {
       title: 'Classified-but-vague',
       projectSlug: 'proj',
       statusChangeReason: 'unresolved merge conflict on rebase',
-      failureClassification: { category: 'tool_error', confidence: 0.5, recoveryStrategy: { type: 'retry' }, retryable: true, timestamp: 't' },
+      failureClassification: {
+        category: 'tool_error',
+        confidence: 0.5,
+        recoveryStrategy: { type: 'retry' },
+        retryable: true,
+        timestamp: 't',
+      },
     };
     const { pub, publishFn } = makePublisher({ feature });
-    await pub.handleStatusChange({ featureId: 'fc2', projectPath: '/p', oldStatus: 'in_progress', newStatus: 'blocked' });
+    await pub.handleStatusChange({
+      featureId: 'fc2',
+      projectPath: '/p',
+      oldStatus: 'in_progress',
+      newStatus: 'blocked',
+    });
     expect(publishFn.mock.calls[0][0].data.kind).toBe('merge_conflict');
   });
 


### PR DESCRIPTION
Closes #4069. Follow-up to #4068 (kinded `feature.blocked`).

## Why

#4068 derived the workstacean routing `kind` by regex-matching the prose `statusChangeReason` — a keyword fallback, by design. But the lead-engineer **ESCALATE path already persists a structured classification** on the feature record (`feature.failureClassification.category`, produced by `FailureClassifierService`). We were ignoring it and re-guessing from free text. This prefers the deterministic enum.

## What

- **`failureCategoryToKind(category)`** maps the structured `FailureCategory` → `BlockedKind`:
  | FailureCategory | kind |
  |---|---|
  | `rate_limit` | `rate_limit` |
  | `quota` | `quota` |
  | `merge_conflict` | `merge_conflict` |
  | `test_failure` | `ci_failure` |
  | `retry_exhausted` | `retries_exhausted` |
  | `transient` / `validation` / `tool_error` / `authentication` / `unknown` | _undefined → reason fallback_ |

- **`handleStatusChange`**: `failureCategoryToKind(feature.failureClassification?.category) ?? deriveBlockedKind(reason)` — structured first, prose keyword fallback, then the router's remediable default. Strictly better than keyword-only; no new plumbing (the classification is already on the record).

## ⚠️ Correctness note

The classifier's `dependency` category (a **fixable** missing npm/module dep) is deliberately **not** mapped to `dependency_unsatisfied` (feature-DAG upstream gating, which the workstacean router **IGNORES**). Mapping it would route a Roxy-fixable failure to the ignore path and silently swallow it. It falls through to the remediable default instead. Covered by a test.

## Tests

`failureCategoryToKind` matrix (including the `dependency` guard) + integration: structured category wins over a conflicting reason; a vague category (`tool_error`) falls back to the reason-text match (`merge_conflict`). **17 publisher tests green; `@protolabsai/server` typecheck clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)