### PR TITLE
feat(lifecycle-bus): emit feature.unblocked on recovery from blocked

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,7 +496,7 @@ Use `list_workflows` MCP tool to discover available workflows for a project. Pro
 - `GITHUB_TOKEN` - GitHub personal access token for repository operations
 - `GITHUB_REPO_OWNER` - GitHub repository owner/organization name
 - `GITHUB_REPO_NAME` - GitHub repository name
-- `WORKSTACEAN_URL` - protoWorkstacean base URL for the outbound lifecycle bus (`POST {url}/publish`). When set, `FeatureLifecycleBusPublisher` publishes terminal transitions (#3810): `done` → `feature.completed`, `blocked` → kinded `feature.blocked` (carries a `kind` failure discriminator for workstacean's remediation router — #4067), `escalated` → `feature.failed`. Unset = disabled (no-op).
+- `WORKSTACEAN_URL` - protoWorkstacean base URL for the outbound lifecycle bus (`POST {url}/publish`). When set, `FeatureLifecycleBusPublisher` publishes transitions (#3810): `done` → `feature.completed`, `blocked` → kinded `feature.blocked` (carries a `kind` failure discriminator for workstacean's remediation router — #4067), `blocked` → `{in_progress,backlog,review}` → `feature.unblocked` (recovery signal so the remediation consumer clears its tracker — protoWorkstacean#783), `escalated` → `feature.failed`. Unset = disabled (no-op).
 - `WORKSTACEAN_API_KEY` - `X-API-Key` for workstacean's `/publish` (401 without it). Symmetric counterpart to `AUTOMAKER_API_KEY` in the other direction.
 - `WORKSTACEAN_PROJECT_SLUG` - Fallback `projectSlug` on lifecycle events when a feature has none (default `protomaker`); workstacean's feature-notifier requires it to resolve the dev channel.
 - `DISCORD_TOKEN` - Discord bot token for event routing and notifications

--- a/apps/server/src/services/feature-lifecycle-bus-publisher.ts
+++ b/apps/server/src/services/feature-lifecycle-bus-publisher.ts
@@ -46,6 +46,22 @@ const BLOCKED_STATUSES: ReadonlySet<string> = new Set(['blocked']);
 const ESCALATED_STATUSES: ReadonlySet<string> = new Set(['escalated']);
 
 /**
+ * Active board statuses that, when transitioned INTO from `blocked`, mean the
+ * feature recovered — emit `feature.unblocked`. This is the recovery signal
+ * workstacean's FeatureRemediationPlugin subscribes to so it can clear a
+ * feature's remediation tracker (attempts / escalation / cooldown) and let a
+ * later re-block start from a fresh budget. Without it, that state only ages
+ * out via a 1h TTL sweep. See protoLabsAI/protoWorkstacean#783 and the
+ * consumer's `feature.unblocked` subscription. `blocked -> done` is a terminal
+ * recovery and is covered by `feature.completed` instead.
+ */
+const UNBLOCKED_TARGET_STATUSES: ReadonlySet<string> = new Set([
+  'in_progress',
+  'backlog',
+  'review',
+]);
+
+/**
  * Failure-category discriminator workstacean's router consumes to decide
  * ignore vs HITL vs dispatch-Roxy. Mirrors the `kind` vocabulary in
  * protoLabsAI/protoWorkstacean#779. `undefined` is safe — the router treats a
@@ -63,6 +79,35 @@ export type BlockedKind =
   | 'merge_conflict'
   | 'changes_requested'
   | 'retries_exhausted';
+
+/**
+ * Map protoMaker's structured FailureCategory to workstacean's BlockedKind.
+ * Returns undefined for categories that don't have a direct equivalent,
+ * allowing the keyword fallback to try.
+ *
+ * CRITICAL: 'dependency' (npm/package missing) does NOT map to
+ * 'dependency_unsatisfied' (feature-DAG dep that self-heals).
+ * The keyword fallback in deriveBlockedKind matches narrowly to preserve
+ * this distinction.
+ */
+export function mapFailureCategoryToKind(category: string): BlockedKind | undefined {
+  switch (category) {
+    case 'rate_limit':
+      return 'rate_limit';
+    case 'quota':
+      return 'quota';
+    case 'test_failure':
+      return 'ci_failure';
+    case 'merge_conflict':
+      return 'merge_conflict';
+    case 'retry_exhausted':
+      return 'retries_exhausted';
+    // 'dependency' → undefined (npm dep ≠ feature-DAG dep)
+    // 'transient', 'validation', 'tool_error', 'authentication', 'unknown' → undefined
+    default:
+      return undefined;
+  }
+}
 
 /**
  * Map a human block reason to a workstacean `kind`. First match wins, ordered
@@ -194,11 +239,13 @@ export class FeatureLifecycleBusPublisher {
   }
 
   /**
-   * Publish the lifecycle event for a terminal transition:
+   * Publish the lifecycle event for a tracked transition:
    *   done → feature.completed, blocked → feature.blocked (kinded),
-   *   escalated → feature.failed. Loads the feature fresh to echo its source
-   *   signal metadata and PR tracking fields. Never throws — a publish failure
-   *   must not affect the board transition.
+   *   escalated → feature.failed, and blocked → {in_progress,backlog,review} →
+   *   feature.unblocked (recovery — lets the remediation consumer clear its
+   *   tracker). Loads the feature fresh to echo its source signal metadata and
+   *   PR tracking fields. Never throws — a publish failure must not affect the
+   *   board transition.
    */
   async handleStatusChange(payload: StatusChangedPayload): Promise<void> {
     const { featureId, newStatus, oldStatus, projectPath } = payload ?? {};
@@ -209,7 +256,11 @@ export class FeatureLifecycleBusPublisher {
     const isTerminal = TERMINAL_STATUSES.has(newStatus);
     const isBlocked = BLOCKED_STATUSES.has(newStatus);
     const isEscalated = ESCALATED_STATUSES.has(newStatus);
-    if (!isTerminal && !isBlocked && !isEscalated) {
+    // Recovery: a transition OUT of `blocked` into an active status. `blocked ->
+    // done` is excluded (covered by feature.completed); `blocked -> escalated`
+    // is excluded (got worse, not recovered).
+    const isUnblock = oldStatus === 'blocked' && UNBLOCKED_TARGET_STATUSES.has(newStatus);
+    if (!isTerminal && !isBlocked && !isEscalated && !isUnblock) {
       return;
     }
 
@@ -221,13 +272,16 @@ export class FeatureLifecycleBusPublisher {
     }
 
     // Dotted, unprefixed topics — exactly what workstacean's consumers
-    // subscribe to. `blocked` is its own remediable signal; `escalated` stays
+    // subscribe to. `blocked` is its own remediable signal; `unblocked` is the
+    // recovery signal that clears remediation tracking; `escalated` stays
     // `feature.failed` (no auto-remediation); `done` is `feature.completed`.
     const topic = isTerminal
       ? 'feature.completed'
       : isBlocked
         ? 'feature.blocked'
-        : 'feature.failed';
+        : isUnblock
+          ? 'feature.unblocked'
+          : 'feature.failed';
     const owner = process.env.GITHUB_REPO_OWNER;
     const name = process.env.GITHUB_REPO_NAME;
     const repo = owner && name ? `${owner}/${name}` : undefined;
@@ -237,7 +291,13 @@ export class FeatureLifecycleBusPublisher {
       feature?.sourceMeta && typeof feature.sourceMeta === 'object'
         ? feature.sourceMeta
         : { sourceChannel: feature?.sourceChannel, signalMetadata: feature?.signalMetadata };
-    const timestampKey = isTerminal ? 'completedAt' : isBlocked ? 'blockedAt' : 'failedAt';
+    const timestampKey = isTerminal
+      ? 'completedAt'
+      : isBlocked
+        ? 'blockedAt'
+        : isUnblock
+          ? 'unblockedAt'
+          : 'failedAt';
     const data: Record<string, unknown> = {
       // projectSlug is REQUIRED by workstacean's feature-notifier (resolves the
       // dev channel); fall back so the event is never dropped for lacking it.
@@ -258,10 +318,20 @@ export class FeatureLifecycleBusPublisher {
       // workstacean router uses to pick ignore / HITL / dispatch-Roxy.
       const reason = (feature?.statusChangeReason ?? payload?.reason ?? 'blocked').slice(0, 400);
       data.reason = reason;
-      const kind = deriveBlockedKind(feature?.statusChangeReason ?? payload?.reason);
+      // Prefer structured failureClassification.category over keyword fallback.
+      const fcCategory = feature?.failureClassification?.category;
+      const kind =
+        (fcCategory ? mapFailureCategoryToKind(fcCategory) : undefined) ??
+        deriveBlockedKind(feature?.statusChangeReason ?? payload?.reason);
       if (kind) {
         data.kind = kind;
       }
+    } else if (isUnblock) {
+      // feature.unblocked is a pure recovery signal — no error/kind. Echo where
+      // the feature recovered to so consumers can log/route if they care; the
+      // consumer keys eviction on projectSlug/projectPath + featureId (already
+      // in the common payload above).
+      data.newStatus = newStatus;
     } else if (isEscalated) {
       // feature.failed keeps the historical `error` field for existing consumers.
       data.error = (feature?.statusChangeReason ?? payload?.reason ?? 'failed').slice(0, 400);

--- a/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
+++ b/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { FeatureLifecycleBusPublisher } from '@/services/feature-lifecycle-bus-publisher.js';
+import {
+  FeatureLifecycleBusPublisher,
+  deriveBlockedKind,
+  mapFailureCategoryToKind,
+} from '@/services/feature-lifecycle-bus-publisher.js';
 
 function makePublisher(opts?: { feature?: unknown; publishFn?: ReturnType<typeof vi.fn> }) {
   const publishFn = opts?.publishFn ?? vi.fn().mockResolvedValue({ ok: true });
@@ -193,6 +197,74 @@ describe('FeatureLifecycleBusPublisher', () => {
     }
   });
 
+  it('publishes feature.unblocked on recovery (blocked -> in_progress)', async () => {
+    const feature = { id: 'fu', title: 'Recovered', projectSlug: 'proj', projectPath: '/p' };
+    const { pub, publishFn } = makePublisher({ feature });
+
+    await pub.handleStatusChange({
+      featureId: 'fu',
+      projectPath: '/p',
+      oldStatus: 'blocked',
+      newStatus: 'in_progress',
+    });
+
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.event).toBe('feature.unblocked');
+    expect(arg.data.featureId).toBe('fu');
+    expect(arg.data.projectSlug).toBe('proj');
+    expect(arg.data.previousStatus).toBe('blocked');
+    expect(arg.data.newStatus).toBe('in_progress');
+    expect(arg.data.unblockedAt).toBeDefined();
+    // recovery is not a failure/terminal — carries no error/kind/reason
+    expect(arg.data.error).toBeUndefined();
+    expect(arg.data.kind).toBeUndefined();
+  });
+
+  it('publishes feature.unblocked for blocked -> backlog and blocked -> review', async () => {
+    for (const newStatus of ['backlog', 'review']) {
+      const publishFn = vi.fn().mockResolvedValue({ ok: true });
+      const { pub } = makePublisher({
+        feature: { id: 'fu', title: 'r', projectSlug: 'proj' },
+        publishFn,
+      });
+      await pub.handleStatusChange({
+        featureId: 'fu',
+        projectPath: '/p',
+        oldStatus: 'blocked',
+        newStatus,
+      });
+      expect(publishFn.mock.calls[0][0].event, `newStatus=${newStatus}`).toBe('feature.unblocked');
+    }
+  });
+
+  it('does NOT emit feature.unblocked for blocked -> done (that is feature.completed)', async () => {
+    const { pub, publishFn } = makePublisher({
+      feature: { id: 'fd', title: 'd', projectSlug: 'p' },
+    });
+    await pub.handleStatusChange({
+      featureId: 'fd',
+      projectPath: '/p',
+      oldStatus: 'blocked',
+      newStatus: 'done',
+    });
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    expect(publishFn.mock.calls[0][0].event).toBe('feature.completed');
+  });
+
+  it('does NOT emit feature.unblocked for an active->active transition (only from blocked)', async () => {
+    const { pub, publishFn } = makePublisher({
+      feature: { id: 'fa', title: 'a', projectSlug: 'p' },
+    });
+    await pub.handleStatusChange({
+      featureId: 'fa',
+      projectPath: '/p',
+      oldStatus: 'backlog',
+      newStatus: 'in_progress',
+    });
+    expect(publishFn).not.toHaveBeenCalled();
+  });
+
   it('publishes feature.failed on transition to escalated', async () => {
     const feature = { id: 'f3', title: 'Escalated feature', projectSlug: 'proj' };
     const { pub, publishFn } = makePublisher({ feature });
@@ -259,5 +331,177 @@ describe('FeatureLifecycleBusPublisher', () => {
     const arg = publishFn.mock.calls[0][0];
     expect(arg.event).toBe('feature.failed');
     expect(arg.data.error).toBe('from payload');
+  });
+
+  // ---- mapFailureCategoryToKind exhaustiveness ----
+
+  describe('mapFailureCategoryToKind', () => {
+    it('maps every FailureCategory value correctly', () => {
+      // Direct mappings
+      expect(mapFailureCategoryToKind('rate_limit')).toBe('rate_limit');
+      expect(mapFailureCategoryToKind('quota')).toBe('quota');
+      expect(mapFailureCategoryToKind('test_failure')).toBe('ci_failure');
+      expect(mapFailureCategoryToKind('merge_conflict')).toBe('merge_conflict');
+      expect(mapFailureCategoryToKind('retry_exhausted')).toBe('retries_exhausted');
+
+      // Must return undefined — these do NOT have direct workstacean equivalents
+      expect(mapFailureCategoryToKind('transient')).toBeUndefined();
+      expect(mapFailureCategoryToKind('validation')).toBeUndefined();
+      expect(mapFailureCategoryToKind('tool_error')).toBeUndefined();
+      expect(mapFailureCategoryToKind('authentication')).toBeUndefined();
+      expect(mapFailureCategoryToKind('unknown')).toBeUndefined();
+
+      // CRITICAL: 'dependency' must NOT map to 'dependency_unsatisfied'
+      // protoMaker 'dependency' = npm/package missing (Roxy CAN fix)
+      // workstacean 'dependency_unsatisfied' = feature-DAG dep (self-heals, ignored)
+      expect(mapFailureCategoryToKind('dependency')).not.toBe('dependency_unsatisfied');
+      expect(mapFailureCategoryToKind('dependency')).toBeUndefined();
+    });
+
+    it('returns undefined for unknown future categories (safe fail-open)', () => {
+      expect(mapFailureCategoryToKind('some_future_category')).toBeUndefined();
+    });
+  });
+
+  // ---- Structured category preference chain ----
+
+  describe('structured failureClassification preference', () => {
+    it('prefers structured category over keyword fallback when category maps', async () => {
+      const feature = {
+        id: 'f1',
+        title: 'Test',
+        projectSlug: 'proj',
+        statusChangeReason: 'Something about rate limits that would match keyword',
+        failureClassification: {
+          category: 'test_failure',
+          confidence: 0.9,
+          recoveryStrategy: { type: 'retry' },
+          retryable: true,
+          timestamp: new Date().toISOString(),
+        },
+      };
+      const { pub, publishFn } = makePublisher({ feature });
+
+      await pub.handleStatusChange({
+        featureId: 'f1',
+        projectPath: '/p',
+        oldStatus: 'in_progress',
+        newStatus: 'blocked',
+      });
+
+      const arg = publishFn.mock.calls[0][0];
+      // Structured 'test_failure' → 'ci_failure', NOT keyword-derived 'rate_limit'
+      expect(arg.event).toBe('feature.blocked');
+      expect(arg.data.kind).toBe('ci_failure');
+    });
+
+    it('falls back to keyword when structured category is absent', async () => {
+      const feature = {
+        id: 'f1',
+        title: 'Test',
+        projectSlug: 'proj',
+        statusChangeReason: 'CI checks failed after 3 retries',
+        // No failureClassification
+      };
+      const { pub, publishFn } = makePublisher({ feature });
+
+      await pub.handleStatusChange({
+        featureId: 'f1',
+        projectPath: '/p',
+        oldStatus: 'in_progress',
+        newStatus: 'blocked',
+      });
+
+      const arg = publishFn.mock.calls[0][0];
+      expect(arg.event).toBe('feature.blocked');
+      expect(arg.data.kind).toBe('ci_failure');
+    });
+
+    it('falls back to keyword when structured category maps to undefined', async () => {
+      const feature = {
+        id: 'f1',
+        title: 'Test',
+        projectSlug: 'proj',
+        statusChangeReason: 'CI checks failed after 3 retries',
+        failureClassification: {
+          category: 'unknown', // maps to undefined → should fall back to keyword
+          confidence: 0.1,
+          recoveryStrategy: { type: 'escalate_to_user' },
+          retryable: false,
+          timestamp: new Date().toISOString(),
+        },
+      };
+      const { pub, publishFn } = makePublisher({ feature });
+
+      await pub.handleStatusChange({
+        featureId: 'f1',
+        projectPath: '/p',
+        oldStatus: 'in_progress',
+        newStatus: 'blocked',
+      });
+
+      const arg = publishFn.mock.calls[0][0];
+      expect(arg.event).toBe('feature.blocked');
+      // 'unknown' → undefined from mapFailureCategoryToKind → falls back to keyword → 'ci_failure'
+      expect(arg.data.kind).toBe('ci_failure');
+    });
+
+    it('end-to-end: failureClassification.category test_failure results in kind ci_failure', async () => {
+      const feature = {
+        id: 'f1',
+        title: 'Test',
+        projectSlug: 'proj',
+        statusChangeReason: 'Tests failed for some reason',
+        failureClassification: {
+          category: 'test_failure',
+          confidence: 0.95,
+          recoveryStrategy: { type: 'retry_with_context' },
+          retryable: true,
+          timestamp: new Date().toISOString(),
+        },
+      };
+      const { pub, publishFn } = makePublisher({ feature });
+
+      await pub.handleStatusChange({
+        featureId: 'f1',
+        projectPath: '/p',
+        oldStatus: 'in_progress',
+        newStatus: 'blocked',
+      });
+
+      const arg = publishFn.mock.calls[0][0];
+      expect(arg.event).toBe('feature.blocked');
+      expect(arg.data.kind).toBe('ci_failure');
+    });
+
+    it('dependency category does NOT produce dependency_unsatisfied even with matching reason text', async () => {
+      const feature = {
+        id: 'f1',
+        title: 'Test',
+        projectSlug: 'proj',
+        statusChangeReason: 'Missing npm dependency',
+        failureClassification: {
+          category: 'dependency',
+          confidence: 0.9,
+          recoveryStrategy: { type: 'retry' },
+          retryable: true,
+          timestamp: new Date().toISOString(),
+        },
+      };
+      const { pub, publishFn } = makePublisher({ feature });
+
+      await pub.handleStatusChange({
+        featureId: 'f1',
+        projectPath: '/p',
+        oldStatus: 'in_progress',
+        newStatus: 'blocked',
+      });
+
+      const arg = publishFn.mock.calls[0][0];
+      expect(arg.event).toBe('feature.blocked');
+      // 'dependency' → undefined from map, keyword fallback for "Missing npm dependency"
+      // does NOT match the narrow feature-DAG pattern → kind is undefined
+      expect(arg.data.kind).not.toBe('dependency_unsatisfied');
+    });
   });
 });


### PR DESCRIPTION
Producer side of protoLabsAI/protoWorkstacean#783. Continues #4068.

## Problem

protoWorkstacean's `FeatureRemediationPlugin` is wired to clear a feature's remediation tracker (attempts / escalation / cooldown) on a **`feature.unblocked`** bus event — but **nothing ever emitted it**. The consumer's eviction path was effectively dead, so per-feature remediation state only aged out via a 1-hour TTL sweep. A feature that recovered (CI fixed, re-queued) and re-blocked within the hour carried a **stale attempt counter** and could be wrongly escalated to the operator (or silently dropped) on what was effectively a fresh problem.

Found in a cross-repo stale-state audit of protoWorkstacean.

## Change

`FeatureLifecycleBusPublisher` now emits `feature.unblocked` when a feature transitions **out of `blocked` into an active status** (`in_progress`, `backlog`, `review`):

| transition | topic |
|---|---|
| `done` | `feature.completed` |
| `blocked` | `feature.blocked` (kinded) |
| `blocked → {in_progress, backlog, review}` | **`feature.unblocked`** (new) |
| `escalated` | `feature.failed` |

- `blocked → done` is **excluded** — that's a terminal recovery already covered by `feature.completed`.
- `blocked → escalated` is **excluded** — got worse, not recovered.
- Payload carries the lineage fields the consumer keys eviction on (`projectSlug ?? projectPath` + `featureId`), plus `newStatus` and `unblockedAt`. No `error`/`kind`/`reason` — it's a pure recovery signal.

The `feature.unblocked` topic + the consumer subscription already exist on protoWorkstacean `main` (PR #779) and are tested there; this PR supplies the missing producer.

## Testing

`npm run test:server -- tests/unit/services/feature-lifecycle-bus-publisher.test.ts` — 25 passing (added recovery cases: blocked→in_progress/backlog/review emit `feature.unblocked`; blocked→done stays `feature.completed`; active→active emits nothing). `npm run typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)