### PR TITLE
feat(lifecycle-bus): echo githubIssueNumber on feature.completed (close-the-loop prereq)

### DIFF
--- a/apps/server/src/services/feature-lifecycle-bus-publisher.ts
+++ b/apps/server/src/services/feature-lifecycle-bus-publisher.ts
@@ -308,6 +308,10 @@ export class FeatureLifecycleBusPublisher {
       prNumber: feature?.prNumber,
       branchName: feature?.branchName,
       repo,
+      // Originating GitHub issue (captured at intake), echoed so the
+      // workstacean close-the-loop can close it when the feature ships —
+      // otherwise issues created on intake never get closed on resolution.
+      githubIssueNumber: feature?.githubIssueNumber,
       previousStatus: oldStatus,
       sourceMeta,
       [timestampKey]: new Date().toISOString(),

--- a/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
+++ b/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
@@ -281,6 +281,26 @@ describe('FeatureLifecycleBusPublisher', () => {
     expect(publishFn.mock.calls[0][0].data.featureId).toBe('f3');
   });
 
+  it('echoes githubIssueNumber on completed so the close-the-loop can close it', async () => {
+    const feature = {
+      id: 'f7',
+      title: 'Shipped from an issue',
+      projectSlug: 'proj',
+      prNumber: 12,
+      githubIssueNumber: 345,
+    };
+    const { pub, publishFn } = makePublisher({ feature });
+    await pub.handleStatusChange({
+      featureId: 'f7',
+      projectPath: '/p',
+      oldStatus: 'review',
+      newStatus: 'done',
+    });
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.event).toBe('feature.completed');
+    expect(arg.data.githubIssueNumber).toBe(345);
+  });
+
   it('includes prNumber in completed payload (no status/reason fields)', async () => {
     const feature = { id: 'f4', title: 'Completed with PR', projectSlug: 'proj', prNumber: 99 };
     const { pub, publishFn } = makePublisher({ feature });


### PR DESCRIPTION
## Why

protoMaker captures the originating GitHub issue number at intake (`feature.githubIssueNumber`, `signal-intake-service.ts`) but **drops it** when publishing `feature.completed`. So a GitHub issue filed to spawn a feature is never closed when that feature ships — the "issue created on an event, never cleared on resolve" pile-up.

## What

Echo `githubIssueNumber` into the `feature.completed` payload, alongside the existing `repo` + `prNumber` lineage. Additive — consumers that don't use it are unaffected.

## Pairs with

The workstacean-side close-the-loop (separate PR): a `feature.completed` consumer + a `close_issue` action that closes the originating issue with a "shipped in PR #N" comment. This is the GitHub analog of the Linear close-the-loop, and the prerequisite for it.

## Tests

`feature.completed` echoes `githubIssueNumber` (345) when set on the feature. 26 publisher tests green; `@protolabsai/server` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)