### PR TITLE
fix(workflow): keep code features on delivery + promote-to-delivery path (#4073)

### DIFF
--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -1141,6 +1141,22 @@ export class FeatureLoader implements FeatureStore {
       }
     }
 
+    // Promote-to-delivery (#4073): when a feature is moved off read-only execution, the
+    // stale all-false gitWorkflow override (and any read-only workflow pin) must be cleared
+    // too. Otherwise the promotion is a no-op in practice: resolveGitWorkflowSettings still
+    // honors the false autoCommit/autoPush/autoCreatePR overrides (so no PR), and the next
+    // workflow re-resolution can snap the feature straight back to read-only. Clearing both
+    // lets it re-inherit project/global delivery defaults and re-resolve cleanly. A
+    // caller that sets gitWorkflow/workflow explicitly in the same update wins.
+    if (updates.executionMode === 'standard' && feature.executionMode === 'read-only') {
+      if (!('gitWorkflow' in updates)) updates.gitWorkflow = undefined;
+      if (!('workflow' in updates)) updates.workflow = undefined;
+      logger.info(
+        `Promoting feature ${featureId} to delivery — cleared stale read-only ` +
+          `gitWorkflow/workflow overrides so it re-inherits delivery defaults`
+      );
+    }
+
     // Merge updates
     const updatedFeature: Feature = {
       ...feature,

--- a/apps/server/src/services/git-workflow-service.ts
+++ b/apps/server/src/services/git-workflow-service.ts
@@ -410,7 +410,22 @@ export class GitWorkflowService {
   ): Promise<GitWorkflowResult | null> {
     // Read-only features should never reach git workflow, but guard defensively.
     if (feature.executionMode === 'read-only') {
-      logger.debug(`Skipping git workflow for read-only feature ${featureId}`);
+      // De-silenced (#4073): a code-delivery feature reaching here read-only is almost
+      // always a mis-route — the agent runs and may auto-commit locally, but no branch,
+      // push, or PR is created, yet the board can still mark it done. Surface that at
+      // warn so the silent "done with no PR" failure mode is visible in logs and points
+      // at the remedy (promote it: set executionMode=standard so it re-resolves to a
+      // delivery workflow). Genuine read-only work (audit/research/signal) stays debug.
+      const featureType = feature.featureType ?? 'code';
+      if (featureType === 'code') {
+        logger.warn(
+          `Skipping git workflow for read-only feature ${featureId} (featureType=code) — ` +
+            `no branch/push/PR will be created. If this is delivery work, promote it ` +
+            `(set executionMode=standard) so it re-resolves to a delivery workflow.`
+        );
+      } else {
+        logger.debug(`Skipping git workflow for read-only feature ${featureId}`);
+      }
       return null;
     }
 

--- a/apps/server/src/services/workflow-loader.ts
+++ b/apps/server/src/services/workflow-loader.ts
@@ -430,6 +430,7 @@ export class WorkflowLoader {
       if (!match) continue;
 
       let score = 0;
+      let categoryMatched = false;
       const category = (feature.category ?? '').toLowerCase();
       const title = (feature.title ?? '').toLowerCase();
       const description = (feature.description ?? '').toLowerCase();
@@ -440,6 +441,7 @@ export class WorkflowLoader {
         for (const cat of match.categories) {
           if (category === cat.toLowerCase()) {
             score += 10;
+            categoryMatched = true;
             break;
           }
         }
@@ -460,6 +462,23 @@ export class WorkflowLoader {
       // Legacy executionMode match
       if (match.executionMode && feature.executionMode === match.executionMode) {
         score += 10;
+      }
+
+      // Delivery guard (#4073): a code-delivery feature must not be stripped of
+      // worktree isolation + PR creation by a *keyword-only* match. Routing a real
+      // code feature into a no-worktree/no-PR workflow (audit, research, signal,
+      // tech-debt-scan, ...) requires an explicit signal — an exact category match,
+      // an explicit feature.workflow, or feature.executionMode: 'read-only' (the latter
+      // two are handled by the short-circuits above). Keyword hits alone are far too
+      // noisy: words like "audit"/"review"/"analyze"/"research"/"check" routinely appear
+      // in ordinary delivery features (e.g. a "zizmor-remediation" task), and silently
+      // disabling delivery means the agent runs, auto-commits locally, and produces no
+      // branch/push/PR while the board still marks it done. This is the same false-positive
+      // class as the #3946 substring bug, generalized to whole-word keyword hits.
+      const featureType = feature.featureType ?? 'code';
+      const stripsDelivery = workflow.execution.useWorktrees === false;
+      if (featureType === 'code' && stripsDelivery && !categoryMatched) {
+        continue;
       }
 
       if (score > bestScore) {

--- a/apps/server/tests/unit/feature-loader-epic-completion.test.ts
+++ b/apps/server/tests/unit/feature-loader-epic-completion.test.ts
@@ -286,3 +286,75 @@ describe('FeatureLoader — epic completion delegation', () => {
     expect(writtenEpic?.status).not.toBe('done');
   });
 });
+
+describe('FeatureLoader — promote-to-delivery (#4073)', () => {
+  let loader: FeatureLoader;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loader = new FeatureLoader();
+  });
+
+  it('clears stale read-only gitWorkflow + workflow overrides when promoting executionMode to standard', async () => {
+    const feature = makeFeature({
+      id: 'ro-1',
+      status: 'backlog',
+      executionMode: 'read-only',
+      workflow: 'read-only',
+      gitWorkflow: { autoCommit: false, autoPush: false, autoCreatePR: false },
+    });
+    mockFeatureStore([feature]);
+    const { getWritten } = captureWrites();
+
+    const result = await loader.update(PROJECT_PATH, 'ro-1', { executionMode: 'standard' });
+
+    // The stale all-false gitWorkflow and the read-only workflow pin must be cleared so the
+    // feature re-inherits delivery defaults and re-resolves cleanly (not snap back to read-only).
+    expect(result.executionMode).toBe('standard');
+    expect(result.gitWorkflow).toBeUndefined();
+    expect(result.workflow).toBeUndefined();
+
+    const written = getWritten('ro-1');
+    expect(written?.gitWorkflow).toBeUndefined();
+    expect(written?.workflow).toBeUndefined();
+  });
+
+  it('does NOT clobber gitWorkflow/workflow that the caller sets explicitly in the same update', async () => {
+    const feature = makeFeature({
+      id: 'ro-2',
+      status: 'backlog',
+      executionMode: 'read-only',
+      gitWorkflow: { autoCommit: false, autoPush: false, autoCreatePR: false },
+    });
+    mockFeatureStore([feature]);
+    const { getWritten } = captureWrites();
+
+    const result = await loader.update(PROJECT_PATH, 'ro-2', {
+      executionMode: 'standard',
+      gitWorkflow: { autoCommit: true, autoPush: true, autoCreatePR: false },
+      workflow: 'audit',
+    });
+
+    expect(result.gitWorkflow).toEqual({ autoCommit: true, autoPush: true, autoCreatePR: false });
+    expect(result.workflow).toBe('audit');
+    const written = getWritten('ro-2');
+    expect(written?.gitWorkflow).toEqual({ autoCommit: true, autoPush: true, autoCreatePR: false });
+  });
+
+  it('leaves gitWorkflow untouched for a normal (non-promoting) update', async () => {
+    const feature = makeFeature({
+      id: 'std-1',
+      status: 'backlog',
+      executionMode: 'standard',
+      gitWorkflow: { autoCommit: true, autoPush: true, autoCreatePR: true },
+    });
+    mockFeatureStore([feature]);
+    const { getWritten } = captureWrites();
+
+    await loader.update(PROJECT_PATH, 'std-1', { title: 'Renamed' });
+
+    const written = getWritten('std-1');
+    expect(written?.gitWorkflow).toEqual({ autoCommit: true, autoPush: true, autoCreatePR: true });
+    expect(written?.executionMode).toBe('standard');
+  });
+});

--- a/apps/server/tests/unit/services/workflow-loader.test.ts
+++ b/apps/server/tests/unit/services/workflow-loader.test.ts
@@ -61,7 +61,12 @@ describe('WorkflowLoader', () => {
       expect(result.execution.useWorktrees).toBe(false);
     });
 
-    it('should resolve title containing "research" to the research workflow', async () => {
+    it('does NOT route a code feature to a read-only workflow on keyword-only hits (#4073)', async () => {
+      // A code-delivery feature whose text merely contains "research"/"explore" must
+      // stay on standard (worktree + commit + PR). Keyword-only matches are too noisy
+      // to silently strip delivery — that produced the #4073 "done with no PR" incident.
+      // To intentionally route research work, set category: 'research' (see below) or an
+      // explicit workflow. Generalizes the #3946 substring guard to whole-word hits.
       const feature = createFeature({
         category: 'code',
         title: 'Research authentication options',
@@ -70,8 +75,40 @@ describe('WorkflowLoader', () => {
 
       const result = await loader.resolveForFeature(testProjectPath, feature);
 
+      expect(result.name).toBe('standard');
+      expect(result.execution.useWorktrees).toBe(true);
+    });
+
+    it('routes a code feature into a read-only workflow on an EXACT category match (#4073)', async () => {
+      // The delivery guard only blocks keyword-only matches; an exact category match is
+      // an explicit signal and still routes to the read-only workflow.
+      const feature = createFeature({
+        category: 'research',
+        title: 'Research authentication options',
+        description: 'Explore different auth libraries',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
       expect(result.name).toBe('research');
       expect(result.execution.useWorktrees).toBe(false);
+    });
+
+    it('does NOT route a code feature to read-only on audit/security keyword hits (#4073 repro)', async () => {
+      // Mirrors the release-tools "zizmor-remediation" incident: a genuine code feature
+      // whose description contains audit/security/review keywords must NOT be downgraded
+      // to a no-PR workflow. It is real delivery work and must keep worktree + PR.
+      const feature = createFeature({
+        category: 'Signal Intake',
+        title: '[github] Remediate zizmor security findings in workflows',
+        description:
+          'Audit the GitHub Actions workflows and review/fix the security issues zizmor flagged.',
+      });
+
+      const result = await loader.resolveForFeature(testProjectPath, feature);
+
+      expect(result.name).toBe('standard');
+      expect(result.execution.useWorktrees).toBe(true);
     });
 
     it('does NOT route a code feature to a read-only workflow on a substring keyword false-positive (#3946)', async () => {

--- a/docs/guides/custom-workflows.md
+++ b/docs/guides/custom-workflows.md
@@ -176,7 +176,13 @@ match:
   executionMode: read-only # Match legacy executionMode field
 ```
 
-Match rules are not yet used for auto-assignment -- they are reserved for future workflow auto-detection.
+Match rules drive automatic workflow assignment via a scoring pass (see [Resolution Order](#resolution-order)): an exact `category` match scores 10, each whole-word `keyword` hit in the title/description scores 1, and an `executionMode` match scores 10. The highest-scoring workflow with a non-zero score wins.
+
+::: warning Delivery guard for code features
+A `featureType: 'code'` feature (the default) is **never** routed into a workflow that disables worktrees (`useWorktrees: false`) on a **keyword-only** match. Stripping a code feature of delivery (worktree → branch → push → PR) requires an explicit signal — an **exact category match**, an explicit `feature.workflow`, or `feature.executionMode: 'read-only'`.
+
+This prevents the false-positive class where ordinary delivery work whose text happens to contain words like `audit`, `review`, `analyze`, `research`, or `check` is silently downgraded to a no-PR read-only run (#4073). To intentionally route code work to a read-only workflow, set its `category` to one the workflow matches exactly, or pin `workflow` explicitly.
+:::
 
 ## Backward Compatibility
 
@@ -299,8 +305,14 @@ See `tools/swebench/` for the evaluation harness that uses this workflow.
 
 When the Lead Engineer picks up a feature, it resolves the workflow in this order:
 
-1. `feature.workflow` field (explicit assignment)
-2. `feature.executionMode === 'read-only'` maps to `read-only` workflow
-3. Falls back to `standard`
+1. `feature.workflow` field (explicit assignment) — if set but unknown, falls back to `standard`
+2. `feature.featureType === 'signal'` maps to the `signal` workflow
+3. `feature.executionMode === 'read-only'` maps to the `read-only` workflow
+4. **Match-rule scoring** across all built-in and project workflows (see [Match Rules](#match-rules)), subject to the **delivery guard** — a `featureType: 'code'` feature can only be scored into a `useWorktrees: false` workflow via an **exact category match**, not keyword hits alone
+5. Falls back to `standard`
 
 Project-level YAML files (`.automaker/workflows/{name}.yml`) take priority over built-in defaults with the same name, allowing you to override built-in behavior.
+
+### Promoting a read-only feature to delivery
+
+If a feature ended up read-only and you want it to branch/push/PR, set `executionMode: 'standard'` via the feature update API. The update path also clears the stale all-false `gitWorkflow` overrides and any read-only `workflow` pin (unless you set them explicitly in the same update), so the feature re-inherits delivery defaults and re-resolves cleanly instead of snapping back to read-only.


### PR DESCRIPTION
Closes #4073. Implements **Pieces 1+2** of the consolidated diagnosis in that issue; the formal per-project delivery-vs-observe stance (Piece 3) is deferred to #4074.

## The incident
A `featureType: code` delivery feature (a `[github]` signal-intake **zizmor-remediation** task on `release-tools`) ran but produced **no worktree, no branch, no push, no PR** — yet the board marked it done, bypassing review and committing straight onto local `main`.

## Root cause (confirmed in code)
1. Signal-intake creates the feature with **no** `executionMode` → `featureType` defaults to `code`.
2. `WorkflowLoader.resolveForFeature` **match-scores it into a read-only workflow** purely on keyword hits — the feature's text contains `audit`/`security`/`review`/`check`, which are keywords for `audit` / `dependency-health` / `signal` (all `useWorktrees: false`, all-false `gitWorkflow`). Same false-positive class as #3946, but whole-word.
3. `lead-engineer-service` sees a non-standard no-worktree workflow → **writes** `executionMode: 'read-only'` + merges the all-false `gitWorkflow`, persists.
4. The `executionMode === 'read-only'` branch in `resolveForFeature` then makes it **circular** — it can never resolve back.
5. `git-workflow-service` **skips the entire git workflow** (debug log only) → silent no-PR.

Flipping `executionMode → standard` didn't fix it: the stale all-false `gitWorkflow` persisted and match-scoring re-hijacked it on the next resolve.

## Fix
**Piece 2 — delivery guard (`workflow-loader.ts`):** a `featureType: code` feature can no longer be routed into a worktree-disabling workflow on a **keyword-only** match. Stripping delivery now requires an explicit signal — exact category match, explicit `feature.workflow`, or `executionMode: 'read-only'`.

**Piece 1:**
- **Promote-to-delivery (`feature-loader.ts`):** promoting `executionMode` read-only → standard now also clears the stale `gitWorkflow` + read-only `workflow` pin (caller-set values win), so the feature re-inherits delivery defaults and re-resolves cleanly instead of snapping back.
- **De-silence (`git-workflow-service.ts`):** a read-only `featureType: code` feature skipping the git workflow now logs at **warn** (was debug), surfacing the "done with no PR" failure mode and pointing at the remedy.

## Tests
- `workflow-loader.test.ts`: code feature with research/audit/security keywords → stays `standard`; exact category still routes to read-only; the zizmor repro stays `standard`. (Flipped one prior test that encoded the bug.)
- `feature-loader-epic-completion.test.ts`: promote clears stale `gitWorkflow`/`workflow`; caller-set values are preserved; normal updates leave `gitWorkflow` untouched.
- Full `typecheck` passes; workflow-loader, feature-loader, and git-workflow-service suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Features promoted from read-only to standard mode now properly clear outdated workflow configuration.
  * Improved workflow assignment logic to prevent read-only workflows from being incorrectly routed to code-delivery features.
  * Enhanced warning messages for read-only features attempting delivery workflows, with clearer guidance to switch execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->