### PR TITLE
[github] Per-project delivery-vs-observe stance for signal-intake features (#4073 follow-up)

### DIFF
--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -636,6 +636,16 @@ export class SignalIntakeService {
 
       // Ops signals: route to Lead Engineer state machine
 
+      // Resolve project execution stance (#4073 follow-up).
+      // 'observe' → read-only feature (no branches/PRs); 'delivery' (default) → standard workflow.
+      const projectSettings = this.settingsService
+        ? await this.settingsService.getProjectSettings(projectPath).catch((err) => {
+            logger.warn(`Failed to read project settings for stance resolution:`, err);
+            return null;
+          })
+        : null;
+      const isObserveStance = projectSettings?.executionStance === 'observe';
+
       // Create feature with idea state
       this.updateRingBufferEntry(bufferEntry.id, 'creating');
       const feature = await this.featureLoader.create(projectPath, {
@@ -646,6 +656,7 @@ export class SignalIntakeService {
         complexity: 'medium',
         workItemState: 'idea',
         sourceChannel: sourceToChannel(signal.source),
+        ...(isObserveStance ? { executionMode: 'read-only' as const } : {}),
         // Store GitHub issue number for auto-close on PR merge AND for future
         // idempotency lookups. Any caller that plumbs an issueNumber through
         // channelContext gets it persisted, not just native github-webhook

--- a/apps/server/tests/unit/services/signal-intake-service.test.ts
+++ b/apps/server/tests/unit/services/signal-intake-service.test.ts
@@ -1169,4 +1169,188 @@ describe('SignalIntakeService', () => {
       expect(lastCreateProjectPath()).toBe('/test/path');
     });
   });
+
+  describe('execution stance (#4073 follow-up)', () => {
+    let freshEmitter: EventEmitter;
+    let freshFeatureLoader: FeatureLoader;
+    let freshSettingsService: SettingsService;
+
+    function createFreshService(settingsOverride?: ProjectSettings): SignalIntakeService {
+      freshEmitter = createMockEventEmitter() as unknown as EventEmitter;
+      freshFeatureLoader = createMockFeatureLoader([], {
+        create: vi.fn().mockResolvedValue({
+          id: 'feature-stance-test',
+          title: 'Stance Test Feature',
+          status: 'backlog',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }),
+      }) as unknown as FeatureLoader;
+      freshSettingsService = createMockSettingsService({
+        getGlobalSettings: vi.fn().mockResolvedValue({}),
+        getProjectSettings: vi.fn().mockResolvedValue(settingsOverride ?? {}),
+      }) as unknown as SettingsService;
+
+      return new SignalIntakeService(
+        freshEmitter,
+        freshFeatureLoader,
+        '/test/path',
+        freshSettingsService
+      );
+    }
+
+    it('should create feature WITHOUT executionMode when stance is delivery (default)', async () => {
+      // Default: no executionStance set → delivery → no executionMode on feature
+      createFreshService({});
+
+      freshEmitter.emit(
+        'signal:received',
+        createTestSignal({
+          source: 'github',
+          author: { id: 'gh-stance-1', name: 'Dev' },
+          content: 'Delivery stance feature',
+        })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(freshFeatureLoader.create).toHaveBeenCalledTimes(1);
+      // @ts-expect-error — create is a vi mock
+      const createCall = freshFeatureLoader.create.mock.calls[0]?.[1];
+      expect(createCall?.executionMode).toBeUndefined();
+    });
+
+    it('should create feature WITHOUT executionMode when stance is explicitly delivery', async () => {
+      createFreshService({ executionStance: 'delivery' });
+
+      freshEmitter.emit(
+        'signal:received',
+        createTestSignal({
+          source: 'github',
+          author: { id: 'gh-stance-2', name: 'Dev' },
+          content: 'Explicit delivery stance',
+        })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(freshFeatureLoader.create).toHaveBeenCalledTimes(1);
+      // @ts-expect-error — create is a vi mock
+      const createCall = freshFeatureLoader.create.mock.calls[0]?.[1];
+      expect(createCall?.executionMode).toBeUndefined();
+    });
+
+    it('should create feature WITH executionMode: read-only when stance is observe', async () => {
+      createFreshService({ executionStance: 'observe' });
+
+      freshEmitter.emit(
+        'signal:received',
+        createTestSignal({
+          source: 'github',
+          author: { id: 'gh-stance-3', name: 'Dev' },
+          content: 'Observe stance feature',
+        })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(freshFeatureLoader.create).toHaveBeenCalledTimes(1);
+      // @ts-expect-error — create is a vi mock
+      const createCall = freshFeatureLoader.create.mock.calls[0]?.[1];
+      expect(createCall).toMatchObject({ executionMode: 'read-only' });
+    });
+
+    it('should default to delivery when getProjectSettings throws', async () => {
+      // If reading project settings fails, default to delivery (no executionMode)
+      freshEmitter = createMockEventEmitter() as unknown as EventEmitter;
+      freshFeatureLoader = createMockFeatureLoader([], {
+        create: vi.fn().mockResolvedValue({
+          id: 'feature-stance-test',
+          title: 'Stance Test Feature',
+          status: 'backlog',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }),
+      }) as unknown as FeatureLoader;
+      freshSettingsService = createMockSettingsService({
+        getGlobalSettings: vi.fn().mockResolvedValue({}),
+        getProjectSettings: vi.fn().mockRejectedValue(new Error('Settings file not found')),
+      }) as unknown as SettingsService;
+
+      const service = new SignalIntakeService(
+        freshEmitter,
+        freshFeatureLoader,
+        '/test/path',
+        freshSettingsService
+      );
+
+      freshEmitter.emit(
+        'signal:received',
+        createTestSignal({
+          source: 'github',
+          author: { id: 'gh-stance-4', name: 'Dev' },
+          content: 'Settings read failure',
+        })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(freshFeatureLoader.create).toHaveBeenCalledTimes(1);
+      // @ts-expect-error — create is a vi mock
+      const createCall = freshFeatureLoader.create.mock.calls[0]?.[1];
+      expect(createCall?.executionMode).toBeUndefined();
+    });
+
+    it('should default to delivery when no settingsService is provided', async () => {
+      const noSettingsEmitter = createMockEventEmitter() as unknown as EventEmitter;
+      const noSettingsLoader = createMockFeatureLoader([], {
+        create: vi.fn().mockResolvedValue({
+          id: 'feature-stance-test',
+          title: 'Stance Test Feature',
+          status: 'backlog',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }),
+      }) as unknown as FeatureLoader;
+
+      const service = new SignalIntakeService(noSettingsEmitter, noSettingsLoader, '/test/path');
+
+      noSettingsEmitter.emit(
+        'signal:received',
+        createTestSignal({
+          source: 'github',
+          author: { id: 'gh-stance-5', name: 'Dev' },
+          content: 'No settings service',
+        })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(noSettingsLoader.create).toHaveBeenCalledTimes(1);
+      // @ts-expect-error — create is a vi mock
+      const createCall = noSettingsLoader.create.mock.calls[0]?.[1];
+      expect(createCall?.executionMode).toBeUndefined();
+    });
+
+    it('should set executionMode: read-only for observe stance on Discord signals', async () => {
+      createFreshService({ executionStance: 'observe' });
+
+      freshEmitter.emit(
+        'signal:received',
+        createTestSignal({
+          source: 'discord',
+          author: { id: 'disc-stance-1', name: 'User' },
+          content: 'Discord observe signal',
+          channelContext: { channelName: 'dev-chat' },
+        })
+      );
+
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(freshFeatureLoader.create).toHaveBeenCalledTimes(1);
+      // @ts-expect-error — create is a vi mock
+      const createCall = freshFeatureLoader.create.mock.calls[0]?.[1];
+      expect(createCall).toMatchObject({ executionMode: 'read-only' });
+    });
+  });
 });

--- a/apps/ui/src/components/views/project-settings-view/config/navigation.ts
+++ b/apps/ui/src/components/views/project-settings-view/config/navigation.ts
@@ -7,6 +7,7 @@ import {
   Webhook,
   Bot,
   Library,
+  GitPullRequest,
 } from 'lucide-react';
 import type { SettingsNavigationItem } from '@/components/shared/settings';
 import type { ProjectSettingsViewId } from '../hooks/use-project-settings-view';
@@ -31,6 +32,7 @@ export const PROJECT_NAV_GROUPS: ProjectNavigationGroup[] = [
       { id: 'claude', label: 'Models', icon: Workflow },
       { id: 'webhooks', label: 'Webhooks', icon: Webhook },
       { id: 'agents', label: 'Agents', icon: Bot },
+      { id: 'execution', label: 'Execution Stance', icon: GitPullRequest },
     ],
   },
   {

--- a/apps/ui/src/components/views/project-settings-view/hooks/use-project-settings-view.ts
+++ b/apps/ui/src/components/views/project-settings-view/hooks/use-project-settings-view.ts
@@ -8,6 +8,7 @@ export type ProjectSettingsViewId =
   | 'claude'
   | 'webhooks'
   | 'agents'
+  | 'execution'
   | 'danger';
 
 interface UseProjectSettingsViewOptions {

--- a/apps/ui/src/components/views/project-settings-view/project-execution-stance-section.tsx
+++ b/apps/ui/src/components/views/project-settings-view/project-execution-stance-section.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from 'react';
+import { Label } from '@protolabsai/ui/atoms';
+import { Button } from '@protolabsai/ui/atoms';
+import { GitPullRequest, Eye } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useProjectSettings } from '@/hooks/queries/use-settings';
+import { useUpdateProjectSettings } from '@/hooks/mutations/use-settings-mutations';
+import type { Project } from '@/lib/electron';
+
+interface ProjectExecutionStanceSectionProps {
+  project: Project;
+}
+
+type ExecutionStance = 'delivery' | 'observe';
+
+const STANCE_OPTIONS: {
+  value: ExecutionStance;
+  label: string;
+  description: string;
+  icon: typeof GitPullRequest;
+}[] = [
+  {
+    value: 'delivery',
+    label: 'Delivery',
+    description: 'Agents branch → push → PR → review → merge',
+    icon: GitPullRequest,
+  },
+  {
+    value: 'observe',
+    label: 'Observe',
+    description: 'Read-only triage/analysis, no PRs',
+    icon: Eye,
+  },
+];
+
+export function ProjectExecutionStanceSection({ project }: ProjectExecutionStanceSectionProps) {
+  const { data: settings } = useProjectSettings(project.path);
+  const updateSettings = useUpdateProjectSettings();
+
+  const [stance, setStance] = useState<ExecutionStance>(settings?.executionStance ?? 'delivery');
+
+  useEffect(() => {
+    if (settings?.executionStance) {
+      setStance(settings.executionStance);
+    }
+  }, [settings?.executionStance]);
+
+  function handleSave(value: ExecutionStance) {
+    setStance(value);
+    updateSettings.mutate({
+      projectPath: project.path,
+      settings: { executionStance: value },
+    });
+  }
+
+  return (
+    <div
+      className={cn(
+        'rounded-xl overflow-hidden',
+        'border border-border/50',
+        'bg-gradient-to-br from-card/90 via-card/70 to-card/80 backdrop-blur-xl',
+        'shadow-sm shadow-black/5'
+      )}
+    >
+      <div className="p-6 border-b border-border/50 bg-gradient-to-r from-transparent via-accent/5 to-transparent">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="w-9 h-9 rounded-lg bg-gradient-to-br from-brand-500/20 to-brand-600/10 flex items-center justify-center border border-brand-500/20">
+            <GitPullRequest className="w-5 h-5 text-brand-500" />
+          </div>
+          <h2 className="text-lg font-semibold text-foreground tracking-tight">Execution Stance</h2>
+        </div>
+        <p className="text-sm text-muted-foreground/80 ml-12">
+          Controls whether signal-intake features produce PRs or stay read-only for this project.
+        </p>
+      </div>
+      <div className="p-6 space-y-4">
+        <Label>Default Stance</Label>
+        <p className="text-xs text-muted-foreground mb-2">
+          Determines how incoming signals (GitHub issues, Discord, MCP) are triaged. A delivery
+          stance produces branches and PRs; an observe stance keeps agents read-only.
+        </p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          {STANCE_OPTIONS.map((option) => {
+            const Icon = option.icon;
+            const isActive = stance === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() => handleSave(option.value)}
+                disabled={updateSettings.isPending}
+                className={cn(
+                  'relative flex items-start gap-3 p-4 rounded-lg border text-left transition-all',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2',
+                  isActive
+                    ? 'border-brand-500/50 bg-brand-500/5 shadow-sm'
+                    : 'border-border/50 bg-card/50 hover:border-border hover:bg-card/80'
+                )}
+              >
+                <div
+                  className={cn(
+                    'w-8 h-8 rounded-md flex items-center justify-center shrink-0 mt-0.5',
+                    isActive
+                      ? 'bg-brand-500/20 text-brand-500'
+                      : 'bg-muted/50 text-muted-foreground'
+                  )}
+                >
+                  <Icon className="w-4 h-4" />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-foreground">{option.label}</span>
+                    {isActive && (
+                      <span className="text-xs px-1.5 py-0.5 rounded-full bg-brand-500/10 text-brand-500 font-medium">
+                        Active
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-0.5">{option.description}</p>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {updateSettings.isPending && <p className="text-xs text-muted-foreground">Saving...</p>}
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/components/views/project-settings-view/project-settings-view.tsx
+++ b/apps/ui/src/components/views/project-settings-view/project-settings-view.tsx
@@ -10,6 +10,7 @@ import { ProjectDocsSection } from './project-docs-section';
 import { ProjectModelsSection } from './project-models-section';
 import { ProjectWebhooksSection } from './project-webhooks-section';
 import { ProjectAgentsSection } from './project-agents-section';
+import { ProjectExecutionStanceSection } from './project-execution-stance-section';
 import { DangerZoneSection } from '../settings-view/danger-zone/danger-zone-section';
 import { DeleteProjectDialog } from '../settings-view/components/delete-project-dialog';
 import { SettingsScopeToggle } from '../settings-view/components/settings-scope-toggle';
@@ -73,6 +74,8 @@ export function ProjectSettingsView() {
         return <ProjectWebhooksSection project={currentProject} />;
       case 'agents':
         return <ProjectAgentsSection project={currentProject} />;
+      case 'execution':
+        return <ProjectExecutionStanceSection project={currentProject} />;
       case 'danger':
         return (
           <DangerZoneSection

--- a/libs/types/src/project-settings.ts
+++ b/libs/types/src/project-settings.ts
@@ -277,6 +277,21 @@ export interface ProjectSettings {
    * as a global server overrides it for this project.
    */
   mcpServers?: MCPServerConfig[];
+
+  // Execution Stance (per-project)
+  /**
+   * Per-project delivery-vs-observe stance for signal-intake features.
+   *
+   * - 'delivery' (default): agents branch → push → PR → review → merge.
+   *   Signal-intake creates features with standard (push+PR) workflow.
+   * - 'observe': read-only triage/analysis, no PRs. Signal-intake creates
+   *   features with executionMode: 'read-only'.
+   *
+   * Independent of the PM agent's read-only-on-code mandate. A delivery-managed
+   * project with a read-only PM should still produce PRs from its execution agents.
+   * @see #4073 follow-up
+   */
+  executionStance?: 'delivery' | 'observe';
 }
 
 /** Default project settings (empty - all settings are optional and fall back to global) */


### PR DESCRIPTION
## Summary

# [github] Per-project delivery-vs-observe stance for signal-intake features (#4073 follow-up)

## Situation
This feature was requested but PRD generation encountered an issue.

## Problem
Per-project delivery-vs-observe stance for signal-intake features (#4073 follow-up)

Follow-up to #4073 (Piece 3). Pieces 1+2 of #4073 land separately and make **delivery the default for `featureType: code` work**, with read-only now requiring an explicit opt-in (explicit `workflow`, `executionMode: read-only`...

Closes #4074

---
*Created automatically by Automaker*

<!-- automaker:owner instance=ef15d09b-b02a-4f05-bb57-fcc898070dd7 team= created=2026-06-05T01:00:42.584Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Execution Stance" setting in project configuration, allowing projects to operate in "Delivery" mode (standard) or "Observe" mode (read-only operations).
  * Projects set to "Observe" mode will have restricted, read-only access.

* **Tests**
  * Added comprehensive test coverage for execution stance configuration and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->