### PR TITLE
docs: normalize MCP prefix + fix stale `dev` base branch (audit batch 1)

### DIFF
--- a/docs/agents/authoring-templates.md
+++ b/docs/agents/authoring-templates.md
@@ -145,7 +145,7 @@ console.log(template?.name); // 'Dana'
 
 ```typescript
 // Via MCP tool
-mcp__protolabs__start_agent({
+mcp__plugin_protolabs_studio__start_agent({
   projectPath: '/path/to/project',
   featureId: 'feature-123',
   agentRole: 'docs-writer', // Uses your new template

--- a/docs/agents/sdk-integration.md
+++ b/docs/agents/sdk-integration.md
@@ -120,7 +120,7 @@ POST /api/agent/start-session
 }
 
 // Via MCP Tool
-mcp__protolabs__start_agent({
+mcp__plugin_protolabs_studio__start_agent({
   projectPath: '/path/to/project',
   featureId: 'feature-123',
   model: 'claude-sonnet-4-6',

--- a/docs/guides/agent-memory.md
+++ b/docs/guides/agent-memory.md
@@ -377,7 +377,7 @@ curl -X POST http://localhost:3008/api/knowledge/compact \
 Or via MCP:
 
 ```typescript
-mcp__protolabs__compact_memory({
+mcp__plugin_protolabs_studio__compact_memory({
   projectPath: '/path/to/project',
   categoryFile: 'patterns.md',
   threshold: 30000, // Custom threshold
@@ -424,7 +424,7 @@ curl -X POST http://localhost:3008/api/knowledge/prune \
 Or via MCP:
 
 ```typescript
-mcp__protolabs__prune_knowledge({
+mcp__plugin_protolabs_studio__prune_knowledge({
   projectPath: '/path/to/project',
 });
 ```

--- a/docs/guides/context-files.md
+++ b/docs/guides/context-files.md
@@ -42,7 +42,7 @@ This guide provides a comprehensive overview of protoLabs's context loading syst
 
 ```bash
 # Via MCP tool
-mcp__protolabs__create_context_file({
+mcp__plugin_protolabs_studio__create_context_file({
   projectPath: '/path/to/project',
   filename: 'code-quality.md',
   content: '# Code Quality Standards\n\n...'

--- a/docs/guides/custom-workflows.md
+++ b/docs/guides/custom-workflows.md
@@ -160,7 +160,7 @@ execution:
     autoPush: true
     autoCreatePR: true
     autoMergePR: false
-    prBaseBranch: dev
+    prBaseBranch: main
   outputDir: .automaker/reports # Custom output directory (optional)
   terminalStatus: done # Where feature goes after: 'done' or 'review'
 ```

--- a/docs/infra/orchestration.md
+++ b/docs/infra/orchestration.md
@@ -114,7 +114,7 @@ interface Phase {
 ### Via MCP Tool
 
 ```typescript
-mcp__protolabs__create_project({
+mcp__plugin_protolabs_studio__create_project({
   projectPath: '/path/to/project',
   title: 'User Authentication System',
   goal: 'Implement secure JWT-based authentication',
@@ -176,7 +176,7 @@ curl -X POST http://localhost:3008/api/projects/create \
 Convert project phases to board features with milestones as epics:
 
 ```typescript
-mcp__protolabs__create_project_features({
+mcp__plugin_protolabs_studio__create_project_features({
   projectPath: '/path/to/project',
   projectSlug: 'user-authentication-system',
   createEpics: true, // Create epic for each milestone
@@ -196,7 +196,7 @@ Board Features:
 ### Without Epics
 
 ```typescript
-mcp__protolabs__create_project_features({
+mcp__plugin_protolabs_studio__create_project_features({
   projectPath: '/path/to/project',
   projectSlug: 'user-authentication-system',
   createEpics: false,
@@ -235,7 +235,7 @@ interface Feature {
 
 ```typescript
 // 1. Create epic feature
-mcp__protolabs__create_feature({
+mcp__plugin_protolabs_studio__create_feature({
   projectPath: '/path/to/project',
   title: 'Foundation Infrastructure',
   description: 'Core types, services, and utilities',
@@ -245,7 +245,7 @@ mcp__protolabs__create_feature({
 });
 
 // 2. Create child features
-mcp__protolabs__create_feature({
+mcp__plugin_protolabs_studio__create_feature({
   projectPath: '/path/to/project',
   title: 'Add Auth Types',
   description: 'TypeScript definitions for auth',
@@ -284,7 +284,7 @@ feat-a    feat-b    feat-c   Feature PRs (target epic branch)
 ### Setting Dependencies
 
 ```typescript
-mcp__protolabs__set_feature_dependencies({
+mcp__plugin_protolabs_studio__set_feature_dependencies({
   projectPath: '/path/to/project',
   featureId: 'feature-456',
   dependsOn: ['feature-123', 'feature-789'],
@@ -294,7 +294,7 @@ mcp__protolabs__set_feature_dependencies({
 ### Dependency Graph
 
 ```typescript
-const graph = await mcp__protolabs__get_dependency_graph({
+const graph = await mcp__plugin_protolabs_studio__get_dependency_graph({
   projectPath: '/path/to/project',
 });
 ```
@@ -314,7 +314,7 @@ const graph = await mcp__protolabs__get_dependency_graph({
 ### Execution Order
 
 ```typescript
-const order = await mcp__protolabs__get_execution_order({
+const order = await mcp__plugin_protolabs_studio__get_execution_order({
   projectPath: '/path/to/project',
 });
 // Returns: ["feature-123", "feature-456", "feature-789"]
@@ -325,7 +325,7 @@ const order = await mcp__protolabs__get_execution_order({
 Auto-mode processes features in dependency order:
 
 ```typescript
-mcp__protolabs__start_auto_mode({
+mcp__plugin_protolabs_studio__start_auto_mode({
   projectPath: '/path/to/project',
   respectDependencies: true,
 });

--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -391,7 +391,7 @@ If neither of the above applies:
 ### Tools Not Available
 
 1. Check the health endpoint: `/board` — if it fails, start protoLabs
-2. Verify MCP tools are loaded: `mcp__protolabs__health_check()`
+2. Verify MCP tools are loaded: `mcp__plugin_protolabs_studio__health_check()`
 
 ### Feature Dependencies Not Working
 

--- a/docs/integrations/mcp-tools-reference.md
+++ b/docs/integrations/mcp-tools-reference.md
@@ -10,7 +10,7 @@ claude plugin marketplace add /path/to/automaker/packages/mcp-server/plugins
 claude plugin install protolabs
 
 # Verify connectivity
-mcp__protolabs__health_check({})
+mcp__plugin_protolabs_studio__health_check({})
 ```
 
 All tools follow this response structure:
@@ -34,7 +34,7 @@ Manage features on the Kanban board.
 List all features in a project.
 
 ```typescript
-mcp__protolabs__list_features({
+mcp__plugin_protolabs_studio__list_features({
   projectPath: '/home/user/my-project',
   status: 'backlog', // Optional: filter by status
 });
@@ -52,7 +52,7 @@ mcp__protolabs__list_features({
 Get details for a specific feature.
 
 ```typescript
-mcp__protolabs__get_feature({
+mcp__plugin_protolabs_studio__get_feature({
   projectPath: '/home/user/my-project',
   featureId: 'feature-1741234567890-abc123',
 });
@@ -63,7 +63,7 @@ mcp__protolabs__get_feature({
 Create a new feature on the board.
 
 ```typescript
-mcp__protolabs__create_feature({
+mcp__plugin_protolabs_studio__create_feature({
   projectPath: '/home/user/my-project',
   title: 'Add user authentication',
   description: 'Implement JWT-based authentication with login/logout endpoints',
@@ -89,7 +89,7 @@ mcp__protolabs__create_feature({
 Update a feature's properties.
 
 ```typescript
-mcp__protolabs__update_feature({
+mcp__plugin_protolabs_studio__update_feature({
   projectPath: '/home/user/my-project',
   featureId: 'feature-1741234567890-abc123',
   title: 'Updated title',
@@ -102,7 +102,7 @@ mcp__protolabs__update_feature({
 Delete a feature from the board.
 
 ```typescript
-mcp__protolabs__delete_feature({
+mcp__plugin_protolabs_studio__delete_feature({
   projectPath: '/home/user/my-project',
   featureId: 'feature-1741234567890-abc123',
 });
@@ -113,7 +113,7 @@ mcp__protolabs__delete_feature({
 Move a feature to a different status.
 
 ```typescript
-mcp__protolabs__move_feature({
+mcp__plugin_protolabs_studio__move_feature({
   projectPath: '/home/user/my-project',
   featureId: 'feature-1741234567890-abc123',
   status: 'in_progress',
@@ -129,7 +129,7 @@ Start, stop, and monitor AI agents.
 Start an agent on a feature.
 
 ```typescript
-mcp__protolabs__start_agent({
+mcp__plugin_protolabs_studio__start_agent({
   projectPath: '/home/user/my-project',
   featureId: 'feature-1741234567890-abc123',
   model: 'sonnet', // Optional: override default model
@@ -142,7 +142,7 @@ mcp__protolabs__start_agent({
 Stop a running agent.
 
 ```typescript
-mcp__protolabs__stop_agent({
+mcp__plugin_protolabs_studio__stop_agent({
   projectPath: '/home/user/my-project',
   featureId: 'feature-1741234567890-abc123',
 });
@@ -153,7 +153,7 @@ mcp__protolabs__stop_agent({
 List all currently running agents.
 
 ```typescript
-mcp__protolabs__list_running_agents({
+mcp__plugin_protolabs_studio__list_running_agents({
   projectPath: '/home/user/my-project',
 });
 ```
@@ -163,7 +163,7 @@ mcp__protolabs__list_running_agents({
 Get the output from a completed or running agent.
 
 ```typescript
-mcp__protolabs__get_agent_output({
+mcp__plugin_protolabs_studio__get_agent_output({
   projectPath: '/home/user/my-project',
   featureId: 'feature-1741234567890-abc123',
 });
@@ -174,7 +174,7 @@ mcp__protolabs__get_agent_output({
 Send a message to a running agent.
 
 ```typescript
-mcp__protolabs__send_message_to_agent({
+mcp__plugin_protolabs_studio__send_message_to_agent({
   projectPath: '/home/user/my-project',
   featureId: 'feature-1741234567890-abc123',
   message: 'Also add TypeScript types for the response schema',
@@ -190,7 +190,7 @@ Manage the auto-mode processing queue.
 Add a feature to the auto-mode processing queue.
 
 ```typescript
-mcp__protolabs__queue_feature({
+mcp__plugin_protolabs_studio__queue_feature({
   projectPath: '/home/user/my-project',
   featureId: 'feature-1741234567890-abc123',
   priority: 1, // Optional: higher priority = processed first
@@ -202,7 +202,7 @@ mcp__protolabs__queue_feature({
 List all features in the processing queue.
 
 ```typescript
-mcp__protolabs__list_queue({
+mcp__plugin_protolabs_studio__list_queue({
   projectPath: '/home/user/my-project',
 });
 ```
@@ -212,7 +212,7 @@ mcp__protolabs__list_queue({
 Remove all features from the queue.
 
 ```typescript
-mcp__protolabs__clear_queue({
+mcp__plugin_protolabs_studio__clear_queue({
   projectPath: '/home/user/my-project',
 });
 ```
@@ -226,7 +226,7 @@ Manage `.automaker/context/` files that define agent rules and conventions.
 List all context files for a project.
 
 ```typescript
-mcp__protolabs__list_context_files({
+mcp__plugin_protolabs_studio__list_context_files({
   projectPath: '/home/user/my-project',
 });
 ```
@@ -236,7 +236,7 @@ mcp__protolabs__list_context_files({
 Read a context file's content.
 
 ```typescript
-mcp__protolabs__get_context_file({
+mcp__plugin_protolabs_studio__get_context_file({
   projectPath: '/home/user/my-project',
   fileName: 'CLAUDE.md',
 });
@@ -247,7 +247,7 @@ mcp__protolabs__get_context_file({
 Create a new context file.
 
 ```typescript
-mcp__protolabs__create_context_file({
+mcp__plugin_protolabs_studio__create_context_file({
   projectPath: '/home/user/my-project',
   fileName: 'testing-conventions.md',
   content: '# Testing Conventions\n\nAlways write unit tests for services...',
@@ -259,7 +259,7 @@ mcp__protolabs__create_context_file({
 Delete a context file.
 
 ```typescript
-mcp__protolabs__delete_context_file({
+mcp__plugin_protolabs_studio__delete_context_file({
   projectPath: '/home/user/my-project',
   fileName: 'outdated-rules.md',
 });
@@ -274,7 +274,7 @@ Create and manage hierarchical project plans.
 Create a new project with PRD and milestones.
 
 ```typescript
-mcp__protolabs__create_project({
+mcp__plugin_protolabs_studio__create_project({
   projectPath: '/home/user/my-project',
   title: 'User Authentication System',
   goal: 'Implement secure JWT-based authentication',
@@ -308,7 +308,7 @@ mcp__protolabs__create_project({
 List all projects in a workspace.
 
 ```typescript
-mcp__protolabs__list_projects({
+mcp__plugin_protolabs_studio__list_projects({
   projectPath: '/home/user/my-project',
 });
 ```
@@ -318,7 +318,7 @@ mcp__protolabs__list_projects({
 Get full project details including milestones and phases.
 
 ```typescript
-mcp__protolabs__get_project({
+mcp__plugin_protolabs_studio__get_project({
   projectPath: '/home/user/my-project',
   projectSlug: 'user-authentication-system',
 });
@@ -329,7 +329,7 @@ mcp__protolabs__get_project({
 Convert project phases to board features.
 
 ```typescript
-mcp__protolabs__create_project_features({
+mcp__plugin_protolabs_studio__create_project_features({
   projectPath: '/home/user/my-project',
   projectSlug: 'user-authentication-system',
   createEpics: true, // Create epic per milestone
@@ -342,7 +342,7 @@ mcp__protolabs__create_project_features({
 Set dependencies between features.
 
 ```typescript
-mcp__protolabs__set_feature_dependencies({
+mcp__plugin_protolabs_studio__set_feature_dependencies({
   projectPath: '/home/user/my-project',
   featureId: 'feature-456',
   dependsOn: ['feature-123', 'feature-789'],
@@ -354,7 +354,7 @@ mcp__protolabs__set_feature_dependencies({
 Get the full dependency graph for a project.
 
 ```typescript
-mcp__protolabs__get_dependency_graph({
+mcp__plugin_protolabs_studio__get_dependency_graph({
   projectPath: '/home/user/my-project',
 });
 ```
@@ -364,7 +364,7 @@ mcp__protolabs__get_dependency_graph({
 Get the topologically sorted execution order.
 
 ```typescript
-mcp__protolabs__get_execution_order({
+mcp__plugin_protolabs_studio__get_execution_order({
   projectPath: '/home/user/my-project',
 });
 ```
@@ -378,7 +378,7 @@ Start and stop autonomous feature processing.
 Start auto-mode for a project.
 
 ```typescript
-mcp__protolabs__start_auto_mode({
+mcp__plugin_protolabs_studio__start_auto_mode({
   projectPath: '/home/user/my-project',
   respectDependencies: true, // Process in dependency order
 });
@@ -389,7 +389,7 @@ mcp__protolabs__start_auto_mode({
 Stop auto-mode.
 
 ```typescript
-mcp__protolabs__stop_auto_mode({
+mcp__plugin_protolabs_studio__stop_auto_mode({
   projectPath: '/home/user/my-project',
 });
 ```
@@ -399,7 +399,7 @@ mcp__protolabs__stop_auto_mode({
 Get auto-mode status and current queue.
 
 ```typescript
-mcp__protolabs__get_auto_mode_status({
+mcp__plugin_protolabs_studio__get_auto_mode_status({
   projectPath: '/home/user/my-project',
 });
 ```
@@ -413,7 +413,7 @@ Work with pull requests and CI status.
 Check the status of a pull request.
 
 ```typescript
-mcp__protolabs__check_pr_status({
+mcp__plugin_protolabs_studio__check_pr_status({
   projectPath: '/home/user/my-project',
   prNumber: 123,
 });
@@ -424,7 +424,7 @@ mcp__protolabs__check_pr_status({
 Merge an approved pull request.
 
 ```typescript
-mcp__protolabs__merge_pr({
+mcp__plugin_protolabs_studio__merge_pr({
   projectPath: '/home/user/my-project',
   prNumber: 123,
   mergeStrategy: 'squash', // 'squash' | 'merge' | 'rebase'
@@ -436,7 +436,7 @@ mcp__protolabs__merge_pr({
 Resolve all open review threads on a PR.
 
 ```typescript
-mcp__protolabs__resolve_pr_threads({
+mcp__plugin_protolabs_studio__resolve_pr_threads({
   projectPath: '/home/user/my-project',
   prNumber: 123,
 });
@@ -451,7 +451,7 @@ Access traces, costs, and evaluation data.
 List recent agent execution traces.
 
 ```typescript
-mcp__protolabs__langfuse_list_traces({
+mcp__plugin_protolabs_studio__langfuse_list_traces({
   limit: 20,
   userId: 'feature-1741234567890-abc123', // Optional: filter by feature
 });
@@ -462,7 +462,7 @@ mcp__protolabs__langfuse_list_traces({
 Get cost breakdown for a time period.
 
 ```typescript
-mcp__protolabs__langfuse_get_costs({
+mcp__plugin_protolabs_studio__langfuse_get_costs({
   fromDate: '2026-01-01',
   toDate: '2026-01-31',
 });
@@ -473,7 +473,7 @@ mcp__protolabs__langfuse_get_costs({
 Add a quality score to a trace.
 
 ```typescript
-mcp__protolabs__langfuse_score_trace({
+mcp__plugin_protolabs_studio__langfuse_score_trace({
   traceId: 'trace-abc123',
   name: 'code-quality',
   value: 0.9,
@@ -488,7 +488,7 @@ mcp__protolabs__langfuse_score_trace({
 Verify MCP server connectivity.
 
 ```typescript
-mcp__protolabs__health_check({});
+mcp__plugin_protolabs_studio__health_check({});
 // Returns: { success: true, data: { status: 'healthy', version: '1.0.0' } }
 ```
 
@@ -497,7 +497,7 @@ mcp__protolabs__health_check({});
 Get a summary of the current board state.
 
 ```typescript
-mcp__protolabs__get_board_summary({
+mcp__plugin_protolabs_studio__get_board_summary({
   projectPath: '/home/user/my-project',
 });
 ```
@@ -511,7 +511,7 @@ Manage the project specification document.
 Get the project specification from `.automaker/spec.md`.
 
 ```typescript
-mcp__protolabs__get_project_spec({
+mcp__plugin_protolabs_studio__get_project_spec({
   projectPath: '/home/user/my-project',
 });
 ```
@@ -521,7 +521,7 @@ mcp__protolabs__get_project_spec({
 Update the project specification.
 
 ```typescript
-mcp__protolabs__update_project_spec({
+mcp__plugin_protolabs_studio__update_project_spec({
   projectPath: '/home/user/my-project',
   content: '# Project Spec\n\n## Goals\n...',
 });

--- a/docs/integrations/plugin-commands.md
+++ b/docs/integrations/plugin-commands.md
@@ -477,7 +477,7 @@ User: Create a feature to add a dark mode toggle
 
 Claude: I'll create that feature for you.
 
-[Calls mcp__protolabs__create_feature with:
+[Calls mcp__plugin_protolabs_studio__create_feature with:
   projectPath: "/path/to/project"
   title: "Add dark mode toggle"
   description: "## Overview
@@ -505,7 +505,7 @@ User: The dashboard feature should depend on the auth feature
 
 Claude: I'll set up that dependency.
 
-[Calls mcp__protolabs__set_feature_dependencies with:
+[Calls mcp__plugin_protolabs_studio__set_feature_dependencies with:
   projectPath: "/path/to/project"
   featureId: "dashboard-id"
   dependencies: ["auth-id"]]
@@ -521,7 +521,7 @@ User: Start auto-mode with 2 concurrent agents
 
 Claude: Starting auto-mode...
 
-[Calls mcp__protolabs__start_auto_mode with:
+[Calls mcp__plugin_protolabs_studio__start_auto_mode with:
   projectPath: "/path/to/project"
   maxConcurrency: 2]
 
@@ -540,7 +540,7 @@ User: What did the agent do on the auth feature?
 
 Claude: Let me check the agent output.
 
-[Calls mcp__protolabs__get_agent_output with:
+[Calls mcp__plugin_protolabs_studio__get_agent_output with:
   projectPath: "/path/to/project"
   featureId: "auth-id"]
 
@@ -574,7 +574,7 @@ name: my-command
 description: What this command does
 argument-hint: (optional arguments)
 allowed-tools:
-  - mcp__protolabs__tool_name
+  - mcp__plugin_protolabs_studio__tool_name
 ---
 # Command Instructions
 
@@ -592,7 +592,7 @@ description: What this agent does
 allowed-tools:
   - Read
   - Write
-  - mcp__protolabs__tool_name
+  - mcp__plugin_protolabs_studio__tool_name
 model: sonnet
 ---
 # Agent Instructions

--- a/docs/internal/agents/mcp-integration.md
+++ b/docs/internal/agents/mcp-integration.md
@@ -155,13 +155,13 @@ async *executeQuery(options: ExecuteOptions): AsyncGenerator<ProviderMessage> {
 
 ```typescript
 // List features on the board
-mcp__protolabs__list_features({ projectPath, status: 'backlog' });
+mcp__plugin_protolabs_studio__list_features({ projectPath, status: 'backlog' });
 
 // Get feature details
-mcp__protolabs__get_feature({ projectPath, featureId });
+mcp__plugin_protolabs_studio__get_feature({ projectPath, featureId });
 
 // Create new feature
-mcp__protolabs__create_feature({
+mcp__plugin_protolabs_studio__create_feature({
   projectPath,
   title: 'Add authentication',
   description: 'Implement OAuth2 + JWT',
@@ -170,7 +170,7 @@ mcp__protolabs__create_feature({
 });
 
 // Update feature
-mcp__protolabs__update_feature({
+mcp__plugin_protolabs_studio__update_feature({
   projectPath,
   featureId,
   title: 'Updated title',
@@ -178,29 +178,29 @@ mcp__protolabs__update_feature({
 });
 
 // Delete feature
-mcp__protolabs__delete_feature({ projectPath, featureId });
+mcp__plugin_protolabs_studio__delete_feature({ projectPath, featureId });
 
 // Move feature to different column
-mcp__protolabs__move_feature({ projectPath, featureId, toStatus: 'review' });
+mcp__plugin_protolabs_studio__move_feature({ projectPath, featureId, toStatus: 'review' });
 ```
 
 ### Agent Control
 
 ```typescript
 // Start agent for a feature
-mcp__protolabs__start_agent({ projectPath, featureId, useWorktrees: true });
+mcp__plugin_protolabs_studio__start_agent({ projectPath, featureId, useWorktrees: true });
 
 // Stop running agent
-mcp__protolabs__stop_agent({ featureId });
+mcp__plugin_protolabs_studio__stop_agent({ featureId });
 
 // List all running agents
-mcp__protolabs__list_running_agents();
+mcp__plugin_protolabs_studio__list_running_agents();
 
 // Get agent output
-mcp__protolabs__get_agent_output({ projectPath, featureId });
+mcp__plugin_protolabs_studio__get_agent_output({ projectPath, featureId });
 
 // Send message to running agent
-mcp__protolabs__send_message_to_agent({
+mcp__plugin_protolabs_studio__send_message_to_agent({
   projectPath,
   featureId,
   message: 'Please add error handling',
@@ -211,73 +211,73 @@ mcp__protolabs__send_message_to_agent({
 
 ```typescript
 // Add feature to queue
-mcp__protolabs__queue_feature({ projectPath, featureId });
+mcp__plugin_protolabs_studio__queue_feature({ projectPath, featureId });
 
 // List queue
-mcp__protolabs__list_queue();
+mcp__plugin_protolabs_studio__list_queue();
 
 // Clear queue
-mcp__protolabs__clear_queue();
+mcp__plugin_protolabs_studio__clear_queue();
 ```
 
 ### Context Files
 
 ```typescript
 // List context files
-mcp__protolabs__list_context_files({ projectPath });
+mcp__plugin_protolabs_studio__list_context_files({ projectPath });
 
 // Read context file
-mcp__protolabs__get_context_file({ projectPath, filename: 'coding-rules.md' });
+mcp__plugin_protolabs_studio__get_context_file({ projectPath, filename: 'coding-rules.md' });
 
 // Create context file
-mcp__protolabs__create_context_file({
+mcp__plugin_protolabs_studio__create_context_file({
   projectPath,
   filename: 'security-guidelines.md',
   content: '# Security Guidelines\n\n...',
 });
 
 // Delete context file
-mcp__protolabs__delete_context_file({ projectPath, filename: 'old-rules.md' });
+mcp__plugin_protolabs_studio__delete_context_file({ projectPath, filename: 'old-rules.md' });
 ```
 
 ### Auto-Mode
 
 ```typescript
 // Start auto-mode
-mcp__protolabs__start_auto_mode({ projectPath, maxConcurrency: 2 });
+mcp__plugin_protolabs_studio__start_auto_mode({ projectPath, maxConcurrency: 2 });
 
 // Stop auto-mode
-mcp__protolabs__stop_auto_mode({ projectPath });
+mcp__plugin_protolabs_studio__stop_auto_mode({ projectPath });
 
 // Get auto-mode status
-mcp__protolabs__get_auto_mode_status({ projectPath });
+mcp__plugin_protolabs_studio__get_auto_mode_status({ projectPath });
 ```
 
 ### Orchestration
 
 ```typescript
 // Set feature dependencies
-mcp__protolabs__set_feature_dependencies({
+mcp__plugin_protolabs_studio__set_feature_dependencies({
   projectPath,
   featureId,
   dependencies: ['feature-123', 'feature-456'],
 });
 
 // Get dependency graph
-mcp__protolabs__get_dependency_graph({ projectPath });
+mcp__plugin_protolabs_studio__get_dependency_graph({ projectPath });
 
 // Get execution order
-mcp__protolabs__get_execution_order({ projectPath, status: 'backlog' });
+mcp__plugin_protolabs_studio__get_execution_order({ projectPath, status: 'backlog' });
 ```
 
 ### Project Management
 
 ```typescript
 // List projects
-mcp__protolabs__list_projects({ projectPath });
+mcp__plugin_protolabs_studio__list_projects({ projectPath });
 
 // Create project plan
-mcp__protolabs__create_project({
+mcp__plugin_protolabs_studio__create_project({
   projectPath,
   title: 'Authentication System',
   goal: 'Implement OAuth2 authentication',
@@ -286,7 +286,7 @@ mcp__protolabs__create_project({
 });
 
 // Create features from project
-mcp__protolabs__create_project_features({
+mcp__plugin_protolabs_studio__create_project_features({
   projectPath,
   projectSlug: 'authentication-system',
   createEpics: true,
@@ -298,10 +298,10 @@ mcp__protolabs__create_project_features({
 
 ```typescript
 // Health check
-mcp__protolabs__health_check();
+mcp__plugin_protolabs_studio__health_check();
 
 // Get board summary
-mcp__protolabs__get_board_summary({ projectPath });
+mcp__plugin_protolabs_studio__get_board_summary({ projectPath });
 ```
 
 ## Creating New MCP Tools
@@ -406,7 +406,7 @@ claude
 
 ```
 ┌──────────────────────────────────────────────────────┐
-│  Chief of Staff calls mcp__protolabs__start_agent    │
+│  Chief of Staff calls mcp__plugin_protolabs_studio__start_agent    │
 │  - Passes projectPath and featureId                  │
 └──────────────────┬───────────────────────────────────┘
                    │

--- a/docs/internal/agents/sdk-integration.md
+++ b/docs/internal/agents/sdk-integration.md
@@ -120,7 +120,7 @@ POST /api/agent/start-session
 }
 
 // Via MCP Tool
-mcp__protolabs__start_agent({
+mcp__plugin_protolabs_studio__start_agent({
   projectPath: '/path/to/project',
   featureId: 'feature-123',
   model: 'claude-sonnet-4-6',

--- a/docs/internal/dev/lead-engineer-pipeline.md
+++ b/docs/internal/dev/lead-engineer-pipeline.md
@@ -186,11 +186,11 @@ Execution is blocked when:
 
 Before launching the agent, the processor validates the worktree environment:
 
-| Check                 | What It Does                                                          |
-| --------------------- | --------------------------------------------------------------------- |
-| **Worktree currency** | `git fetch` + `git rebase origin/dev` to sync with the latest changes |
-| **Package builds**    | Ensures all required packages are compiled before the agent runs      |
-| **Dependency merge**  | Verifies blocking dependencies have been merged and are available     |
+| Check                 | What It Does                                                           |
+| --------------------- | ---------------------------------------------------------------------- |
+| **Worktree currency** | `git fetch` + `git rebase origin/main` to sync with the latest changes |
+| **Package builds**    | Ensures all required packages are compiled before the agent runs       |
+| **Dependency merge**  | Verifies blocking dependencies have been merged and are available      |
 
 Pre-flight checks can be disabled globally via `preFlightChecks.enabled: false`.
 

--- a/docs/internal/dev/project-orchestration.md
+++ b/docs/internal/dev/project-orchestration.md
@@ -108,7 +108,7 @@ This keeps the base branch clean while allowing incremental feature development 
 
 ```typescript
 // Create project plan
-mcp__protolabs__create_project({
+mcp__plugin_protolabs_studio__create_project({
   projectPath: '/path/to/project',
   title: 'My Feature',
   goal: 'Implement X functionality',
@@ -137,7 +137,7 @@ mcp__protolabs__create_project({
 });
 
 // Convert to board features
-mcp__protolabs__create_project_features({
+mcp__plugin_protolabs_studio__create_project_features({
   projectPath: '/path/to/project',
   projectSlug: 'my-feature',
   createEpics: true,

--- a/docs/internal/dev/qa-engineer.md
+++ b/docs/internal/dev/qa-engineer.md
@@ -47,7 +47,7 @@ agent-browser uses an accessibility tree with semantic element references (`@e1`
 Single-call QA health snapshot that consolidates multiple verification sources.
 
 ```typescript
-mcp__protolabs__run_qa_check({
+mcp__plugin_protolabs_studio__run_qa_check({
   projectPath: '/home/josh/dev/ava',
 });
 ```
@@ -227,7 +227,7 @@ Aggregation endpoint that returns a consolidated QA snapshot for a project.
 
 ```typescript
 // MCP call
-mcp__protolabs__run_qa_check({
+mcp__plugin_protolabs_studio__run_qa_check({
   projectPath: '/home/josh/dev/ava',
 });
 ```

--- a/docs/internal/server/automation-registry.md
+++ b/docs/internal/server/automation-registry.md
@@ -366,7 +366,7 @@ Conditional registration: `data-integrity` requires `IntegrityWatchdogService`, 
 
 ### Branch-Aware Tasks
 
-Tasks marked "Branch-Aware" in the table above call `resolveIntegrationBranch()` to determine the correct target branch from the project's `gitWorkflow.prBaseBranch` setting (defaults to `dev`). This means:
+Tasks marked "Branch-Aware" in the table above call `resolveIntegrationBranch()` to determine the correct target branch from the project's `gitWorkflow.prBaseBranch` setting (defaults to `main`). This means:
 
 - **`stale-worktrees`** uses the integration branch when determining which branches are safe to clean (covers both worktree removal and merged branch deletion)
 

--- a/docs/internal/server/git-workflow-service.md
+++ b/docs/internal/server/git-workflow-service.md
@@ -49,7 +49,7 @@ Settings come from `GitWorkflowSettings` in `.automaker/settings.json`:
 ```typescript
 interface GitWorkflowSettings {
   commitMessage?: string; // default: derived from feature title
-  prBaseBranch?: string; // default: 'dev'
+  prBaseBranch?: string; // default: 'main'
   prTemplate?: string; // PR body template
   autoMerge?: boolean; // enable auto-merge
   mergeStrategy?: PRMergeStrategy; // 'merge' | 'squash' | 'rebase'
@@ -59,7 +59,7 @@ interface GitWorkflowSettings {
 
 | Setting         | Default    | Description                                 |
 | --------------- | ---------- | ------------------------------------------- |
-| `prBaseBranch`  | `'dev'`    | Target branch for PR creation               |
+| `prBaseBranch`  | `'main'`   | Target branch for PR creation               |
 | `mergeStrategy` | `'squash'` | How the PR is merged                        |
 | `autoMerge`     | `true`     | Enable GitHub auto-merge if CI is pending   |
 | `closeIssues`   | `true`     | Include issue-closing references in PR body |

--- a/docs/internal/server/maintenance-checks.md
+++ b/docs/internal/server/maintenance-checks.md
@@ -14,7 +14,7 @@ Signal features:
 **How to create a signal feature via MCP:**
 
 ```typescript
-mcp__protolabs__create_feature({
+mcp__plugin_protolabs_studio__create_feature({
   projectPath: '/path/to/project',
   title: 'Signal: rabbit-hole.io CI failing on main',
   description: 'CI checks on rabbit-hole.io main are red. Investigate and document root cause.',
@@ -29,7 +29,7 @@ mcp__protolabs__create_feature({
 **Immediate recovery for stuck signal features:** If you find existing features stuck in `review` with no `prNumber` that describe external-repo issues, update them in place:
 
 ```typescript
-mcp__protolabs__update_feature({
+mcp__plugin_protolabs_studio__update_feature({
   projectPath: '/path/to/project',
   featureId: 'feature-...',
   featureType: 'signal',

--- a/docs/internal/server/worktree-recovery-service.md
+++ b/docs/internal/server/worktree-recovery-service.md
@@ -37,7 +37,7 @@ checkAndRecoverUncommittedWork(feature, worktreePath, projectPath, prBaseBranch?
 
 ## Rebase Strategy
 
-After committing, the service fetches and rebases onto `origin/<baseBranch>` (default: `dev`). This prevents the PR from diverging from the base branch.
+After committing, the service fetches and rebases onto `origin/<baseBranch>` (default: `main`). This prevents the PR from diverging from the base branch.
 
 - **On success:** push uses `--force-with-lease` (safe force push)
 - **On conflict:** rebases is aborted, push proceeds without force flag

--- a/docs/reference/knowledge-hive.md
+++ b/docs/reference/knowledge-hive.md
@@ -567,7 +567,7 @@ Use the top 3 results to inform your implementation.
 The protoLabs Studio MCP server exposes knowledge search:
 
 ```typescript
-mcp__protolabs__search_knowledge({
+mcp__plugin_protolabs_studio__search_knowledge({
   projectPath: '/path/to/project',
   query: 'how to add a new memory category',
   maxResults: 5,

--- a/docs/reference/model-resolver.md
+++ b/docs/reference/model-resolver.md
@@ -66,7 +66,7 @@ import { resolveModelString } from '@protolabsai/model-resolver';
 
 // Model resolution happens inside the Lead Engineer INTAKE phase.
 // When creating a feature, specify the alias — the pipeline resolves it:
-mcp__protolabs__create_feature({
+mcp__plugin_protolabs_studio__create_feature({
   projectPath: '/path/to/project',
   title: 'Core Infrastructure',
   model: 'opus', // Resolved to claude-opus-4-6 at INTAKE
@@ -81,14 +81,14 @@ const model = resolveModelString('opus'); // → 'claude-opus-4-6'
 
 ```typescript
 // MCP tool call with alias
-mcp__protolabs__start_agent({
+mcp__plugin_protolabs_studio__start_agent({
   projectPath: '/path/to/project',
   featureId: 'feature-123',
   model: 'sonnet', // Automatically resolved to claude-sonnet-4-6
 });
 
 // Or use full model string
-mcp__protolabs__start_agent({
+mcp__plugin_protolabs_studio__start_agent({
   projectPath: '/path/to/project',
   featureId: 'feature-123',
   model: 'claude-opus-4-6', // Passed through as-is
@@ -195,7 +195,7 @@ Override model selection in `.automaker/settings.json`:
 Specify model when creating a feature:
 
 ```typescript
-mcp__protolabs__create_feature({
+mcp__plugin_protolabs_studio__create_feature({
   projectPath: '/path/to/project',
   title: 'Performance Optimization',
   description: '...',

--- a/docs/reference/workflow-settings.md
+++ b/docs/reference/workflow-settings.md
@@ -134,7 +134,7 @@ interface WorkflowSettings {
 
 When enabled (`true`), the EXECUTE processor runs three checks before launching the agent:
 
-1. **Worktree currency** — syncs worktree with `git fetch` + `git rebase origin/dev`
+1. **Worktree currency** — syncs worktree with `git fetch` + `git rebase origin/main`
 2. **Package builds** — validates required packages compile successfully
 3. **Dependency merge** — verifies all blocking upstream features are merged
 

--- a/docs/self-hosting/orchestration.md
+++ b/docs/self-hosting/orchestration.md
@@ -114,7 +114,7 @@ interface Phase {
 ### Via MCP Tool
 
 ```typescript
-mcp__protolabs__create_project({
+mcp__plugin_protolabs_studio__create_project({
   projectPath: '/path/to/project',
   title: 'User Authentication System',
   goal: 'Implement secure JWT-based authentication',
@@ -189,7 +189,7 @@ curl -X POST http://localhost:3008/api/projects/create \
 Convert project phases to board features with milestones as epics:
 
 ```typescript
-mcp__protolabs__create_project_features({
+mcp__plugin_protolabs_studio__create_project_features({
   projectPath: '/path/to/project',
   projectSlug: 'user-authentication-system',
   createEpics: true, // Create epic for each milestone
@@ -213,7 +213,7 @@ Board Features:
 Convert phases directly to features without epic grouping:
 
 ```typescript
-mcp__protolabs__create_project_features({
+mcp__plugin_protolabs_studio__create_project_features({
   projectPath: '/path/to/project',
   projectSlug: 'user-authentication-system',
   createEpics: false, // No epics
@@ -261,7 +261,7 @@ interface Feature {
 
 ```typescript
 // 1. Create epic feature
-mcp__protolabs__create_feature({
+mcp__plugin_protolabs_studio__create_feature({
   projectPath: '/path/to/project',
   title: 'Foundation Infrastructure',
   description: 'Core types, services, and utilities',
@@ -271,7 +271,7 @@ mcp__protolabs__create_feature({
 });
 
 // 2. Create child features
-mcp__protolabs__create_feature({
+mcp__plugin_protolabs_studio__create_feature({
   projectPath: '/path/to/project',
   title: 'Add Auth Types',
   description: 'TypeScript definitions for auth',
@@ -329,7 +329,7 @@ gh pr create --base main --title "Epic: Foundation Infrastructure"
 **Via MCP Tool:**
 
 ```typescript
-mcp__protolabs__set_feature_dependencies({
+mcp__plugin_protolabs_studio__set_feature_dependencies({
   projectPath: '/path/to/project',
   featureId: 'feature-456',
   dependsOn: ['feature-123', 'feature-789'],
@@ -353,7 +353,7 @@ curl -X POST http://localhost:3008/api/features/set-dependencies \
 **Get dependency graph:**
 
 ```typescript
-const graph = await mcp__protolabs__get_dependency_graph({
+const graph = await mcp__plugin_protolabs_studio__get_dependency_graph({
   projectPath: '/path/to/project',
 });
 ```
@@ -375,7 +375,7 @@ const graph = await mcp__protolabs__get_dependency_graph({
 **Get topologically sorted execution order:**
 
 ```typescript
-const order = await mcp__protolabs__get_execution_order({
+const order = await mcp__plugin_protolabs_studio__get_execution_order({
   projectPath: '/path/to/project',
 });
 ```
@@ -395,7 +395,7 @@ const order = await mcp__protolabs__get_execution_order({
 Auto-mode processes features in dependency order:
 
 ```typescript
-mcp__protolabs__start_auto_mode({
+mcp__plugin_protolabs_studio__start_auto_mode({
   projectPath: '/path/to/project',
   respectDependencies: true, // Wait for dependencies to complete
 });
@@ -586,7 +586,7 @@ ls .automaker/projects/
 **Solution:** Review dependency chain:
 
 ```typescript
-const graph = await mcp__protolabs__get_dependency_graph({
+const graph = await mcp__plugin_protolabs_studio__get_dependency_graph({
   projectPath: '/path/to/project',
 });
 // Visualize to find cycle

--- a/docs/server/model-resolver.md
+++ b/docs/server/model-resolver.md
@@ -51,7 +51,7 @@ import { resolveModelString } from '@protolabsai/model-resolver';
 
 // Model resolution happens inside the Lead Engineer INTAKE phase.
 // When creating a feature, specify the alias — the pipeline resolves it:
-mcp__protolabs__create_feature({
+mcp__plugin_protolabs_studio__create_feature({
   projectPath: '/path/to/project',
   title: 'Core Infrastructure',
   model: 'opus', // Resolved to claude-opus-4-6 at INTAKE
@@ -66,14 +66,14 @@ const model = resolveModelString('opus'); // → 'claude-opus-4-6'
 
 ```typescript
 // MCP tool call with alias
-mcp__protolabs__start_agent({
+mcp__plugin_protolabs_studio__start_agent({
   projectPath: '/path/to/project',
   featureId: 'feature-123',
   model: 'sonnet', // Automatically resolved to claude-sonnet-4-6
 });
 
 // Or use full model string
-mcp__protolabs__start_agent({
+mcp__plugin_protolabs_studio__start_agent({
   projectPath: '/path/to/project',
   featureId: 'feature-123',
   model: 'claude-opus-4-6', // Passed through as-is
@@ -141,7 +141,7 @@ Override model selection in `.automaker/settings.json`:
 Specify model when creating a feature:
 
 ```typescript
-mcp__protolabs__create_feature({
+mcp__plugin_protolabs_studio__create_feature({
   projectPath: '/path/to/project',
   title: 'Performance Optimization',
   description: '...',


### PR DESCRIPTION
First (mechanical, low-risk) batch from the docs deep audit (#4076).

## Changes
- **MCP tool prefix** — replace stale `mcp__protolabs__` with the real plugin-namespaced `mcp__plugin_protolabs_studio__` (the form used in all 291 plugin command-file references) across 17 docs.
- **Stale `dev` base branch** — there is no `dev` branch (single-trunk `feature/* → main`). Fixed `origin/dev → origin/main` and `prBaseBranch` default `dev → main` in: lead-engineer-pipeline, workflow-settings, git-workflow-service, automation-registry, worktree-recovery-service, custom-workflows.

## Deferred to themed batches (tracked in #4076)
Phantom-tool removal (e.g. `compact_memory`, `langfuse_*`), model-resolution rewrite, `/devops → /frank` prose, duplicate-file deletions, and the pure-executor / SDK-migration narrative rewrites.

Content-only; no link/structure changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)