### PR TITLE
docs: correct pure-executor service docs (audit batch 5)

### DIFF
--- a/docs/internal/server/git-workflow-service.md
+++ b/docs/internal/server/git-workflow-service.md
@@ -4,65 +4,48 @@ Post-execution automation that commits, pushes, and creates pull requests after 
 
 ## Overview
 
-`GitWorkflowService` runs immediately after an agent finishes a feature in auto-mode. It handles the full git pipeline:
+`GitWorkflowService.runPostCompletionWorkflow()` is the **single guarded PR-creation chokepoint**. It runs after an agent finishes a feature and handles the full git pipeline, each step gated by the resolved git-workflow settings:
 
-- **Commit** staged changes with a feature-title-derived message
-- **Push** the branch to remote
-- **Create PR** via `gh` CLI with issue-closing references
-- **Resolve bot review threads** via `CodeRabbitResolverService`
-- **Merge** the PR according to configured `AutoMergeSettings`
-- **Retry** all operations with exponential backoff (3 attempts: 2s, 4s, 8s delays)
+- **Commit** staged changes with a feature-title-derived message (`autoCommit`)
+- **Push** the branch to remote (`autoPush`)
+- **Create PR** via `gh` CLI with issue-closing references and an ownership watermark (`autoCreatePR`)
+- **Auto-merge** the PR when enabled and eligible (`autoMergePR`)
+- **Enforce the epic-base invariant** — features in an epic must base their PR on the epic branch, never on `main` (auto-creates the epic branch on the remote if missing)
+- **Retry** push/PR operations with exponential backoff
+
+Read-only features short-circuit before any git work (it logs a warning for `featureType: code` read-only features, since that usually means a mis-route — see [issue #4073]).
 
 ## Architecture
 
-```text
-GitWorkflowService
-  ├── commitAndPush()           — stage, commit, push
-  ├── createPullRequest()       — gh pr create with ownership watermark
-  ├── mergePR()                 — CodeRabbitResolverService + GitHubMergeService
-  └── merge()                   — public entry point (full pipeline)
-```
-
-### Full Pipeline Flow
+`runPostCompletionWorkflow` is the only public workflow entry point; the steps are private helpers it calls in sequence:
 
 ```text
-merge(feature, worktreePath, settings)
-  → commitAndPush()
-      → git add (pathspec-based staging)
-      → git commit -m "feat: <title>"
-      → git push -u origin <branch>
-  → createPullRequest()
-      → Build PR body with feature summary + issue close refs ("Closes #<id>")
-      → Append PR ownership watermark
-      → gh pr create --base <prBaseBranch>
-  → mergePR()
-      → codeRabbitResolverService.resolveThreads()   — clear bot threads
-      → mergeEligibilityService.evaluatePR()          — check auto-merge settings
-      → githubMergeService.mergePR()                  — gh pr merge
+runPostCompletionWorkflow(projectPath, featureId, feature, workDir, settings, epicBranchName?, events?, projectPrBaseBranch?)
+  → read-only? → log + return null (no git work)
+  → resolveGitWorkflowSettings(feature, settings, projectPrBaseBranch)
+  → resolve PR base branch (epic-base invariant: epic children base on the epic branch)
+  → if autoCommit  → commitChanges()           (pathspec staging + prettier; amend/force paths for already-pushed branches)
+  → if autoPush    → pushToRemote()             (--force-with-lease when needed)
+  → if autoCreatePR→ createPullRequest()        (PR body + "Closes #<id>" + ownership watermark; size/critical-thread gates)
+  → if autoMergePR → CodeRabbit thread resolution + GitHubMergeService merge
   → GitWorkflowResult
 ```
 
+There is no `merge()` / `commitAndPush()` / `mergePR()` method — those are not real. `saveAgentProgress()` (a lightweight WIP commit+push, no PR) and `resolveGitWorkflowSettings()` are the other public methods.
+
 ## Configuration
 
-Settings come from `GitWorkflowSettings` in `.automaker/settings.json`:
+Settings resolve through `resolveGitWorkflowSettings()`, which merges per-feature `gitWorkflow` overrides over global `GitWorkflowSettings` over `DEFAULT_GIT_WORKFLOW_SETTINGS` (`libs/types/src/git-settings.ts`). Key fields:
 
-```typescript
-interface GitWorkflowSettings {
-  commitMessage?: string; // default: derived from feature title
-  prBaseBranch?: string; // default: 'main'
-  prTemplate?: string; // PR body template
-  autoMerge?: boolean; // enable auto-merge
-  mergeStrategy?: PRMergeStrategy; // 'merge' | 'squash' | 'rebase'
-  closeIssues?: boolean; // add "Closes #<id>" refs
-}
-```
-
-| Setting         | Default    | Description                                 |
-| --------------- | ---------- | ------------------------------------------- |
-| `prBaseBranch`  | `'main'`   | Target branch for PR creation               |
-| `mergeStrategy` | `'squash'` | How the PR is merged                        |
-| `autoMerge`     | `true`     | Enable GitHub auto-merge if CI is pending   |
-| `closeIssues`   | `true`     | Include issue-closing references in PR body |
+| Setting           | Default    | Description                                                |
+| ----------------- | ---------- | ---------------------------------------------------------- |
+| `autoCommit`      | `true`     | Commit staged changes                                      |
+| `autoPush`        | `true`     | Push to remote (requires `autoCommit`)                     |
+| `autoCreatePR`    | `true`     | Create the PR (requires `autoPush`)                        |
+| `autoMergePR`     | `true`     | Enable auto-merge after creation (requires `autoCreatePR`) |
+| `prMergeStrategy` | `'squash'` | How the PR is merged (`merge` \| `squash` \| `rebase`)     |
+| `waitForCI`       | —          | Wait for CI before merging                                 |
+| `prBaseBranch`    | `'main'`   | Target branch for PR creation                              |
 
 ## PR Ownership Watermark
 
@@ -103,6 +86,6 @@ interface GitWorkflowResult {
 
 ## See Also
 
-- [Worktree Recovery Service](./worktree-recovery-service) — fallback path when agent exits with uncommitted work
-- [Auto Mode Service](./auto-mode-service) — calls `gitWorkflowService.merge()` on execution success
+- [Worktree Recovery Service](./worktree-recovery-service) — fallback path when an agent exits with uncommitted work (commit + push only, no PR)
+- [Lead Engineer Service](./lead-engineer-service) — drives feature execution and invokes `runPostCompletionWorkflow` on success
 - [GitHub Merge Service](./github-merge-service) — handles the actual merge call

--- a/docs/internal/server/worktree-recovery-service.md
+++ b/docs/internal/server/worktree-recovery-service.md
@@ -1,6 +1,6 @@
 # Worktree Recovery Service
 
-Post-agent safety net that detects uncommitted work after an agent exits and automatically creates a PR to preserve the work.
+Post-agent safety net that detects uncommitted work after an agent exits and **preserves it (commit + push)**. It does **not** create a PR — PR creation is owned by the single guarded chokepoint (`GitWorkflowService.runPostCompletionWorkflow`), per the pure-executor principle.
 
 ## Overview
 
@@ -10,11 +10,10 @@ Post-agent safety net that detects uncommitted work after an agent exits and aut
 2. **Formats** changed files with Prettier (non-fatal if it fails)
 3. **Stages** changes using pathspec-based `git add`, with fallback to `git add .`
 4. **Commits** with `--no-verify` and `HUSKY=0` to bypass pre-commit hooks
-5. **Rebases** onto `origin/<baseBranch>` to avoid conflicting PRs
-6. **Pushes** the branch to remote
-7. **Creates a PR** via `gh pr create` and **enables auto-merge** (`--squash`)
+5. **Rebases** onto `origin/<baseBranch>` to avoid diverging from the base
+6. **Pushes** the branch to remote — and **stops there**
 
-The function returns a structured `WorktreeRecoveryResult`. The **caller** is responsible for updating feature status and emitting events.
+It never calls `gh pr create` or enables auto-merge. The net exists only to keep work from being lost; turning that work into a PR is a separate, guarded step. The function returns a structured `WorktreeRecoveryResult`; the **caller** updates feature status and emits events.
 
 ## Recovery Flow
 
@@ -29,18 +28,16 @@ checkAndRecoverUncommittedWork(feature, worktreePath, projectPath, prBaseBranch?
   → Step 3: git commit --no-verify -m "refactor: <feature title>"  (HUSKY=0)
   → Step 3.5: git fetch origin <baseBranch> && git rebase origin/<baseBranch>
       → conflict? → git rebase --abort, push without rebase
-  → Step 4: git push [-–force-with-lease] -u origin <branchName>
-  → Step 5: gh pr create --base <baseBranch> --head <branchName>
-  → gh pr merge <prNumber> --auto --squash
-  → return { detected: true, recovered: true, prUrl, prNumber, prCreatedAt }
+  → Step 4: git push [--force-with-lease] -u origin <branchName>
+  → return { detected: true, recovered: true }   // work preserved; NO PR
 ```
 
 ## Rebase Strategy
 
-After committing, the service fetches and rebases onto `origin/<baseBranch>` (default: `main`). This prevents the PR from diverging from the base branch.
+After committing, the service fetches and rebases onto `origin/<baseBranch>` (default: `main`). This keeps the pushed branch from diverging from the base.
 
 - **On success:** push uses `--force-with-lease` (safe force push)
-- **On conflict:** rebases is aborted, push proceeds without force flag
+- **On conflict:** the rebase is aborted, push proceeds without the force flag
 
 Branch name is sanitized (`/[^a-zA-Z0-9_./-]/g` stripped) to prevent shell injection.
 
@@ -49,10 +46,7 @@ Branch name is sanitized (`/[^a-zA-Z0-9_./-]/g` stripped) to prevent shell injec
 ```typescript
 interface WorktreeRecoveryResult {
   detected: boolean; // uncommitted changes were found
-  recovered: boolean; // commit + push + PR succeeded
-  prUrl?: string; // e.g., https://github.com/org/repo/pull/42
-  prNumber?: number;
-  prCreatedAt?: string; // ISO-8601 timestamp
+  recovered: boolean; // work preserved (commit + push succeeded); PR creation is NOT done here
   error?: string; // message if recovery failed
 }
 ```
@@ -74,5 +68,5 @@ If the pathspec stages nothing (e.g., all files are in unusual locations), the s
 
 ## See Also
 
-- [Git Workflow Service](./git-workflow-service) — the primary happy-path git pipeline (agent commits correctly)
-- [Auto Mode Service](./auto-mode-service) — owns the execution loop that triggers recovery
+- [Git Workflow Service](./git-workflow-service) — the happy-path git pipeline and the single guarded PR-creation chokepoint (`runPostCompletionWorkflow`)
+- [Lead Engineer Service](./lead-engineer-service) — owns the execution loop that triggers recovery


### PR DESCRIPTION
Fifth batch from the docs deep audit (#4076): fix two server-service docs that described **self-directed PR side-effects the code does not do** and that CLAUDE.md's pure-executor principle forbids. Verified against the service source.

## Changes
- **`worktree-recovery-service.md`** — removed the "creates a PR via `gh pr create` + enables auto-merge" claim and the `prUrl`/`prNumber`/`prCreatedAt` result fields. The recovery net **preserves work (commit + push) and stops** — PR creation is the single guarded chokepoint's job (matches the service's own header comment).
- **`git-workflow-service.md`** — replaced the fictional `merge()` / `commitAndPush()` / `mergePR()` architecture and the made-up `GitWorkflowSettings` interface with the real `runPostCompletionWorkflow` entry point, its `autoCommit`/`autoPush`/`autoCreatePR`/`autoMergePR`-gated steps, `ResolvedGitWorkflowSettings` fields, the epic-base invariant, and the #4073 read-only warning. Fixed a dead See-Also link.

Internal docs (excluded from the public VitePress build); links verified against existing pages.

## Deferred
The broader Ava-as-orchestrator narrative (`how-it-works`, `agency-*`, `org-architecture`, `authority/*`) — same theme, larger prose — is a follow-up batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)