### PR TITLE
docs: fix command references — /frank + real plugin commands (audit batch 7+8)

### DIFF
--- a/docs/integrations/claude-plugin.md
+++ b/docs/integrations/claude-plugin.md
@@ -67,27 +67,31 @@ claude
 > /board
 ```
 
-That's it! You now have access to ~170 MCP tools and slash commands for managing your Kanban board directly from Claude Code.
+That's it! You now have access to ~159 MCP tools and 19 slash commands for managing your Kanban board directly from Claude Code.
 
 ### What You Can Do
 
-| Command            | Description                                       |
-| ------------------ | ------------------------------------------------- |
-| `/welcome`         | User onboarding and status refresh                |
-| `/board`           | View and manage your Kanban board                 |
-| `/auto-mode`       | Start/stop autonomous feature processing          |
-| `/orchestrate`     | Manage feature dependencies                       |
-| `/context`         | Manage AI agent context files                     |
-| `/plan-project`    | Full project orchestration pipeline               |
-| `/ship`            | Stage, commit, push, create PR, auto-merge        |
-| `/headsdown`       | Deep work mode — process features autonomously    |
-| `/due-diligence`   | Validate approaches with evidence-based research  |
-| `/deep-research`   | Research codebase before planning                 |
-| `/sparc-prd`       | Create a SPARC-style PRD                          |
-| `/improve-prompts` | Analyze and improve LLM prompts                   |
-| `/ava`             | Autonomous operator with multi-project delegation |
-| `/setuplab`        | 7-phase project onboarding pipeline               |
-| `/update-plugin`   | Guided plugin version upgrade                     |
+| Command              | Description                                        |
+| -------------------- | -------------------------------------------------- |
+| `/welcome`           | User onboarding and status refresh                 |
+| `/board`             | View and manage your Kanban board                  |
+| `/auto-mode`         | Start/stop autonomous feature processing           |
+| `/orchestrate`       | Manage feature dependencies                        |
+| `/context`           | Manage AI agent context files                      |
+| `/plan-project`      | Full project orchestration pipeline                |
+| `/ship`              | Stage, commit, push, create PR, auto-merge         |
+| `/roxy`              | Per-project autonomous operator (CLI-driven)       |
+| `/cli-control`       | Manage the board and crew via the `protomaker` CLI |
+| `/quinn`             | QA engineer — release verification, regression     |
+| `/bug_triage`        | Autonomous PR remediation and antagonistic review  |
+| `/due-diligence`     | Validate approaches with evidence-based research   |
+| `/deep-research`     | Research codebase before planning                  |
+| `/sparc-prd`         | Create a SPARC-style PRD                           |
+| `/improve-prompts`   | Analyze and improve LLM prompts                    |
+| `/provision_discord` | Provision a Discord category and project channels  |
+| `/setup-tracing`     | Set up Langfuse tracing for Claude Code            |
+| `/setuplab`          | Project onboarding pipeline                        |
+| `/update-plugin`     | Guided plugin version upgrade                      |
 
 See [Plugin Commands](./plugin-commands.md) for full command reference and examples.
 
@@ -213,7 +217,7 @@ The plugin configuration is in `packages/mcp-server/plugins/automaker/.claude-pl
 {
   "name": "automaker",
   "description": "protoLabs Studio — AI Development Studio. Manage Kanban boards, AI agents, and feature orchestration.",
-  "version": "1.1.1",
+  "version": "<managed by the release process>",
   "mcpServers": {
     "automaker": {
       "command": "bash",

--- a/docs/integrations/codex-migration-map.md
+++ b/docs/integrations/codex-migration-map.md
@@ -23,23 +23,23 @@ There are two main Claude-oriented layers in this repo:
 
 ## Recommended Codex Mapping
 
-| Existing Asset Type                 | Current Location                                                                 | Codex-Native Target                         | Notes                                                  |
-| ----------------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------ |
-| Repo rules                          | `CLAUDE.md`, `.claude/settings.json`                                             | `AGENTS.md`                                 | Keep stable instructions here                          |
-| Ava operator workflow               | `plugins/.../commands/ava.md`                                                    | `.codex/skills/ava/SKILL.md`                | Main orchestration skill                               |
-| Headsdown workflow                  | `plugins/.../commands/headsdown.md`                                              | `.codex/skills/headsdown/SKILL.md`          | Continuous deep work skill                             |
-| Lightweight operational specialists | `.claude/skills/board-janitor.md`, `.claude/skills/pr-maintainer.md`             | Ava playbooks first                         | Promote to full skills only if needed                  |
-| Team role specialists               | `.claude/skills/matt.md`, `kai.md`, `frank.md`, `jon.md`, `cindi.md`             | future Codex skills or subagent conventions | Create only as demand appears                          |
-| Analysis agents                     | `.claude/agents/deepdive.md`, `deepcode.md`, `security-vulnerability-scanner.md` | future subagent patterns                    | Better as delegation patterns than static prose clones |
-| Plugin commands                     | `plugins/.../commands/*.md`                                                      | Codex skills selectively                    | Only port the workflows that matter                    |
-| Capability tools                    | `packages/mcp-server/`                                                           | unchanged MCP server                        | Reuse directly from Codex                              |
+| Existing Asset Type           | Current Location                                                                 | Codex-Native Target                         | Notes                                                  |
+| ----------------------------- | -------------------------------------------------------------------------------- | ------------------------------------------- | ------------------------------------------------------ |
+| Repo rules                    | `CLAUDE.md`, `.claude/settings.json`                                             | `AGENTS.md`                                 | Keep stable instructions here                          |
+| Per-project operator workflow | `plugins/.../commands/roxy.md`                                                   | `.codex/skills/roxy/SKILL.md`               | Main per-project orchestration skill                   |
+| CLI-control workflow          | `plugins/.../commands/cli-control.md`                                            | `.codex/skills/cli-control/SKILL.md`        | Deterministic board/crew control via the CLI           |
+| Operational utility skills    | `.claude/skills/board_health.md`, `.claude/skills/plan_resume.md`                | Roxy playbooks first                        | Promote to full skills only if needed                  |
+| Team role specialists         | `.claude/commands/matt.md`, `kai.md`, `frank.md`, `sam.md`                       | future Codex skills or subagent conventions | Create only as demand appears                          |
+| Analysis agents               | `.claude/agents/deepdive.md`, `deepcode.md`, `security-vulnerability-scanner.md` | future subagent patterns                    | Better as delegation patterns than static prose clones |
+| Plugin commands               | `plugins/.../commands/*.md`                                                      | Codex skills selectively                    | Only port the workflows that matter                    |
+| Capability tools              | `packages/mcp-server/`                                                           | unchanged MCP server                        | Reuse directly from Codex                              |
 
 ## Immediate Migration Set
 
 These are the highest-value Codex-native equivalents to maintain operator continuity:
 
-- `ava`
-- `headsdown`
+- `roxy`
+- `cli-control`
 - `deep-research`
 - `deep-dive`
 - `due-diligence`
@@ -52,28 +52,27 @@ These are the highest-value Codex-native equivalents to maintain operator contin
 These should likely come next if the Codex workflow sticks:
 
 - `setuplab`
-- role-specialist skills such as `matt`, `kai`, `frank`, `jon`, `cindi`
+- role-specialist skills such as `matt`, `kai`, `frank`, `sam`
 
 ## Team Skill Interpretation
 
-The project-level Claude skills split into two groups:
+The project-level Claude assets split into two groups:
 
 ### Specialist Implementers
 
 - `matt`
 - `kai`
 - `frank`
-- `jon`
-- `cindi`
+- `sam`
 
-These map well to future Codex skills if you want explicit role activation.
+These team personas live in `.claude/commands/` and map well to future Codex skills if you want explicit role activation.
 
 ### Operational Utilities
 
-- `pr-maintainer`
-- `board-janitor`
+- `board_health`
+- `plan_resume`
 
-These may not need standalone skills immediately. Many of their behaviors can live as Ava playbooks until the workflow volume justifies separate Codex skills.
+These `.claude/skills/` helpers may not need standalone skills immediately. Many of their behaviors can live as Roxy playbooks until the workflow volume justifies separate Codex skills.
 
 ## Agent Interpretation
 

--- a/docs/integrations/plugin-commands.md
+++ b/docs/integrations/plugin-commands.md
@@ -201,21 +201,49 @@ Ship current changes with full git workflow automation.
 - Enables auto-merge
 - Handles conflicts automatically
 
-### /headsdown
+### /roxy
 
-Deep work mode for autonomous feature processing.
+Per-project autonomous operator. Manages a single project board end-to-end using only the `protomaker` CLI (no MCP tools).
 
 ```bash
-/headsdown                # Enter deep work mode
+/roxy                     # Operate the current project
+/roxy /path/to/project    # Operate a specific project
 ```
 
 **What It Does:**
 
-- Autonomously processes features from the backlog
-- Merges approved PRs
-- Grooms the board
-- Stays productive until the system is void of work
-- Minimal human interaction required
+- Creates features, dispatches crew, monitors agents, merges PRs
+- Scoped to one repo — the per-project operator role
+- Drives everything through the `protomaker` CLI for deterministic control
+
+### /cli-control
+
+Manage the board and crew entirely through the `protomaker` CLI (no MCP).
+
+```bash
+/cli-control              # Drive the board via the CLI
+```
+
+**What It Does:**
+
+- Deterministic shell control over features, agents, auto-mode, and PRs
+- Useful when MCP is unavailable, in scripts/CI, or for repeatable automation
+
+### /quinn
+
+QA engineer persona — validates releases, runs regression checks, verifies service wiring, tests API endpoints, and generates pass/fail reports.
+
+```bash
+/quinn                    # Activate Quinn for QA work
+```
+
+### /bug_triage
+
+Autonomous PR remediation. Triages a failing or blocked PR, files a fix feature on the target project board, then antagonistically reviews on completion. Dispatched by protoWorkstacean's pr-remediator plugin.
+
+```bash
+/bug_triage               # Triage and remediate a failing/blocked PR
+```
 
 ### /due-diligence
 
@@ -282,28 +310,21 @@ Analyze, critique, and improve prompts for LLM agents.
 - Identifies anti-patterns
 - Rewrites with improvements and explanations
 
-### /ava
+### /provision_discord
 
-Autonomous operator -- identifies friction, ships fixes, keeps work flowing. Supports multi-project delegation across repos.
+Provision a Discord category and the standard set of project channels (e.g. `#dev`).
 
 ```bash
-/ava                      # Activate in current project
-/ava /path/to/project     # Activate for a specific project
+/provision_discord        # Set up a Discord category and channels
 ```
 
-**Capabilities:**
+### /setup-tracing
 
-- Full control surface: features, agents, worktrees, PRs, context files, auto-mode
-- Multi-project awareness -- can switch between repos
-- Delegation tree: spawns subagents for parallel work
-- Autonomous decision-making: creates features, starts agents, merges PRs
-- Session continuity: state persists across compaction via hooks
+Set up Langfuse tracing for Claude Code in the current project. Configures the Stop hook and environment variables so every conversation turn is traced.
 
-**When to Use:**
-
-- Hands-off autonomous operation ("go work on the backlog")
-- Operational leadership across multiple projects
-- When things need to get done without step-by-step guidance
+```bash
+/setup-tracing            # Configure Langfuse tracing
+```
 
 ### /setuplab
 
@@ -340,11 +361,9 @@ Guided plugin version upgrade. Handles uninstall, reinstall, env migration, and 
 - Migrates environment variables
 - Verifies MCP server connectivity
 
-> **Note:** This is a temporary command for early tester onboarding. It will be removed once all testers are on v0.15.x+.
-
 ## Subagents
 
-The plugin includes 13 specialized agents for complex tasks. Invoke them via the `Task` tool with `subagent_type: "protolabs:<agent-name>"`.
+The plugin includes 11 specialized agents for complex tasks. Invoke them via the `Task` tool with `subagent_type: "protolabs:<agent-name>"`.
 
 ### protolabs:feature-planner
 
@@ -434,23 +453,27 @@ Backup and restore Docker volumes.
 
 ### Command Models
 
-| Command            | Model  | Rationale                    |
-| ------------------ | ------ | ---------------------------- |
-| `/welcome`         | Sonnet | Adaptive conversational flow |
-| `/deep-research`   | Haiku  | Fast exploration             |
-| `/board`           | --     | No model (direct tool calls) |
-| `/auto-mode`       | --     | No model (direct tool calls) |
-| `/orchestrate`     | --     | No model (direct tool calls) |
-| `/context`         | --     | No model (direct tool calls) |
-| `/ship`            | --     | No model (direct tool calls) |
-| `/headsdown`       | --     | No model (direct tool calls) |
-| `/improve-prompts` | --     | No model (direct tool calls) |
-| `/due-diligence`   | Sonnet | Evidence-based analysis      |
-| `/plan-project`    | Sonnet | Complex orchestration        |
-| `/sparc-prd`       | Sonnet | Sophisticated analysis       |
-| `/ava`             | --     | No model (direct tool calls) |
-| `/setuplab`        | Sonnet | Complex multi-phase pipeline |
-| `/update-plugin`   | --     | No model (direct tool calls) |
+| Command              | Model  | Rationale                    |
+| -------------------- | ------ | ---------------------------- |
+| `/welcome`           | Sonnet | Adaptive conversational flow |
+| `/deep-research`     | Haiku  | Fast exploration             |
+| `/board`             | --     | No model (direct tool calls) |
+| `/auto-mode`         | --     | No model (direct tool calls) |
+| `/orchestrate`       | --     | No model (direct tool calls) |
+| `/context`           | --     | No model (direct tool calls) |
+| `/ship`              | --     | No model (direct tool calls) |
+| `/roxy`              | --     | No model (CLI-driven)        |
+| `/cli-control`       | --     | No model (CLI-driven)        |
+| `/quinn`             | Sonnet | QA judgment                  |
+| `/bug_triage`        | Sonnet | PR remediation analysis      |
+| `/improve-prompts`   | --     | No model (direct tool calls) |
+| `/due-diligence`     | Sonnet | Evidence-based analysis      |
+| `/plan-project`      | Sonnet | Complex orchestration        |
+| `/sparc-prd`         | Sonnet | Sophisticated analysis       |
+| `/provision_discord` | --     | No model (direct tool calls) |
+| `/setup-tracing`     | --     | No model (direct tool calls) |
+| `/setuplab`          | Sonnet | Complex multi-phase pipeline |
+| `/update-plugin`     | --     | No model (direct tool calls) |
 
 ### Agent Models
 

--- a/docs/integrations/plugin-deep-dive.md
+++ b/docs/integrations/plugin-deep-dive.md
@@ -10,7 +10,7 @@ For setup instructions, see [Claude Plugin Setup](./claude-plugin.md). For comma
 packages/mcp-server/
 ├── src/
 │   ├── index.ts              # MCP server entry point (stdio transport)
-│   └── tools/                # Tool definition modules (22 files)
+│   └── tools/                # Tool definition modules (18 files)
 │       ├── feature-tools.ts
 │       ├── agent-tools.ts
 │       ├── git-tools.ts
@@ -33,12 +33,12 @@ packages/mcp-server/
     │   └── scripts/
     │       ├── post-edit-typecheck.js
     │       └── evaluate-session.js
-    ├── commands/              # Slash command definitions (18 files)
+    ├── commands/              # Slash command definitions (19 files)
     │   ├── board.md
-    │   ├── ava.md
+    │   ├── roxy.md
     │   ├── setuplab.md
     │   └── ...
-    ├── agents/                # Subagent definitions (13 files)
+    ├── agents/                # Subagent definitions (11 files)
     │   ├── feature-planner.md
     │   ├── codebase-analyzer.md
     │   └── ...
@@ -121,26 +121,26 @@ Some tools compute results in the MCP process without a server endpoint:
 
 All tools are defined as static schemas in separate module files under `packages/mcp-server/src/tools/`, then aggregated in `index.ts`.
 
-| Module             | File                     | Description                                    |
-| ------------------ | ------------------------ | ---------------------------------------------- |
-| Feature Management | `feature-tools.ts`       | Feature CRUD, git settings                     |
-| Agent Control      | `agent-tools.ts`         | Start/stop agents, templates, dynamic executor |
-| Queue              | `queue-tools.ts`         | Feature queue (add, list, clear)               |
-| Orchestration      | `orchestration-tools.ts` | Auto-mode, dependencies, execution order       |
-| Context & Skills   | `context-tools.ts`       | Context files, skills CRUD                     |
-| Git & GitHub       | `git-tools.ts`           | PRs, reviews, worktree management              |
-| Git Operations     | `git-ops-tools.ts`       | Repository status and file details             |
-| Worktree Git       | `worktree-git-tools.ts`  | Cherry-pick, stash, abort/continue             |
-| File Operations    | `file-ops-tools.ts`      | Copy, move, browse files                       |
-| Project Lifecycle  | `project-tools.ts`       | Projects, PRD, milestones, phases              |
-| Integrations       | `integration-tools.ts`   | Discord, HITL forms                            |
-| Lead Engineer      | `lead-engineer-tools.ts` | Lead engineer state machine control            |
-| Observability      | `observability-tools.ts` | Langfuse traces, costs, scoring, datasets      |
-| Quarantine         | `quarantine-tools.ts`    | Quarantine entries, trust tiers                |
-| Scheduler          | `scheduler-tools.ts`     | Scheduler status, maintenance tasks            |
-| Setup              | `setup-tools.ts`         | SetupLab: research, gap analysis, alignment    |
-| Utilities          | `utility-tools.ts`       | Health, board summary, briefing, metrics       |
-| Workspace          | `workspace-tools.ts`     | Worktrees, notes, escalation                   |
+| Module             | File                     | Description                                          |
+| ------------------ | ------------------------ | ---------------------------------------------------- |
+| Feature Management | `feature-tools.ts`       | Feature CRUD, git settings                           |
+| Agent Control      | `agent-tools.ts`         | Start/stop agents, output, messaging                 |
+| Queue              | `queue-tools.ts`         | Feature queue (add, list, clear)                     |
+| Orchestration      | `orchestration-tools.ts` | Auto-mode, dependencies, execution order             |
+| Context            | `context-tools.ts`       | Context files CRUD                                   |
+| Git & GitHub       | `git-tools.ts`           | PRs, reviews, worktrees, triage evidence             |
+| Git Operations     | `git-ops-tools.ts`       | Repository status and file details                   |
+| Cross-Repo         | `cross-repo-tools.ts`    | Flag/resolve cross-repo dependencies                 |
+| Project Lifecycle  | `project-tools.ts`       | Projects, PRD, milestones, phases                    |
+| Integrations       | `integration-tools.ts`   | HITL request/response forms                          |
+| Knowledge          | `knowledge-tools.ts`     | Knowledge search, ingest, rebuild, stats             |
+| QA                 | `qa-tools.ts`            | Run QA checks                                        |
+| Lead Engineer      | `lead-engineer-tools.ts` | Lead engineer state machine control                  |
+| Observability      | `observability-tools.ts` | Settings, project/capacity metrics, forecast         |
+| Scheduler          | `scheduler-tools.ts`     | Scheduler status, maintenance tasks                  |
+| Setup              | `setup-tools.ts`         | SetupLab: research, gap analysis, alignment, Discord |
+| Utilities          | `utility-tools.ts`       | Health, board summary, briefing, sitrep              |
+| Workspace          | `workspace-tools.ts`     | Board query, note tabs                               |
 
 Each module exports a `Tool[]` array:
 
@@ -220,7 +220,7 @@ Injects board state into Claude's context. Reads feature JSON files directly fro
 
 #### compaction-prime-directive.sh
 
-Identity restoration after context window compaction. Outputs mandatory instructions to invoke `/ava`, reads the saved session state, and injects hardcoded operational rules (no server restart, no worktree `cd`, max 2-3 concurrent agents).
+Identity restoration after context window compaction. Outputs mandatory instructions to invoke `/roxy`, reads the saved session state, and injects hardcoded operational rules (no server restart, no worktree `cd`, max 2-3 concurrent agents).
 
 Only fires on the `compact` matcher -- not on normal startup or resume.
 
@@ -317,9 +317,9 @@ temporary-reason: '...'
 | Context    | Full conversation history      | Only the prompt provided                      |
 | Use case   | Interactive workflows          | Parallelizable, isolated tasks                |
 
-### Current Commands (17)
+### Current Commands (19)
 
-`/auto-mode`, `/ava`, `/board`, `/context`, `/deep-research`, `/due-diligence`, `/headsdown`, `/improve-prompts`, `/orchestrate`, `/plan-project`, `/promote`, `/setuplab`, `/ship`, `/sparc-prd`, `/update-plugin`, `/welcome`
+`/auto-mode`, `/board`, `/bug_triage`, `/cli-control`, `/context`, `/deep-research`, `/due-diligence`, `/improve-prompts`, `/orchestrate`, `/plan-project`, `/provision_discord`, `/quinn`, `/roxy`, `/setup-tracing`, `/setuplab`, `/ship`, `/sparc-prd`, `/update-plugin`, `/welcome`
 
 ## Session Lifecycle
 

--- a/docs/self-hosting/backup-recovery.md
+++ b/docs/self-hosting/backup-recovery.md
@@ -132,13 +132,16 @@ Add to crontab:
 0 2 * * * /home/user/scripts/backup-automaker.sh >> /var/log/automaker-backup.log 2>&1
 ```
 
-### Using /devops Skill
+### Using Frank (DevOps Persona)
+
+Invoke `/frank` and ask for a backup:
 
 ```
-/devops backup
+/frank
+> back up the volumes
 ```
 
-This interactive command:
+Frank (via the `devops-backup` agent) interactively:
 
 1. Shows current volume sizes
 2. Confirms backup location

--- a/docs/self-hosting/index.md
+++ b/docs/self-hosting/index.md
@@ -135,15 +135,17 @@ sudo systemctl start protomaker
 
 See [deployment.md](./deployment.md) for a complete list of environment variables.
 
-## Using the /devops Skill
+## Using Frank (DevOps Persona)
 
-protoLabs includes a `/devops` skill for managing infrastructure from Claude Code:
+protoLabs ships `/frank`, a DevOps persona for managing infrastructure from Claude Code. Frank takes natural-language requests (and an optional `[project-path]`) rather than fixed subcommands — just describe what you need:
 
 ```
-/devops           # Show container status
-/devops health    # Run health diagnostics
-/devops logs      # Analyze container logs
-/devops backup    # Backup volumes
-/devops restart   # Restart containers
-/devops info      # Show configuration info
+/frank
+> show container status
+> run a health check
+> analyze the container logs
+> back up the volumes
+> restart the containers
 ```
+
+Under the hood Frank can invoke the plugin's devops agents (`devops-health-check`, `devops-logs`, `devops-backup`) to do the work.

--- a/docs/self-hosting/monitoring.md
+++ b/docs/self-hosting/monitoring.md
@@ -45,13 +45,16 @@ Possible statuses:
 - `unhealthy` - Health check failing
 - `starting` - Within start period
 
-### Using the /devops Skill
+### Using Frank (DevOps Persona)
+
+Invoke `/frank` and ask for a health check:
 
 ```
-/devops health
+/frank
+> run a health check
 ```
 
-This runs a comprehensive health check including:
+Frank (via the `devops-health-check` agent) runs a comprehensive health check including:
 
 - Docker daemon status
 - Container states
@@ -92,13 +95,16 @@ Server logs use structured output with levels:
 [ERROR] Failed to connect to database
 ```
 
-### Log Analysis with /devops
+### Log Analysis with Frank
+
+Invoke `/frank` and ask for log analysis:
 
 ```
-/devops logs
+/frank
+> analyze the container logs
 ```
 
-Analyzes container logs for:
+Frank (via the `devops-logs` agent) analyzes container logs for:
 
 - Error patterns and stack traces
 - Warning frequencies

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -4,10 +4,11 @@ Common issues and their solutions.
 
 ## Quick Diagnostics
 
-Run the DevOps health check:
+Run the DevOps health check — invoke `/frank` and ask for a health check:
 
 ```
-/devops health
+/frank
+> run a health check
 ```
 
 Or manually:


### PR DESCRIPTION
Batches 7+8 from the docs deep audit (#4076): command-reference accuracy.

## Theme 7 — `/devops` → `/frank` (self-hosting)
The `/devops` skill doesn't exist; the DevOps persona is **`/frank`** (natural-language, no subcommands). Reframed `/devops health|logs|backup` usages in `index.md`, `troubleshooting.md`, `backup-recovery.md`, `monitoring.md` as `/frank` requests (Frank invokes the `devops-*` agents).

## Theme 8 — plugin commands (integrations)
- Removed nonexistent `/ava`, `/headsdown`, `/promote`; added real `/roxy`, `/cli-control`, `/quinn`, `/bug_triage`, `/provision_discord`, `/setup-tracing`.
- Corrected counts: **19 commands, 11 agents, 18 tool files**.
- Rewrote the `plugin-deep-dive` tools/ module table to the real modules; dropped stale pinned plugin versions; corrected the `codex-migration-map` asset inventory.

Verified against `.claude/commands`, the plugin dirs, and `src/tools`. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)