### PR TITLE
docs: correct fast-path rule facts + legacy statuses (audit batch 9)

### DIFF
--- a/docs/concepts/feature-lifecycle.md
+++ b/docs/concepts/feature-lifecycle.md
@@ -246,7 +246,7 @@ Status transitions emit typed events (via pipeline processors and `FeatureLoader
 | ------------------------ | ------------------------------------------------------------------ |
 | `feature:status-changed` | Every status transition (carries `previousStatus` and `newStatus`) |
 | `feature:completed`      | Feature reaches `done`                                             |
-| `feature:error`          | Feature reaches `failed` or `blocked`                              |
+| `feature:error`          | Feature reaches `blocked`                                          |
 
 These events drive downstream integrations: Langfuse scoring, UI real-time updates, and any custom listeners.
 
@@ -365,7 +365,6 @@ type LeadRuleAction =
   | { type: 'move_feature'; featureId: string; toStatus: FeatureStatus }
   | { type: 'reset_feature'; featureId: string; reason: string }
   | { type: 'unblock_feature'; featureId: string }
-  | { type: 'enable_auto_merge'; featureId: string; prNumber: number }
   | { type: 'resolve_threads_direct'; featureId: string; prNumber: number }
   | { type: 'restart_auto_mode'; projectPath: string; maxConcurrency?: number }
   | { type: 'stop_agent'; featureId: string }

--- a/docs/concepts/pipeline.md
+++ b/docs/concepts/pipeline.md
@@ -266,23 +266,24 @@ When the Lead Engineer can't resolve a situation, signals are routed through the
 
 ## Fast-path supervisor rules
 
-Defined in `apps/server/src/services/lead-engineer-rules.ts`. 16 pure functions (no LLM) that react to events. Key rules:
+Defined in `apps/server/src/services/lead-engineer-rules.ts`. 13 pure functions (no LLM) that react to events. The rules:
 
-| Rule                 | Trigger                          | Action                                    |
-| -------------------- | -------------------------------- | ----------------------------------------- |
-| mergedNotDone        | PR merged, status still review   | Move to done                              |
-| orphanedInProgress   | In-progress >4h, no agent        | Reset to backlog (block if 3+ failures)   |
-| staleDeps            | Blocked + all deps done          | Unblock                                   |
-| autoModeHealth       | Backlog >0 + auto-mode off       | Restart auto-mode                         |
-| staleReview          | Review >30min, no auto-merge     | Enable auto-merge                         |
-| stuckAgent           | Agent running >2h                | Abort and resume with wrap-up prompt      |
-| prApproved           | PR approved                      | Enable auto-merge, resolve threads        |
-| capacityRestart      | Feature completed + more backlog | Restart auto-mode                         |
-| projectCompleting    | All features done                | Trigger project completion                |
-| classifiedRecovery   | Escalation with retryable error  | Auto-retry if confidence >=0.7            |
-| hitlFormResponse     | HITL form submitted              | Retry / provide context / skip / close    |
-| reviewQueueSaturated | Review count >= max (5)          | Log warning, scheduler pauses pickup      |
-| errorBudgetExhausted | Budget exhausted                 | Log warning, restrict to bug-fix features |
+| Rule                 | Trigger                           | Action                                    |
+| -------------------- | --------------------------------- | ----------------------------------------- |
+| mergedNotDone        | PR merged, status still review    | Move to done                              |
+| orphanedInProgress   | In-progress >4h, no agent         | Reset to backlog (block if 3+ failures)   |
+| staleDeps            | Blocked + all deps done           | Unblock                                   |
+| autoModeHealth       | Backlog >0 + auto-mode off        | Restart auto-mode                         |
+| stuckAgent           | Agent running >2h                 | Abort and resume with wrap-up prompt      |
+| capacityRestart      | Feature completed + more backlog  | Restart auto-mode                         |
+| projectCompleting    | All features done                 | Trigger project completion                |
+| prApproved           | PR approved                       | Resolve unresolved threads directly       |
+| threadsBlocking      | Merge blocked by critical threads | Resolve threads directly                  |
+| classifiedRecovery   | Escalation with retryable error   | Auto-retry if confidence >=0.7            |
+| hitlFormResponse     | HITL form submitted               | Retry / provide context / skip / close    |
+| errorBudgetExhausted | Budget exhausted                  | Log warning, restrict to bug-fix features |
+| reviewQueueSaturated | Review count >= max (5)           | Log warning, scheduler pauses pickup      |
+| errorBudgetExhausted | Budget exhausted                  | Log warning, restrict to bug-fix features |
 
 ## Feature status system
 

--- a/docs/concepts/project-lifecycle.md
+++ b/docs/concepts/project-lifecycle.md
@@ -70,23 +70,22 @@ The project lifecycle operates at the **project level**. The [8-phase pipeline](
 
 ## MCP tools
 
-| Tool                     | Description                                                        |
-| ------------------------ | ------------------------------------------------------------------ |
-| `process_idea`           | LangGraph flow to validate idea with optional HITL gate            |
-| `initiate_project`       | Dedup check + create project + write idea doc                      |
-| `generate_project_prd`   | Check for existing PRD, suggest generation if missing              |
-| `approve_project_prd`    | Create board features from milestones                              |
-| `launch_project`         | Set project to "started" + start auto-mode                         |
-| `start_lead_engineer`    | Manually start Lead Engineer for a project (auto-starts on launch) |
-| `get_lifecycle_status`   | Read local state, return current phase + next actions              |
-| `collect_related_issues` | Move existing issues into a project                                |
+| Tool                      | Description                                                        |
+| ------------------------- | ------------------------------------------------------------------ |
+| `initiate_project`        | Dedup check + create project + write idea doc                      |
+| `generate_project_prd`    | Check for existing PRD, suggest generation if missing              |
+| `approve_project_prd`     | Create board features from milestones                              |
+| `create_project_features` | Materialize milestone/phase features onto the board                |
+| `launch_project`          | Set project to "started" + start auto-mode                         |
+| `start_lead_engineer`     | Manually start Lead Engineer for a project (auto-starts on launch) |
+| `get_lifecycle_status`    | Read local state, return current phase + next actions              |
 
 ### MCP tool flow
 
 The tools are designed to be called in sequence, with human gates between steps:
 
 ```
-process_idea → initiate_project → generate_project_prd → [HUMAN REVIEW] → approve_project_prd → launch_project
+initiate_project → generate_project_prd → [HUMAN REVIEW] → approve_project_prd → launch_project
 ```
 
 Each tool checks prerequisites and returns clear error messages if called out of order. The `/plan-project` skill wraps this entire flow with interactive prompts.
@@ -130,7 +129,7 @@ When `launch_project` is called, the server emits a `project:lifecycle:launched`
 
 The Lead Engineer is **not an LLM agent** — it's a service that evaluates fast-path rules (pure functions) on every relevant event. It only invokes LLM agents when a situation exceeds what rules can handle.
 
-**Fast-path rules** (defined in `lead-engineer-rules.ts`, 16 rules total):
+**Fast-path rules** (defined in `lead-engineer-rules.ts`, 13 rules total):
 
 | Rule                 | What it does                                                                   |
 | -------------------- | ------------------------------------------------------------------------------ |
@@ -138,7 +137,8 @@ The Lead Engineer is **not an LLM agent** — it's a service that evaluates fast
 | `orphanedInProgress` | Resets in-progress features with no running agent (>4h); blocks if 3+ failures |
 | `staleDeps`          | Unblocks features when all dependencies are done                               |
 | `autoModeHealth`     | Restarts auto-mode if it stopped unexpectedly                                  |
-| `staleReview`        | Enables auto-merge on PRs stuck in review (>30min)                             |
+| `prApproved`         | Resolves unresolved PR threads directly once the PR is approved                |
+| `threadsBlocking`    | Resolves critical threads directly when they block a merge                     |
 | `stuckAgent`         | Aborts agents running >2h and resumes with wrap-up prompt                      |
 | `capacityRestart`    | Restarts auto-mode when capacity frees up                                      |
 | `projectCompleting`  | Detects when all features are done and triggers completion                     |
@@ -235,7 +235,7 @@ After creation, project files are organized as:
 | ---------------------------------------------------------------- | ------------------------------------------------------ |
 | `apps/server/src/services/project-lifecycle-service.ts`          | Service orchestrating the lifecycle                    |
 | `apps/server/src/services/lead-engineer-service.ts`              | Lead Engineer production orchestrator                  |
-| `apps/server/src/services/lead-engineer-rules.ts`                | 16 fast-path rules (pure functions, no LLM)            |
+| `apps/server/src/services/lead-engineer-rules.ts`                | 13 fast-path rules (pure functions, no LLM)            |
 | `apps/server/src/services/event-ledger-service.ts`               | Append-only JSONL event persistence                    |
 | `apps/server/src/services/project-artifact-service.ts`           | Project artifact persistence                           |
 | `apps/server/src/routes/projects/lifecycle/`                     | Route handlers                                         |

--- a/docs/concepts/reliability.md
+++ b/docs/concepts/reliability.md
@@ -270,7 +270,7 @@ When a feature enters EXECUTE, the Lead Engineer loads trajectories from recentl
 
 ```typescript
 const siblings = features
-  .filter((f) => f.status === 'verified' && f.lastExecutionTime)
+  .filter((f) => f.status === 'done' && f.lastExecutionTime)
   .sort((a, b) => (b.lastExecutionTime || 0) - (a.lastExecutionTime || 0))
   .slice(0, 3); // max 3 reflections
 ```
@@ -366,7 +366,7 @@ interface Feature {
 }
 ```
 
-All 4 git workflow catch blocks in `auto-mode-service.ts` persist errors to `feature.json` instead of silently logging them. Feature status remains unchanged (e.g., stays `verified`) — the error field provides a separate visibility channel.
+All 4 git workflow catch blocks in `auto-mode-service.ts` persist errors to `feature.json` instead of silently logging them. Feature status remains unchanged (e.g., stays `done`) — the error field provides a separate visibility channel.
 
 **Source:** `libs/types/src/feature.ts`, `apps/server/src/services/auto-mode-service.ts`
 


### PR DESCRIPTION
Batch 9 from the docs deep audit (#4076): pipeline/state facts. Verified against `lead-engineer-rules.ts` and `lead-engineer.ts`.

## Changes
- **Fast-path rules: 16 → 13** (`pipeline.md`, `project-lifecycle.md`). Removed the nonexistent `staleReview` rule and the `enable_auto_merge` action; corrected `prApproved`/`threadsBlocking` to "resolve threads directly" (there is no auto-merge rule action). Added the real `threadsBlocking` rule to the tables.
- **`feature-lifecycle.md`** — `feature:error` reaches `blocked` (not legacy `failed`); removed the phantom `enable_auto_merge` `LeadRuleAction` member.
- **`project-lifecycle.md`** — removed nonexistent MCP tools `process_idea` / `collect_related_issues`; flow now starts at `initiate_project`; added the real `create_project_features`.
- **`reliability.md`** — legacy `verified` status → canonical `done`.

Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)