### PR TITLE
fix(auto-mode): surface real worktree-creation error on statusChangeReason (#4086)

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -1827,16 +1827,17 @@ export class AutoModeService {
       } else {
         // Auto-create worktree if it doesn't exist
         logger.info(`Follow-up auto-creating worktree for branch "${branchName}"`);
-        worktreePath = await this.createWorktreeForBranch(
-          projectPath,
-          branchName,
-          feature ?? undefined
-        );
-        if (worktreePath) {
+        try {
+          worktreePath = await this.createWorktreeForBranch(
+            projectPath,
+            branchName,
+            feature ?? undefined
+          );
           workDir = worktreePath;
           logger.info(`Follow-up created worktree for branch "${branchName}": ${workDir}`);
-        } else {
-          const reason = `Follow-up worktree creation failed for branch "${branchName}" (feature ${featureId}). Refusing to fall back to main working tree.`;
+        } catch (worktreeErr) {
+          const detail = worktreeErr instanceof Error ? worktreeErr.message : String(worktreeErr);
+          const reason = `Follow-up worktree creation failed for branch "${branchName}" (feature ${featureId}): ${detail}. Refusing to fall back to main working tree.`;
           logger.error(reason);
           await this.featureLoader.update(projectPath, featureId, {
             status: 'blocked',
@@ -3044,7 +3045,9 @@ Format your response as a structured markdown document.`;
     projectPath: string,
     branchName: string,
     feature?: Feature
-  ): Promise<string | null> {
+  ): Promise<string> {
+    // Throws on failure (with the real git stderr) rather than returning null — the
+    // caller surfaces the message on statusChangeReason so failures are diagnosable (#4086).
     try {
       // Sanitize branch name for directory usage
       const sanitizedName = branchName.replace(/[^a-zA-Z0-9_-]/g, '-');
@@ -3398,8 +3401,16 @@ Format your response as a structured markdown document.`;
 
       return path.resolve(worktreePath);
     } catch (error) {
-      logger.error(`Failed to create worktree for branch "${branchName}":`, error);
-      return null;
+      // Surface the real failure (including git stderr) instead of swallowing it to
+      // null. Callers put this on statusChangeReason so a worktree-creation failure is
+      // diagnosable from the board, not just buried in server logs (#4086).
+      const stderr =
+        error && typeof error === 'object' && 'stderr' in error
+          ? String((error as { stderr: unknown }).stderr).trim()
+          : '';
+      const detail = stderr || (error instanceof Error ? error.message : String(error));
+      logger.error(`Failed to create worktree for branch "${branchName}": ${detail}`);
+      throw new Error(`git worktree creation failed for "${branchName}": ${detail}`);
     }
   }
 

--- a/apps/server/src/services/auto-mode/execution-service.ts
+++ b/apps/server/src/services/auto-mode/execution-service.ts
@@ -523,18 +523,20 @@ export class ExecutionService {
         } else {
           // Auto-create worktree if it doesn't exist
           logger.info(`Auto-creating worktree for branch "${branchName}"`);
-          worktreePath = await this.callbacks.createWorktreeForBranch(
-            projectPath,
-            branchName,
-            feature
-          );
-          if (worktreePath) {
+          try {
+            worktreePath = await this.callbacks.createWorktreeForBranch(
+              projectPath,
+              branchName,
+              feature
+            );
             logger.info(`Created worktree for branch "${branchName}": ${worktreePath}`);
-          } else {
+          } catch (worktreeErr) {
             // FATAL: Never fall back to projectPath when worktrees are enabled.
             // Falling back silently causes agents to write into the main working tree,
-            // corrupting it and losing work from other features.
-            const reason = `Worktree creation failed for branch "${branchName}" (feature ${featureId}). Blocking feature to prevent main working tree corruption.`;
+            // corrupting it and losing work from other features. Surface the real
+            // failure (git stderr) on statusChangeReason so it's diagnosable (#4086).
+            const detail = worktreeErr instanceof Error ? worktreeErr.message : String(worktreeErr);
+            const reason = `Worktree creation failed for branch "${branchName}" (feature ${featureId}): ${detail}. Blocking feature to prevent main working tree corruption.`;
             logger.error(reason);
             await this.featureLoader.update(projectPath, featureId, {
               status: 'blocked',
@@ -625,26 +627,28 @@ Output the branch name only.`,
         );
         if (!worktreePath) {
           logger.info(`Auto-creating worktree for generated branch "${generatedBranchName}"`);
-          worktreePath = await this.callbacks.createWorktreeForBranch(
-            projectPath,
-            generatedBranchName,
-            feature
-          );
-        }
-        if (!worktreePath) {
-          const reason = `Worktree creation failed for generated branch "${generatedBranchName}" (feature ${featureId}).`;
-          logger.error(reason);
-          await this.featureLoader.update(projectPath, featureId, {
-            status: 'blocked',
-            statusChangeReason: reason,
-          });
-          this.events.emit('feature:error', {
-            projectPath,
-            featureId,
-            error: reason,
-            projectSlug: feature?.projectSlug,
-          });
-          return;
+          try {
+            worktreePath = await this.callbacks.createWorktreeForBranch(
+              projectPath,
+              generatedBranchName,
+              feature
+            );
+          } catch (worktreeErr) {
+            const detail = worktreeErr instanceof Error ? worktreeErr.message : String(worktreeErr);
+            const reason = `Worktree creation failed for generated branch "${generatedBranchName}" (feature ${featureId}): ${detail}.`;
+            logger.error(reason);
+            await this.featureLoader.update(projectPath, featureId, {
+              status: 'blocked',
+              statusChangeReason: reason,
+            });
+            this.events.emit('feature:error', {
+              projectPath,
+              featureId,
+              error: reason,
+              projectSlug: feature?.projectSlug,
+            });
+            return;
+          }
         }
       }
 

--- a/apps/server/src/services/auto-mode/execution-types.ts
+++ b/apps/server/src/services/auto-mode/execution-types.ts
@@ -84,11 +84,12 @@ export interface IAutoModeCallbacks {
 
   // Worktree management
   findExistingWorktreeForBranch(projectPath: string, branchName: string): Promise<string | null>;
+  /** Throws on failure (carrying the real git stderr) so callers can surface it (#4086). */
   createWorktreeForBranch(
     projectPath: string,
     branchName: string,
     feature: Feature
-  ): Promise<string | null>;
+  ): Promise<string>;
 
   // State persistence
   saveExecutionState(projectPath: string): Promise<void>;

--- a/apps/server/tests/unit/services/worktree-creation-base-branch.test.ts
+++ b/apps/server/tests/unit/services/worktree-creation-base-branch.test.ts
@@ -536,17 +536,13 @@ describe('AutoModeService - createWorktreeForBranch base branch resolution', () 
       branchName: 'feature/test-branch',
     });
 
-    const result = await (svc as any).createWorktreeForBranch(
-      PROJECT_PATH,
-      BRANCH_NAME,
-      childFeature
-    );
-
-    // Auto-push failed → worktree creation should return null (escalates to blocked)
-    expect(result).toBeNull();
+    // Auto-push failed → worktree creation throws with the real stderr (escalates to
+    // blocked; the caller surfaces the message on statusChangeReason — #4086).
+    await expect(
+      (svc as any).createWorktreeForBranch(PROJECT_PATH, BRANCH_NAME, childFeature)
+    ).rejects.toThrow(/permission denied to refs\/heads\/epic\/my-feature/);
     expect(mockLogger.error).toHaveBeenCalledWith(
-      expect.stringContaining(`Failed to create worktree for branch "${BRANCH_NAME}"`),
-      expect.any(Error)
+      expect.stringContaining(`Failed to create worktree for branch "${BRANCH_NAME}"`)
     );
   });
 });

--- a/apps/server/tests/unit/services/worktree-fallback-guard.test.ts
+++ b/apps/server/tests/unit/services/worktree-fallback-guard.test.ts
@@ -279,32 +279,35 @@ describe('Worktree fallback guard', () => {
   });
 
   describe('when worktree creation fails and useWorktrees is true', () => {
-    it('blocks the feature instead of falling back to projectPath', async () => {
+    it('blocks the feature and surfaces the real error on statusChangeReason (#4086)', async () => {
       const callbacks = makeCallbacks(feature, {
         findExistingWorktreeForBranch: vi.fn(async () => null),
-        createWorktreeForBranch: vi.fn(async () => null), // Simulates failure
+        // Simulates failure: createWorktreeForBranch throws with the real git stderr.
+        createWorktreeForBranch: vi.fn(async () => {
+          throw new Error('git worktree creation failed for "feature/wt-test": fatal: boom');
+        }),
       });
       const service = makeService(callbacks, featureLoader, recoveryService, events);
 
       await service.executeFeature(PROJECT_PATH, FEATURE_ID, true);
 
-      // Feature should be updated to blocked status
+      // Feature should be blocked AND carry the real underlying error (not just the generic reason)
       expect(featureLoader.update).toHaveBeenCalledWith(
         PROJECT_PATH,
         FEATURE_ID,
         expect.objectContaining({
           status: 'blocked',
-          statusChangeReason: expect.stringContaining('Worktree creation failed'),
+          statusChangeReason: expect.stringContaining('fatal: boom'),
         })
       );
 
-      // Error event should be emitted
+      // Error event should be emitted with the surfaced detail
       expect(events.emit).toHaveBeenCalledWith(
         'feature:error',
         expect.objectContaining({
           projectPath: PROJECT_PATH,
           featureId: FEATURE_ID,
-          error: expect.stringContaining('Worktree creation failed'),
+          error: expect.stringContaining('fatal: boom'),
         })
       );
 
@@ -322,7 +325,10 @@ describe('Worktree fallback guard', () => {
       const noBranchFeature = makeFeature({ branchName: null });
       const callbacks = makeCallbacks(noBranchFeature, {
         findExistingWorktreeForBranch: vi.fn(async () => null),
-        createWorktreeForBranch: vi.fn(async () => null), // creation fails
+        // creation fails — throws with the real git stderr
+        createWorktreeForBranch: vi.fn(async () => {
+          throw new Error('git worktree creation failed: fatal: boom');
+        }),
       });
       const noBranchLoader = makeFeatureLoader(noBranchFeature);
       const service = makeService(callbacks, noBranchLoader, recoveryService, events);


### PR DESCRIPTION
Part 1 of #4086 — make the swallowed worktree-creation failure diagnosable.

## Problem
`createWorktreeForBranch` caught the underlying `git worktree add` (or pre-step) failure and `return null`, so a blocked feature only showed the generic *"Worktree creation failed … Blocking feature to prevent main working tree corruption."* The real stderr never reached `statusChangeReason` and wasn't obvious in logs — making the failure undebuggable from the board. This is the last blocker for autonomous delivery on a managed project (surfaced while validating #4075).

## Fix
`createWorktreeForBranch` now **throws** on failure carrying the real git stderr (or error message) instead of returning `null`. The three call sites — execution-service primary path, execution-service generated-branch path, and auto-mode-service follow-up path — catch it and include the detail in `statusChangeReason` + the `feature:error` event. The fallback guard is unchanged: it still refuses to run in the main working tree.

- `execution-types.ts`: `createWorktreeForBranch` → `Promise<string>` (throws on failure).
- Tests: `worktree-fallback-guard` + `worktree-creation-base-branch` updated to the throw contract; now assert the underlying error is surfaced.

## Follow-up (#4086 part 2)
With the stderr now visible, the actual cause (worktree creation throwing for a managed project when a manual `git worktree add` succeeds) can be diagnosed and fixed. Tracked on #4086.

Typecheck clean; worktree + auto-mode suites green (76 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)