### PR TITLE
feat(projects): per-project execution stance — delivery vs observe (closes #4074)

### DIFF
--- a/apps/server/src/services/signal-intake-service.ts
+++ b/apps/server/src/services/signal-intake-service.ts
@@ -636,6 +636,26 @@ export class SignalIntakeService {
 
       // Ops signals: route to Lead Engineer state machine
 
+      // Per-project execution stance (#4074): observe-managed projects create
+      // read-only features (no branch/push/PR); delivery-managed (the default) create
+      // standard delivery features. This is independent of the PM agent's
+      // read-only-on-code stance — a delivery project with a read-only PM still ships PRs.
+      let stanceExecutionMode: 'read-only' | undefined;
+      try {
+        const projectSettings = await this.settingsService?.getProjectSettings(projectPath);
+        if (projectSettings?.executionStance === 'observe') {
+          stanceExecutionMode = 'read-only';
+          logger.info(
+            `Project ${projectPath} is observe-managed — creating signal-intake feature as read-only`
+          );
+        }
+      } catch (err) {
+        logger.warn(
+          `Failed to resolve execution stance for ${projectPath} (defaulting to delivery):`,
+          err
+        );
+      }
+
       // Create feature with idea state
       this.updateRingBufferEntry(bufferEntry.id, 'creating');
       const feature = await this.featureLoader.create(projectPath, {
@@ -646,6 +666,9 @@ export class SignalIntakeService {
         complexity: 'medium',
         workItemState: 'idea',
         sourceChannel: sourceToChannel(signal.source),
+        // Observe-managed project → read-only execution (#4074). Delivery projects
+        // leave executionMode unset so it defaults to standard delivery.
+        ...(stanceExecutionMode ? { executionMode: stanceExecutionMode } : {}),
         // Store GitHub issue number for auto-close on PR merge AND for future
         // idempotency lookups. Any caller that plumbs an issueNumber through
         // channelContext gets it persisted, not just native github-webhook

--- a/apps/server/tests/unit/services/signal-intake-service.test.ts
+++ b/apps/server/tests/unit/services/signal-intake-service.test.ts
@@ -153,6 +153,54 @@ describe('SignalIntakeService', () => {
     });
   });
 
+  describe('per-project execution stance (#4074)', () => {
+    it('creates a read-only feature on an observe-managed project', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue({
+        version: 1,
+        executionStance: 'observe',
+      } as never);
+
+      const signal = createTestSignal({ source: 'github', content: 'Investigate flaky CI' });
+      mockEmitter.emit('signal:received', signal);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockFeatureLoader.create).toHaveBeenCalledWith(
+        '/test/path',
+        expect.objectContaining({ executionMode: 'read-only' })
+      );
+    });
+
+    it('creates a standard (delivery) feature on a delivery-managed project', async () => {
+      vi.mocked(mockSettingsService.getProjectSettings).mockResolvedValue({
+        version: 1,
+        executionStance: 'delivery',
+      } as never);
+
+      const signal = createTestSignal({ source: 'github', content: 'Add a search endpoint' });
+      mockEmitter.emit('signal:received', signal);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const createArg = vi.mocked(mockFeatureLoader.create).mock.calls.at(-1)?.[1] as
+        | Record<string, unknown>
+        | undefined;
+      expect(createArg).toBeDefined();
+      expect(createArg?.executionMode).toBeUndefined();
+    });
+
+    it('defaults to delivery when no stance is set', async () => {
+      // mockSettingsService.getProjectSettings defaults to {} → no executionStance
+      const signal = createTestSignal({ source: 'github', content: 'Fix the login bug' });
+      mockEmitter.emit('signal:received', signal);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const createArg = vi.mocked(mockFeatureLoader.create).mock.calls.at(-1)?.[1] as
+        | Record<string, unknown>
+        | undefined;
+      expect(createArg).toBeDefined();
+      expect(createArg?.executionMode).toBeUndefined();
+    });
+  });
+
   describe('deduplication logic', () => {
     it('should prevent duplicate GitHub issue signals by repo+issueNumber', async () => {
       // Same repo + issue number → same dedup key, regardless of author

--- a/apps/ui/src/components/views/project-settings-view/worktree-preferences-section.tsx
+++ b/apps/ui/src/components/views/project-settings-view/worktree-preferences-section.tsx
@@ -52,6 +52,9 @@ export function WorktreePreferencesSection({ project }: WorktreePreferencesSecti
   const projectUseWorktrees = getProjectUseWorktrees(project.path);
   const effectiveUseWorktrees = projectUseWorktrees ?? globalUseWorktrees;
 
+  // Execution stance (#4074): 'delivery' (default) = agents branch/push/PR;
+  // 'observe' = read-only triage/analysis, no PRs. Local state — no dedicated store.
+  const [executionStance, setExecutionStance] = useState<'delivery' | 'observe'>('delivery');
   const [scriptContent, setScriptContent] = useState('');
   const [originalContent, setOriginalContent] = useState('');
   const [scriptExists, setScriptExists] = useState(false);
@@ -97,6 +100,9 @@ export function WorktreePreferencesSection({ project }: WorktreePreferencesSecti
               currentPath,
               response.settings.autoDismissInitScriptIndicator
             );
+          }
+          if (response.settings.executionStance) {
+            setExecutionStance(response.settings.executionStance);
           }
         }
       } catch (error) {
@@ -278,6 +284,45 @@ export function WorktreePreferencesSection({ project }: WorktreePreferencesSecti
             <p className="text-xs text-muted-foreground/80 leading-relaxed">
               Creates isolated git branches for each feature in this project. When disabled, agents
               work directly in the main project directory.
+            </p>
+          </div>
+        </div>
+
+        {/* Separator */}
+        <div className="border-t border-border/30" />
+
+        {/* Execution Stance: observe-only mode (#4074) */}
+        <div className="group flex items-start space-x-3 p-3 rounded-lg hover:bg-accent/30 transition-colors duration-200 -mx-3">
+          <Checkbox
+            id="project-observe-only"
+            checked={executionStance === 'observe'}
+            onCheckedChange={async (checked) => {
+              const value: 'delivery' | 'observe' = checked === true ? 'observe' : 'delivery';
+              setExecutionStance(value);
+              try {
+                const httpClient = getHttpApiClient();
+                await httpClient.settings.updateProject(project.path, {
+                  executionStance: value,
+                });
+              } catch (error) {
+                console.error('Failed to persist executionStance:', error);
+              }
+            }}
+            className="mt-1"
+            data-testid="project-observe-only-checkbox"
+          />
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="project-observe-only"
+              className="text-foreground cursor-pointer font-medium flex items-center gap-2"
+            >
+              <FileCode className="w-4 h-4 text-brand-500" />
+              Observe-only (read-only, no PRs)
+            </Label>
+            <p className="text-xs text-muted-foreground/80 leading-relaxed">
+              When enabled, signal-intake features on this project run read-only (triage/analysis,
+              no branches or PRs). Leave off for delivery — agents branch, push, and open PRs.
+              Independent of the PM agent's read-only-on-code stance.
             </p>
           </div>
         </div>

--- a/libs/types/src/project-settings.ts
+++ b/libs/types/src/project-settings.ts
@@ -190,6 +190,20 @@ export interface ProjectSettings {
   /** Maximum concurrent agents for this project (overrides global maxConcurrency) */
   maxConcurrentAgents?: number;
 
+  // Execution Stance (per-project)
+  /**
+   * Whether agents on this project DELIVER code (branch → push → PR → review →
+   * merge) or only OBSERVE (read-only triage/analysis, no PRs). Signal-intake
+   * features are created with this stance: `'observe'` → read-only execution,
+   * `'delivery'` → standard execution. This is independent of the PM agent's
+   * read-only-on-code stance — a delivery-managed project with a read-only PM
+   * still produces PRs from its execution agents.
+   *
+   * Undefined defaults to `'delivery'` (the opinionated default; observe is the
+   * explicit opt-in). See #4074 / #4073.
+   */
+  executionStance?: 'delivery' | 'observe';
+
   // Phase Model Overrides (per-project)
   /**
    * Override phase model settings for this project.


### PR DESCRIPTION
Closes #4074. Follow-up to #4073 — a first-class per-project **delivery vs observe** stance, independent of the PM agent's read-only-on-code mandate.

## Why
A project's PM being read-only on code (observe/plan-only) was conflated with its *execution agents* being read-only — exactly what caused #4073. This decouples them: a delivery-managed project with a read-only PM still ships PRs.

## Changes
- **`libs/types`** — new optional `ProjectSettings.executionStance` (`'delivery' | 'observe'`); `undefined` defaults to `'delivery'` (opinionated default; observe is the explicit opt-in).
- **`signal-intake-service`** — consults the stance at feature creation: **observe** → read-only feature (no branch/push/PR); **delivery** → leaves `executionMode` unset (standard delivery). Settings-read failure defaults to delivery (non-fatal).
- **Project settings UI** — "Observe-only (read-only, no PRs)" toggle in the project **Worktree Preferences** section (loads + persists `executionStance`).
- **Tests** — observe → read-only feature; delivery + unset → standard. (46 signal-intake tests green.)

Typecheck clean (UI + server).

## Acceptance (from #4074)
- ✅ New `ProjectSettings` field (`executionStance`, default delivery)
- ✅ Surfaced in project settings UI
- ✅ `signal-intake-service` honors it at feature creation
- ✅ Unit tests for both stances

🤖 Generated with [Claude Code](https://claude.com/claude-code)