### PR TITLE
fix(git): repo default branch outranks global prBaseBranch + validate base exists (#4086)

### DIFF
--- a/apps/server/src/lib/settings-helpers.ts
+++ b/apps/server/src/lib/settings-helpers.ts
@@ -875,44 +875,107 @@ export async function getEffectivePrBaseBranch(
   settingsService?: SettingsService | null,
   logPrefix = '[PrBaseBranch]'
 ): Promise<string> {
+  // Precedence (first usable match wins):
+  //   1. Project-level `workflow.gitWorkflow.prBaseBranch` — explicit per-repo intent.
+  //   2. The repo's own default branch (`origin/HEAD`) — repo reality outranks a global
+  //      blanket default, which is the least repo-aware signal we have.
+  //   3. Global `gitWorkflow.prBaseBranch` — a true fallback for repos that expose no
+  //      detectable default branch.
+  //   4. DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch ('main') — hardcoded floor.
+  //
+  // A *configured* candidate (project or global) that does not exist on the remote is
+  // skipped rather than returned: returning a non-existent base ref makes
+  // `git worktree add ... origin/<base>` fail with `fatal: invalid reference` and
+  // hard-blocks the feature (#4086). It is only skipped when the remote is reachable and
+  // definitively reports the branch absent — a transient check failure honors the
+  // configured value (fail-open to stated intent). origin/HEAD comes from a local ref
+  // that points at a real branch by construction, so it is trusted without a remote probe.
+
+  // 1. Project-level override.
   if (settingsService) {
     try {
-      // 1. Check per-project gitWorkflow settings
       const projectSettings = await settingsService.getProjectSettings(projectPath);
       const projectBranch = projectSettings.workflow?.gitWorkflow?.prBaseBranch;
       if (projectBranch) {
-        logger.debug(`${logPrefix} Using project-level prBaseBranch: ${projectBranch}`);
-        return projectBranch;
-      }
-      // 2. Check global gitWorkflow settings
-      const globalSettings = await settingsService.getGlobalSettings();
-      const globalBranch = globalSettings.gitWorkflow?.prBaseBranch;
-      if (globalBranch) {
-        logger.debug(`${logPrefix} Using global-level prBaseBranch: ${globalBranch}`);
-        return globalBranch;
+        if (await isUsableBaseBranch(projectPath, projectBranch)) {
+          logger.debug(`${logPrefix} Using project-level prBaseBranch: ${projectBranch}`);
+          return projectBranch;
+        }
+        logger.warn(
+          `${logPrefix} Project-level prBaseBranch "${projectBranch}" not found on origin — falling through to repo default`
+        );
       }
     } catch (err) {
-      logger.warn(`${logPrefix} Failed to read settings for prBaseBranch:`, err);
+      logger.warn(`${logPrefix} Failed to read project settings for prBaseBranch:`, err);
     }
   }
 
-  // 3. Auto-detect from remote HEAD
+  // 2. The repo's own default branch (origin/HEAD) outranks the global default.
+  const originHead = await detectOriginHeadBranch(projectPath);
+  if (originHead) {
+    logger.debug(`${logPrefix} Using repo default branch from origin/HEAD: ${originHead}`);
+    return originHead;
+  }
+
+  // 3. Global default — fallback when the repo exposes no default branch.
+  if (settingsService) {
+    try {
+      const globalSettings = await settingsService.getGlobalSettings();
+      const globalBranch = globalSettings.gitWorkflow?.prBaseBranch;
+      if (globalBranch) {
+        if (await isUsableBaseBranch(projectPath, globalBranch)) {
+          logger.debug(`${logPrefix} Using global-level prBaseBranch: ${globalBranch}`);
+          return globalBranch;
+        }
+        logger.warn(
+          `${logPrefix} Global prBaseBranch "${globalBranch}" not found on origin — using default "${DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch}"`
+        );
+      }
+    } catch (err) {
+      logger.warn(`${logPrefix} Failed to read global settings for prBaseBranch:`, err);
+    }
+  }
+
+  // 4. Hardcoded floor.
+  return DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch;
+}
+
+/**
+ * Read a repo's default branch from its local `origin/HEAD` symbolic ref
+ * (set at clone time, e.g. `refs/remotes/origin/main`). Returns null when the
+ * ref is unset or git is unavailable.
+ */
+async function detectOriginHeadBranch(projectPath: string): Promise<string | null> {
   try {
     const { stdout } = await execFileAsync('git', ['symbolic-ref', 'refs/remotes/origin/HEAD'], {
       cwd: projectPath,
       timeout: 5000,
       encoding: 'utf-8',
     });
-    const ref = stdout.trim(); // e.g., refs/remotes/origin/main
-    const branch = ref.replace('refs/remotes/origin/', '');
-    if (branch) {
-      logger.debug(`${logPrefix} Auto-detected prBaseBranch from remote HEAD: ${branch}`);
-      return branch;
-    }
+    const branch = stdout.trim().replace('refs/remotes/origin/', '');
+    return branch || null;
   } catch {
-    // origin/HEAD not set or git not available — fall through to default
+    // origin/HEAD not set or git not available.
+    return null;
   }
+}
 
-  // 5. Final fallback
-  return DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch;
+/**
+ * Whether a configured base branch is usable. Returns true unless the remote is
+ * reachable and definitively reports the branch absent. `git ls-remote --exit-code`
+ * exits 2 when no ref matches (a definitive "absent"); any other failure (not a repo,
+ * no network, timeout) is inconclusive and returns true so an explicitly configured
+ * branch is honored rather than silently downgraded.
+ */
+async function isUsableBaseBranch(projectPath: string, branch: string): Promise<boolean> {
+  try {
+    await execFileAsync('git', ['ls-remote', '--exit-code', '--heads', 'origin', branch], {
+      cwd: projectPath,
+      timeout: 8000,
+    });
+    return true; // branch present on origin
+  } catch (err) {
+    const code = (err as { code?: number }).code;
+    return code !== 2;
+  }
 }

--- a/apps/server/tests/unit/lib/pr-base-branch-precedence.test.ts
+++ b/apps/server/tests/unit/lib/pr-base-branch-precedence.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Precedence + validation tests for getEffectivePrBaseBranch (issue #4086).
+ *
+ * The resolution order is:
+ *   1. Project-level prBaseBranch override (validated against origin)
+ *   2. The repo's own default branch (origin/HEAD) — outranks any global default
+ *   3. Global prBaseBranch (validated against origin)
+ *   4. DEFAULT_GIT_WORKFLOW_SETTINGS.prBaseBranch ('main')
+ *
+ * A configured branch (project or global) that origin definitively reports absent
+ * (`git ls-remote --exit-code` exits 2) is skipped instead of hard-blocking the
+ * feature; an inconclusive check (any other error) honors the configured value.
+ *
+ * git is mocked via node:child_process so each case drives a deterministic response.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { SettingsService } from '@/services/settings-service.js';
+
+type GitResult = { stdout?: string } | { code: number } | { error: Error };
+
+// Per-test git behavior, swapped in via setGit(). Default: every git call fails
+// inconclusively (no exit code) so nothing is treated as definitively absent.
+const h = vi.hoisted(() => {
+  let impl: (cmd: string, args: string[]) => GitResult = () => ({ error: new Error('git failed') });
+  return {
+    setGit: (fn: (cmd: string, args: string[]) => GitResult) => {
+      impl = fn;
+    },
+    execFile: vi.fn(
+      (
+        cmd: string,
+        args: string[],
+        _opts: unknown,
+        cb: (err: (Error & { code?: number }) | null, result?: { stdout: string }) => void
+      ) => {
+        const r = impl(cmd, args);
+        if ('stdout' in r) {
+          cb(null, { stdout: r.stdout ?? '' });
+        } else if ('code' in r) {
+          const err = new Error(`git exited ${r.code}`) as Error & { code?: number };
+          err.code = r.code;
+          cb(err);
+        } else {
+          cb(r.error as Error & { code?: number });
+        }
+      }
+    ),
+  };
+});
+
+vi.mock('node:child_process', () => ({ execFile: h.execFile }));
+
+vi.mock('@protolabsai/utils', async () => {
+  const actual = await vi.importActual('@protolabsai/utils');
+  return {
+    ...actual,
+    createLogger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }),
+  };
+});
+
+/** Branch name passed to `git ls-remote --exit-code --heads origin <branch>`. */
+function lsRemoteBranch(args: string[]): string {
+  return args[args.length - 1];
+}
+
+function makeSettings(opts: { project?: string; global?: string }): SettingsService {
+  return {
+    getProjectSettings: vi
+      .fn()
+      .mockResolvedValue(
+        opts.project ? { workflow: { gitWorkflow: { prBaseBranch: opts.project } } } : {}
+      ),
+    getGlobalSettings: vi
+      .fn()
+      .mockResolvedValue(opts.global ? { gitWorkflow: { prBaseBranch: opts.global } } : {}),
+  } as unknown as SettingsService;
+}
+
+describe('getEffectivePrBaseBranch precedence (#4086)', () => {
+  let getEffectivePrBaseBranch: (
+    projectPath: string,
+    settingsService?: SettingsService | null,
+    logPrefix?: string
+  ) => Promise<string>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    h.setGit(() => ({ error: new Error('git failed') }));
+    const mod = await import('@/lib/settings-helpers.js');
+    getEffectivePrBaseBranch = mod.getEffectivePrBaseBranch;
+  });
+
+  it("repo's origin/HEAD outranks a global default that points elsewhere", async () => {
+    // This is the core #4086 regression: global was 'dev', repo default is 'main'.
+    h.setGit((_cmd, args) => {
+      if (args[0] === 'symbolic-ref') return { stdout: 'refs/remotes/origin/main\n' };
+      return { error: new Error('unexpected') };
+    });
+    const result = await getEffectivePrBaseBranch('/repo', makeSettings({ global: 'dev' }));
+    expect(result).toBe('main');
+  });
+
+  it('a project override that exists on origin wins over origin/HEAD', async () => {
+    h.setGit((_cmd, args) => {
+      if (args[0] === 'symbolic-ref') return { stdout: 'refs/remotes/origin/main\n' };
+      if (args[0] === 'ls-remote' && lsRemoteBranch(args) === 'epic/foo')
+        return { stdout: '<sha>\n' };
+      return { code: 2 };
+    });
+    const result = await getEffectivePrBaseBranch('/repo', makeSettings({ project: 'epic/foo' }));
+    expect(result).toBe('epic/foo');
+  });
+
+  it('a project override absent on origin degrades to origin/HEAD (no hard block)', async () => {
+    h.setGit((_cmd, args) => {
+      if (args[0] === 'symbolic-ref') return { stdout: 'refs/remotes/origin/main\n' };
+      if (args[0] === 'ls-remote') return { code: 2 }; // 'ghost' not found
+      return { error: new Error('unexpected') };
+    });
+    const result = await getEffectivePrBaseBranch('/repo', makeSettings({ project: 'ghost' }));
+    expect(result).toBe('main');
+  });
+
+  it('falls back to the global default when origin/HEAD is undetectable and the global exists', async () => {
+    h.setGit((_cmd, args) => {
+      if (args[0] === 'symbolic-ref') return { error: new Error('no origin/HEAD') };
+      if (args[0] === 'ls-remote' && lsRemoteBranch(args) === 'staging')
+        return { stdout: '<sha>\n' };
+      return { code: 2 };
+    });
+    const result = await getEffectivePrBaseBranch('/repo', makeSettings({ global: 'staging' }));
+    expect(result).toBe('staging');
+  });
+
+  it('falls back to main when origin/HEAD is undetectable and the global default is absent on origin', async () => {
+    h.setGit((_cmd, args) => {
+      if (args[0] === 'symbolic-ref') return { error: new Error('no origin/HEAD') };
+      if (args[0] === 'ls-remote') return { code: 2 }; // 'dev' not found anywhere
+      return { error: new Error('unexpected') };
+    });
+    const result = await getEffectivePrBaseBranch('/repo', makeSettings({ global: 'dev' }));
+    expect(result).toBe('main');
+  });
+
+  it('honors a configured branch when the existence check is inconclusive (fail-open, not exit 2)', async () => {
+    // origin/HEAD undetectable; ls-remote fails with a transient (non-2) error.
+    h.setGit((_cmd, args) => {
+      if (args[0] === 'symbolic-ref') return { error: new Error('no origin/HEAD') };
+      if (args[0] === 'ls-remote') return { code: 128 }; // e.g. network/transport error
+      return { error: new Error('unexpected') };
+    });
+    const result = await getEffectivePrBaseBranch('/repo', makeSettings({ project: 'release/x' }));
+    expect(result).toBe('release/x');
+  });
+
+  it('returns main when there are no settings and origin/HEAD is undetectable', async () => {
+    h.setGit(() => ({ error: new Error('git failed') }));
+    const result = await getEffectivePrBaseBranch('/repo', null);
+    expect(result).toBe('main');
+  });
+});


### PR DESCRIPTION
## What

Fixes the root cause of #4086: `getEffectivePrBaseBranch` returned the **global** `gitWorkflow.prBaseBranch` *before* auto-detecting a repo's own default branch. With this instance's global set to `"dev"`, every managed project without a project-level override and without a `dev` branch resolved to `origin/dev`, so `git worktree add -B <branch> <path> origin/dev` threw `fatal: invalid reference: origin/dev` and **hard-blocked the feature at execution start**.

Diagnosed live: the part-1 diagnostic (#4096) surfaced the real stderr (`fatal: invalid reference: origin/dev`); confirmed the instance global is `dev` and that **4 of 8 managed projects hard-block** (protoWorkstacean, release-tools, contentMachine, pwnDeck), while 2 more (protocli, protoAgent) silently PR'd into `dev` despite every actual PR across all repos targeting `main`.

## Fix

Two changes to the single resolution chokepoint (feeds both worktree creation and PR base via `projectPrBaseBranch`):

1. **Precedence.** A global base-branch default is the least repo-aware signal and must not override repo reality. New order:

   | Priority | Source |
   |---|---|
   | 1 | Project `prBaseBranch` override |
   | 2 | Repo's `origin/HEAD` (actual default branch) |
   | 3 | Global `prBaseBranch` (true fallback) |
   | 4 | `main` |

2. **Validation.** A *configured* candidate (project or global) that origin definitively reports absent (`git ls-remote --exit-code` exits 2) is skipped and degrades to the repo default, instead of returning an invalid ref that hard-blocks. An inconclusive check (not-a-repo / network / timeout) **fails open** to the configured value. `origin/HEAD` points at a real branch by construction, so it's trusted without a remote probe — keeping the common path zero-overhead (no `ls-remote` when there's no override and `origin/HEAD` resolves).

## Why this is the right fix

A guard-only approach (just reject invalid refs) would leave protocli/protoAgent silently on `dev` (their `dev` exists), which the evidence shows is wrong — they PR into `main`. Reordering so the repo's real default outranks a blanket global default fixes the conceptual error; the validation is the belt-and-suspenders that makes the #4086 symptom impossible to recur regardless of config.

## Tests

New `pr-base-branch-precedence.test.ts` (git mocked via `node:child_process`):
- repo `origin/HEAD` beats a divergent global default (the #4086 regression)
- valid project override wins over `origin/HEAD`
- project/global candidate absent on origin → degrades (no hard block)
- global used only when `origin/HEAD` is undetectable
- inconclusive existence check fails open to the configured value
- no settings + undetectable `origin/HEAD` → `main`

All existing `getEffectivePrBaseBranch` / worktree / execution tests stay green (111 + 43 across the touched suites). Typecheck clean.

## Companion config fix (applied to this instance, not in this diff)

The instance global `gitWorkflow.prBaseBranch` was corrected `dev → main` (evidence: zero PRs across the 8 repos target `dev`), and the interim per-project `release-tools` override was removed so it inherits the now-correct resolution. The code fix is what makes this robust for any future project; the config change is hygiene.

Closes #4086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
