### PR TITLE
feat(webhooks): auto-close the linked feature when a GitHub issue closes

### DIFF
--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -388,6 +388,91 @@ export function createGitHubWebhookHandler(
           });
         }
 
+        // Close out (or recover) the linked feature when the issue's state flips.
+        // Symmetric to `opened` intake: intake CREATES a feature from a new issue, so
+        // a closed issue should DRIVE its feature to done — otherwise shipped work
+        // piles up as phantom backlog (the board drifts out of sync with GitHub).
+        // Push-model: no GitHub read needed, so this works even where the server's
+        // token can't read the repo's issues.
+        if (issuePayload.action === 'closed' || issuePayload.action === 'reopened') {
+          const issueNumber = issuePayload.issue.number;
+          const repoFullName = issuePayload.repository.full_name;
+          const isClosed = issuePayload.action === 'closed';
+
+          // Resolve the project by scanning for one that has a feature linked to
+          // this issue (same strategy the PR-merge path uses for branches).
+          const projectPath = await findProjectPathForFeature(
+            featureLoader,
+            settings.projects,
+            (path) => featureLoader.findByIssueNumber(path, issueNumber).then(Boolean)
+          );
+
+          if (!projectPath) {
+            logger.debug(
+              `No project has a feature linked to issue #${issueNumber} (${repoFullName}) — nothing to ${issuePayload.action}`
+            );
+            res.json({ success: true, message: 'No feature linked to this issue' });
+            return;
+          }
+
+          const linked = await featureLoader.findByIssueNumber(projectPath, issueNumber);
+          if (!linked) {
+            res.json({ success: true, message: 'No feature linked to this issue' });
+            return;
+          }
+
+          const TERMINAL_STATUSES = new Set(['done', 'completed', 'verified']);
+          const isTerminal = TERMINAL_STATUSES.has(linked.status ?? '');
+
+          if (isClosed) {
+            // Idempotency: don't re-mark an already-terminal feature (duplicate deliveries).
+            if (isTerminal) {
+              logger.debug(
+                `Feature ${linked.id} already '${linked.status}' — skipping close for issue #${issueNumber}`
+              );
+              res.json({ success: true, message: 'Feature already terminal' });
+              return;
+            }
+            logger.info(
+              `GitHub issue #${issueNumber} closed (${repoFullName}) — syncing feature ${linked.id} to done`
+            );
+            await featureLoader.update(projectPath, linked.id, {
+              status: 'done',
+              statusChangeReason: `GitHub issue #${issueNumber} closed — auto-synced to done`,
+            });
+            events.emit('feature:issue-closed', {
+              featureId: linked.id,
+              projectPath,
+              issueNumber,
+              repository: repoFullName,
+            });
+            res.json({ success: true, message: `Feature ${linked.id} synced to done` });
+            return;
+          }
+
+          // reopened: recover a terminal feature back to backlog so it's actionable
+          // again; leave non-terminal features as-is (they're already in flight).
+          if (!isTerminal) {
+            res.json({ success: true, message: 'Feature already active, no recovery needed' });
+            return;
+          }
+          logger.info(
+            `GitHub issue #${issueNumber} reopened (${repoFullName}) — recovering feature ${linked.id} to backlog`
+          );
+          await featureLoader.update(projectPath, linked.id, {
+            status: 'backlog',
+            statusChangeReason: `GitHub issue #${issueNumber} reopened — auto-recovered to backlog`,
+          });
+          events.emit('feature:issue-reopened', {
+            featureId: linked.id,
+            projectPath,
+            issueNumber,
+            repository: repoFullName,
+          });
+          res.json({ success: true, message: `Feature ${linked.id} recovered to backlog` });
+          return;
+        }
+
         res.json({ success: true, message: 'Issue event processed' });
         return;
       }

--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -52,6 +52,10 @@ interface GitHubIssuePayload {
     title: string;
     body: string | null;
     state: string;
+    // Why the issue is in its current state. For `closed`: 'completed' (shipped) vs
+    // 'not_planned' (wontfix/duplicate/abandoned). Drives whether the linked feature's
+    // close-out reads as genuine completion or abandonment. Absent on older payloads.
+    state_reason?: 'completed' | 'not_planned' | 'reopened' | null;
     created_at: string;
     html_url: string;
     user: {
@@ -433,18 +437,29 @@ export function createGitHubWebhookHandler(
               res.json({ success: true, message: 'Feature already terminal' });
               return;
             }
+            // Distinguish a genuine completion from an abandonment (wontfix/duplicate).
+            // The board has a single terminal status (`done`), so both terminalize here
+            // to clear phantom backlog — but the reason and the emitted event carry
+            // state_reason so consumers/metrics can tell shipped from abandoned. A
+            // dedicated `cancelled` terminal is tracked as a follow-up.
+            const stateReason = issuePayload.issue.state_reason ?? null;
+            const notPlanned = stateReason === 'not_planned';
             logger.info(
-              `GitHub issue #${issueNumber} closed (${repoFullName}) — syncing feature ${linked.id} to done`
+              `GitHub issue #${issueNumber} closed as ${notPlanned ? 'not planned' : 'completed'} ` +
+                `(${repoFullName}) — syncing feature ${linked.id} to done`
             );
             await featureLoader.update(projectPath, linked.id, {
               status: 'done',
-              statusChangeReason: `GitHub issue #${issueNumber} closed — auto-synced to done`,
+              statusChangeReason: notPlanned
+                ? `GitHub issue #${issueNumber} closed as not planned — auto-synced to done (was not shipped)`
+                : `GitHub issue #${issueNumber} closed — auto-synced to done`,
             });
             events.emit('feature:issue-closed', {
               featureId: linked.id,
               projectPath,
               issueNumber,
               repository: repoFullName,
+              stateReason,
             });
             res.json({ success: true, message: `Feature ${linked.id} synced to done` });
             return;

--- a/apps/server/src/services/feature-loader.ts
+++ b/apps/server/src/services/feature-loader.ts
@@ -658,6 +658,33 @@ export class FeatureLoader implements FeatureStore {
   }
 
   /**
+   * Find the feature linked to a GitHub issue number.
+   *
+   * Used by the webhook handler to close out a feature when its source issue is
+   * closed on GitHub (the symmetric counterpart to issue-`opened` intake). Matches
+   * on `githubIssueNumber`, the field intake populates from the issue.
+   *
+   * @param projectPath - Path to the project
+   * @param issueNumber - The GitHub issue number
+   * @returns The linked feature, or null if none
+   */
+  async findByIssueNumber(projectPath: string, issueNumber: number): Promise<Feature | null> {
+    if (!issueNumber) {
+      return null;
+    }
+
+    const features = await this.getAll(projectPath);
+
+    for (const feature of features) {
+      if (feature.githubIssueNumber === issueNumber) {
+        return feature;
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Check if a title already exists on another active feature (for duplicate detection).
    * Archived features are excluded — delete-then-recreate and archive-then-recreate must work.
    *

--- a/apps/server/tests/unit/services/feature-loader.test.ts
+++ b/apps/server/tests/unit/services/feature-loader.test.ts
@@ -681,6 +681,48 @@ describe('feature-loader.ts', () => {
     });
   });
 
+  describe('findByIssueNumber', () => {
+    it('should find the feature linked to a GitHub issue number', async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: 'feature-1', isDirectory: () => true } as any,
+        { name: 'feature-2', isDirectory: () => true } as any,
+      ]);
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(
+          JSON.stringify({ id: 'feature-1000-abc', title: 'A', githubIssueNumber: 235 })
+        )
+        .mockResolvedValueOnce(
+          JSON.stringify({ id: 'feature-2000-def', title: 'B', githubIssueNumber: 443 })
+        );
+
+      const result = await loader.findByIssueNumber(testProjectPath, 443);
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe('feature-2000-def');
+    });
+
+    it('should return null when no feature is linked to the issue', async () => {
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readdir).mockResolvedValue([
+        { name: 'feature-1', isDirectory: () => true } as any,
+      ]);
+      vi.mocked(fs.readFile).mockResolvedValueOnce(
+        JSON.stringify({ id: 'feature-1000-abc', title: 'A', githubIssueNumber: 235 })
+      );
+
+      const result = await loader.findByIssueNumber(testProjectPath, 999);
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null for a falsy issue number (no scan)', async () => {
+      const result = await loader.findByIssueNumber(testProjectPath, 0);
+      expect(result).toBeNull();
+      expect(fs.readdir).not.toHaveBeenCalled();
+    });
+  });
+
   describe('findDuplicateTitle', () => {
     it('should find duplicate title', async () => {
       vi.mocked(fs.access).mockResolvedValue(undefined);

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -33,6 +33,8 @@ export type EventType =
   | 'epic:auto-completed'
   | 'feature:pr-merged'
   | 'feature:pr-closed-unmerged'
+  | 'feature:issue-closed'
+  | 'feature:issue-reopened'
   | 'feature:auto-reconciled'
   | 'feature:verify-pending'
   | 'feature:blocked'
@@ -469,6 +471,18 @@ export interface EventPayloadMap {
     projectPath: string;
     prNumber: number;
     prUrl?: string;
+  };
+  'feature:issue-closed': {
+    featureId: string;
+    projectPath: string;
+    issueNumber: number;
+    repository: string;
+  };
+  'feature:issue-reopened': {
+    featureId: string;
+    projectPath: string;
+    issueNumber: number;
+    repository: string;
   };
   'feature:verify-pending': {
     featureId: string;

--- a/libs/types/src/event.ts
+++ b/libs/types/src/event.ts
@@ -477,6 +477,9 @@ export interface EventPayloadMap {
     projectPath: string;
     issueNumber: number;
     repository: string;
+    // 'completed' (shipped) vs 'not_planned' (wontfix/duplicate/abandoned); null on
+    // older webhook payloads. Lets consumers distinguish completion from abandonment.
+    stateReason?: 'completed' | 'not_planned' | 'reopened' | null;
   };
   'feature:issue-reopened': {
     featureId: string;


### PR DESCRIPTION
## Problem
The GitHub webhook handler ingests `issues.opened` (creates a board feature via signal intake) but **ignores `issues.closed`**. So when shipped work closes its GitHub issue, the linked board feature stays in `backlog` forever — boards drift out of sync with GitHub and **phantom backlog accumulates**.

A fleet audit (2026-06-05) found **82 stale features across 5 projects**, every one tied to an already-closed GitHub issue (e.g. protoAgent showed 15 backlog, all 15 closed). Those were reconciled manually; this PR stops the drift at the source.

## Change
Add the symmetric close-out to the `issues` event branch in `routes/webhooks/routes/github.ts`:
- **`issues.closed`** → resolve the project (same `findProjectPathForFeature` strategy the PR-merge path uses), find the feature by `githubIssueNumber`, transition it to **`done`**. Idempotent — skips features already terminal (`done`/`completed`/`verified`), so duplicate webhook deliveries are safe.
- **`issues.reopened`** → recover a terminal feature back to `backlog`.
- New `FeatureLoader.findByIssueNumber()` (mirrors `findByPRNumber`).
- New event types `feature:issue-closed` / `feature:issue-reopened` in `libs/types`.

**Push-model:** the handler does a local board write and needs **no GitHub read**, so it works even on repos whose server token lacks `Issues:read` (a known gap on protoContent/protoPen).

## Delivery is already wired
protoContent / protoPen / protoWorkstacean repo webhooks already POST `issues` events to the hooks gateway (`active=true`). This handler starts consuming the `closed`/`reopened` actions they already send.

## Out of scope (operator follow-ups)
- **protoAgent has 0 webhooks** configured (and is the upstream template) — won't auto-sync until a webhook is added or it's dropped as a managed board.
- The server's fine-grained PAT can't read protoContent/protoPen issues (`Resource not accessible by personal access token`) — only affects *read-back* (reconcile/readiness/origin-truth), not this push path. Worth granting `Issues:read` so the polling safety-net works there too.

## Tests
`findByIssueNumber` unit coverage (match / no-match / falsy-number guard); full feature-loader suite green (60 passed). Typecheck clean.