### PR TITLE
[github] Board has no 'cancelled' terminal status — not_planned issue closes emit feature.completed

### DIFF
--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -425,7 +425,7 @@ export function createGitHubWebhookHandler(
             return;
           }
 
-          const TERMINAL_STATUSES = new Set(['done', 'completed', 'verified']);
+          const TERMINAL_STATUSES = new Set(['done', 'cancelled', 'completed', 'verified']);
           const isTerminal = TERMINAL_STATUSES.has(linked.status ?? '');
 
           if (isClosed) {
@@ -438,20 +438,18 @@ export function createGitHubWebhookHandler(
               return;
             }
             // Distinguish a genuine completion from an abandonment (wontfix/duplicate).
-            // The board has a single terminal status (`done`), so both terminalize here
-            // to clear phantom backlog — but the reason and the emitted event carry
-            // state_reason so consumers/metrics can tell shipped from abandoned. A
-            // dedicated `cancelled` terminal is tracked as a follow-up.
+            // `completed` → `done` (shipped), `not_planned` → `cancelled` (abandoned).
             const stateReason = issuePayload.issue.state_reason ?? null;
             const notPlanned = stateReason === 'not_planned';
+            const targetStatus = notPlanned ? 'cancelled' : 'done';
             logger.info(
               `GitHub issue #${issueNumber} closed as ${notPlanned ? 'not planned' : 'completed'} ` +
-                `(${repoFullName}) — syncing feature ${linked.id} to done`
+                `(${repoFullName}) — syncing feature ${linked.id} to ${targetStatus}`
             );
             await featureLoader.update(projectPath, linked.id, {
-              status: 'done',
+              status: targetStatus,
               statusChangeReason: notPlanned
-                ? `GitHub issue #${issueNumber} closed as not planned — auto-synced to done (was not shipped)`
+                ? `GitHub issue #${issueNumber} closed as not planned — auto-synced to cancelled`
                 : `GitHub issue #${issueNumber} closed — auto-synced to done`,
             });
             events.emit('feature:issue-closed', {
@@ -461,7 +459,7 @@ export function createGitHubWebhookHandler(
               repository: repoFullName,
               stateReason,
             });
-            res.json({ success: true, message: `Feature ${linked.id} synced to done` });
+            res.json({ success: true, message: `Feature ${linked.id} synced to ${targetStatus}` });
             return;
           }
 
@@ -652,7 +650,7 @@ export function createGitHubWebhookHandler(
       // Idempotency guard: skip update if feature is already in a terminal status.
       // Prevents double-updating completedAt or re-emitting feature:pr-merged on duplicate
       // webhook deliveries.
-      const TERMINAL_STATUSES = new Set(['done', 'completed', 'verified']);
+      const TERMINAL_STATUSES = new Set(['done', 'cancelled', 'completed', 'verified']);
       const wasAlreadyTerminal = TERMINAL_STATUSES.has(currentFeature.status ?? '');
 
       if (wasAlreadyTerminal) {

--- a/apps/server/src/services/feature-lifecycle-bus-publisher.ts
+++ b/apps/server/src/services/feature-lifecycle-bus-publisher.ts
@@ -5,10 +5,11 @@
  *
  * Subscribes to the existing `feature:status-changed` event (emitted by
  * FeatureLoader.update) and, when a feature transitions into a terminal state,
- * publishes one of three dotted, unprefixed topics workstacean's consumers
+ * publishes one of four dotted, unprefixed topics workstacean's consumers
  * subscribe to:
  *
  *   - `done`      → `feature.completed`
+ *   - `cancelled` → `feature.cancelled`  (abandoned — wontfix/duplicate/not_planned)
  *   - `blocked`   → `feature.blocked`   (carries a `kind` failure discriminator)
  *   - `escalated` → `feature.failed`    (already escalated — no auto-remediation)
  *
@@ -18,6 +19,10 @@
  * (this side) and protoLabsAI/protoWorkstacean#779 / #776 (the consumer + the
  * flag day that depends on this emission). Greenfield: a `blocked` transition
  * emits ONLY `feature.blocked`, never also `feature.failed`.
+ *
+ * `feature.cancelled` is the signal for abandoned features (issue closed as
+ * not_planned). Unlike `feature.completed`, it does NOT count as shipped work
+ * in board metrics. See protoLabsAI/protoMaker#4102 follow-up.
  *
  * The payload echoes the originating signal metadata so a consumer (e.g. the
  * Linear ↔ protoMaker bridge) can reconstruct lineage and post a status comment
@@ -38,6 +43,9 @@ const logger = createLogger('FeatureLifecycleBusPublisher');
 
 /** Board statuses treated as terminal (success) — emit `feature.completed`. */
 const TERMINAL_STATUSES: ReadonlySet<string> = new Set(['done']);
+
+/** Board status that emits `feature.cancelled` (abandoned — terminal, not shipped). */
+const CANCELLED_STATUSES: ReadonlySet<string> = new Set(['cancelled']);
 
 /** Board status that emits the kinded `feature.blocked` (remediable failure). */
 const BLOCKED_STATUSES: ReadonlySet<string> = new Set(['blocked']);
@@ -240,12 +248,12 @@ export class FeatureLifecycleBusPublisher {
 
   /**
    * Publish the lifecycle event for a tracked transition:
-   *   done → feature.completed, blocked → feature.blocked (kinded),
-   *   escalated → feature.failed, and blocked → {in_progress,backlog,review} →
-   *   feature.unblocked (recovery — lets the remediation consumer clear its
-   *   tracker). Loads the feature fresh to echo its source signal metadata and
-   *   PR tracking fields. Never throws — a publish failure must not affect the
-   *   board transition.
+   *   done → feature.completed, cancelled → feature.cancelled,
+   *   blocked → feature.blocked (kinded), escalated → feature.failed, and
+   *   blocked → {in_progress,backlog,review} → feature.unblocked (recovery —
+   *   lets the remediation consumer clear its tracker). Loads the feature fresh
+   *   to echo its source signal metadata and PR tracking fields. Never throws —
+   *   a publish failure must not affect the board transition.
    */
   async handleStatusChange(payload: StatusChangedPayload): Promise<void> {
     const { featureId, newStatus, oldStatus, projectPath } = payload ?? {};
@@ -254,13 +262,14 @@ export class FeatureLifecycleBusPublisher {
     }
 
     const isTerminal = TERMINAL_STATUSES.has(newStatus);
+    const isCancelled = CANCELLED_STATUSES.has(newStatus);
     const isBlocked = BLOCKED_STATUSES.has(newStatus);
     const isEscalated = ESCALATED_STATUSES.has(newStatus);
     // Recovery: a transition OUT of `blocked` into an active status. `blocked ->
     // done` is excluded (covered by feature.completed); `blocked -> escalated`
     // is excluded (got worse, not recovered).
     const isUnblock = oldStatus === 'blocked' && UNBLOCKED_TARGET_STATUSES.has(newStatus);
-    if (!isTerminal && !isBlocked && !isEscalated && !isUnblock) {
+    if (!isTerminal && !isCancelled && !isBlocked && !isEscalated && !isUnblock) {
       return;
     }
 
@@ -274,14 +283,17 @@ export class FeatureLifecycleBusPublisher {
     // Dotted, unprefixed topics — exactly what workstacean's consumers
     // subscribe to. `blocked` is its own remediable signal; `unblocked` is the
     // recovery signal that clears remediation tracking; `escalated` stays
-    // `feature.failed` (no auto-remediation); `done` is `feature.completed`.
+    // `feature.failed` (no auto-remediation); `done` is `feature.completed`;
+    // `cancelled` is `feature.cancelled` (abandoned — not shipped).
     const topic = isTerminal
       ? 'feature.completed'
-      : isBlocked
-        ? 'feature.blocked'
-        : isUnblock
-          ? 'feature.unblocked'
-          : 'feature.failed';
+      : isCancelled
+        ? 'feature.cancelled'
+        : isBlocked
+          ? 'feature.blocked'
+          : isUnblock
+            ? 'feature.unblocked'
+            : 'feature.failed';
     const owner = process.env.GITHUB_REPO_OWNER;
     const name = process.env.GITHUB_REPO_NAME;
     const repo = owner && name ? `${owner}/${name}` : undefined;
@@ -293,11 +305,13 @@ export class FeatureLifecycleBusPublisher {
         : { sourceChannel: feature?.sourceChannel, signalMetadata: feature?.signalMetadata };
     const timestampKey = isTerminal
       ? 'completedAt'
-      : isBlocked
-        ? 'blockedAt'
-        : isUnblock
-          ? 'unblockedAt'
-          : 'failedAt';
+      : isCancelled
+        ? 'cancelledAt'
+        : isBlocked
+          ? 'blockedAt'
+          : isUnblock
+            ? 'unblockedAt'
+            : 'failedAt';
     const data: Record<string, unknown> = {
       // projectSlug is REQUIRED by workstacean's feature-notifier (resolves the
       // dev channel); fall back so the event is never dropped for lacking it.
@@ -330,6 +344,11 @@ export class FeatureLifecycleBusPublisher {
       if (kind) {
         data.kind = kind;
       }
+    } else if (isCancelled) {
+      // feature.cancelled carries the abandonment reason so consumers can
+      // distinguish wontfix / duplicate / abandoned from genuine completions.
+      const reason = (feature?.statusChangeReason ?? payload?.reason ?? 'cancelled').slice(0, 400);
+      data.reason = reason;
     } else if (isUnblock) {
       // feature.unblocked is a pure recovery signal — no error/kind. Echo where
       // the feature recovered to so consumers can log/route if they care; the

--- a/apps/ui/src/components/views/board-view/constants.ts
+++ b/apps/ui/src/components/views/board-view/constants.ts
@@ -47,6 +47,11 @@ export const EMPTY_STATE_CONFIGS: Record<string, EmptyStateConfig> = {
     description: 'Features that are temporarily blocked will appear here.',
     icon: 'clock',
   },
+  cancelled: {
+    title: 'No Cancelled Features',
+    description: 'Features that were abandoned or marked not planned will appear here.',
+    icon: 'clock',
+  },
   done: {
     title: 'No Completed Features',
     description: 'Features with merged PRs will appear here.',
@@ -73,7 +78,7 @@ export interface Column {
   colorClass: string;
 }
 
-// Canonical 5-status columns
+// Canonical 6-status columns
 export const COLUMNS: Column[] = [
   { id: 'backlog', title: 'Backlog', colorClass: 'bg-[var(--status-backlog)]' },
   {
@@ -90,6 +95,11 @@ export const COLUMNS: Column[] = [
     id: 'blocked',
     title: 'Blocked',
     colorClass: 'bg-[var(--status-blocked)]',
+  },
+  {
+    id: 'cancelled',
+    title: 'Cancelled',
+    colorClass: 'bg-[var(--status-cancelled)]',
   },
   {
     id: 'done',

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -755,6 +755,7 @@ export type FeatureStatus =
   | 'review' // PR created, under review
   | 'blocked' // Temporary halt (dependency/issue/failure - consolidates: failed)
   | 'done' // PR merged, work complete (consolidates: completed, waiting_approval, verified)
+  | 'cancelled' // Feature abandoned (wontfix/duplicate/not_planned) — terminal, not shipped
   | 'interrupted'; // Server shut down while feature was running
 
 /**
@@ -798,6 +799,7 @@ export function normalizeFeatureStatus(
     'review',
     'blocked',
     'done',
+    'cancelled',
     'interrupted',
   ];
   if (canonical.includes(status as FeatureStatus)) {

--- a/libs/types/src/pipeline.ts
+++ b/libs/types/src/pipeline.ts
@@ -36,6 +36,7 @@ export type FeatureStatusWithPipeline =
   | 'review'
   | 'blocked'
   | 'done'
+  | 'cancelled'
   | 'verified'
   | 'interrupted' // Server shut down while feature was running
   | 'ready' // Dependencies satisfied, ready for execution


### PR DESCRIPTION
## Summary

# [github] Board has no 'cancelled' terminal status — not_planned issue closes emit feature.completed

## Situation
This feature was requested but PRD generation encountered an issue.

## Problem
Board has no 'cancelled' terminal status — not_planned issue closes emit feature.completed

## Problem
The 5-status board model (`backlog → in_progress → review → done`, plus `blocked`) has **one terminal status: `done`**. `FeatureLifecycleBusPublisher` emits `feature.completed` on any transition to `do...

Closes #4103

---
*Created automatically by Automaker*

<!-- automaker:owner instance=ef15d09b-b02a-4f05-bb57-fcc898070dd7 team= created=2026-06-05T09:06:06.011Z -->