### PR TITLE
fix(lifecycle): not_planned issue close emits feature.cancelled, not completed (#4103)

### DIFF
--- a/apps/server/src/routes/webhooks/routes/github.ts
+++ b/apps/server/src/routes/webhooks/routes/github.ts
@@ -437,21 +437,22 @@ export function createGitHubWebhookHandler(
               res.json({ success: true, message: 'Feature already terminal' });
               return;
             }
-            // Distinguish a genuine completion from an abandonment (wontfix/duplicate).
-            // The board has a single terminal status (`done`), so both terminalize here
-            // to clear phantom backlog — but the reason and the emitted event carry
-            // state_reason so consumers/metrics can tell shipped from abandoned. A
-            // dedicated `cancelled` terminal is tracked as a follow-up.
+            // A genuine completion (`completed`) terminalizes to `done` →
+            // feature.completed. An abandonment (`not_planned`: wontfix/duplicate) is
+            // terminalized AND archived: it clears the active board without counting as
+            // shipped, and the lifecycle bus turns done+archived into feature.cancelled
+            // instead of feature.completed (#4103).
             const stateReason = issuePayload.issue.state_reason ?? null;
             const notPlanned = stateReason === 'not_planned';
             logger.info(
               `GitHub issue #${issueNumber} closed as ${notPlanned ? 'not planned' : 'completed'} ` +
-                `(${repoFullName}) — syncing feature ${linked.id} to done`
+                `(${repoFullName}) — ${notPlanned ? 'archiving' : 'syncing'} feature ${linked.id}`
             );
             await featureLoader.update(projectPath, linked.id, {
               status: 'done',
+              ...(notPlanned ? { archived: true } : {}),
               statusChangeReason: notPlanned
-                ? `GitHub issue #${issueNumber} closed as not planned — auto-synced to done (was not shipped)`
+                ? `GitHub issue #${issueNumber} closed as not planned — archived (not shipped)`
                 : `GitHub issue #${issueNumber} closed — auto-synced to done`,
             });
             events.emit('feature:issue-closed', {
@@ -461,7 +462,12 @@ export function createGitHubWebhookHandler(
               repository: repoFullName,
               stateReason,
             });
-            res.json({ success: true, message: `Feature ${linked.id} synced to done` });
+            res.json({
+              success: true,
+              message: notPlanned
+                ? `Feature ${linked.id} archived (closed not planned)`
+                : `Feature ${linked.id} synced to done`,
+            });
             return;
           }
 
@@ -476,6 +482,7 @@ export function createGitHubWebhookHandler(
           );
           await featureLoader.update(projectPath, linked.id, {
             status: 'backlog',
+            archived: false, // un-archive in case it was closed as not_planned (#4103)
             statusChangeReason: `GitHub issue #${issueNumber} reopened — auto-recovered to backlog`,
           });
           events.emit('feature:issue-reopened', {

--- a/apps/server/src/services/feature-lifecycle-bus-publisher.ts
+++ b/apps/server/src/services/feature-lifecycle-bus-publisher.ts
@@ -8,9 +8,10 @@
  * publishes one of three dotted, unprefixed topics workstacean's consumers
  * subscribe to:
  *
- *   - `done`      → `feature.completed`
- *   - `blocked`   → `feature.blocked`   (carries a `kind` failure discriminator)
- *   - `escalated` → `feature.failed`    (already escalated — no auto-remediation)
+ *   - `done`               → `feature.completed`
+ *   - `done` + `archived`  → `feature.cancelled`  (terminal but not shipped, #4103)
+ *   - `blocked`            → `feature.blocked`    (carries a `kind` failure discriminator)
+ *   - `escalated`          → `feature.failed`     (already escalated — no auto-remediation)
  *
  * `feature.blocked` is split out of the generic `feature.failed` so
  * workstacean's FeatureRemediationPlugin can route a per-feature signal to
@@ -60,6 +61,22 @@ const UNBLOCKED_TARGET_STATUSES: ReadonlySet<string> = new Set([
   'backlog',
   'review',
 ]);
+
+/**
+ * One lifecycle signal per transition. `cancelled` is a terminal feature that was
+ * archived on close (e.g. its issue was closed "not planned", #4103) — NOT shipped,
+ * so it's distinct from `completed`. Topic = what workstacean's consumers subscribe
+ * to; timestampKey = the field name carrying the transition time.
+ */
+type LifecycleSignal = 'cancelled' | 'completed' | 'blocked' | 'unblocked' | 'failed';
+
+const LIFECYCLE_SIGNALS: Record<LifecycleSignal, { topic: string; timestampKey: string }> = {
+  cancelled: { topic: 'feature.cancelled', timestampKey: 'cancelledAt' },
+  completed: { topic: 'feature.completed', timestampKey: 'completedAt' },
+  blocked: { topic: 'feature.blocked', timestampKey: 'blockedAt' },
+  unblocked: { topic: 'feature.unblocked', timestampKey: 'unblockedAt' },
+  failed: { topic: 'feature.failed', timestampKey: 'failedAt' },
+};
 
 /**
  * Failure-category discriminator workstacean's router consumes to decide
@@ -271,17 +288,20 @@ export class FeatureLifecycleBusPublisher {
       logger.warn(`Could not load feature ${featureId} for lifecycle event:`, err);
     }
 
-    // Dotted, unprefixed topics — exactly what workstacean's consumers
-    // subscribe to. `blocked` is its own remediable signal; `unblocked` is the
-    // recovery signal that clears remediation tracking; `escalated` stays
-    // `feature.failed` (no auto-remediation); `done` is `feature.completed`.
-    const topic = isTerminal
-      ? 'feature.completed'
-      : isBlocked
-        ? 'feature.blocked'
-        : isUnblock
-          ? 'feature.unblocked'
-          : 'feature.failed';
+    // Classify into exactly one lifecycle signal (see LIFECYCLE_SIGNALS). A terminal
+    // feature that was ARCHIVED on close is a cancellation, not a completion — e.g. its
+    // GitHub issue was closed "not planned" (#4103) — so workstacean doesn't record it
+    // as shipped or run the close-the-loop it does for feature.completed. (archiveFeature
+    // writes its stub without a status-changed event, so this only fires for the in-band
+    // not-planned close that archives via update().)
+    const isCancelled = isTerminal && feature?.archived === true;
+    let signal: LifecycleSignal = 'failed';
+    if (isCancelled) signal = 'cancelled';
+    else if (isTerminal) signal = 'completed';
+    else if (isBlocked) signal = 'blocked';
+    else if (isUnblock) signal = 'unblocked';
+    const { topic, timestampKey } = LIFECYCLE_SIGNALS[signal];
+
     const owner = process.env.GITHUB_REPO_OWNER;
     const name = process.env.GITHUB_REPO_NAME;
     const repo = owner && name ? `${owner}/${name}` : undefined;
@@ -291,13 +311,6 @@ export class FeatureLifecycleBusPublisher {
       feature?.sourceMeta && typeof feature.sourceMeta === 'object'
         ? feature.sourceMeta
         : { sourceChannel: feature?.sourceChannel, signalMetadata: feature?.signalMetadata };
-    const timestampKey = isTerminal
-      ? 'completedAt'
-      : isBlocked
-        ? 'blockedAt'
-        : isUnblock
-          ? 'unblockedAt'
-          : 'failedAt';
     const data: Record<string, unknown> = {
       // projectSlug is REQUIRED by workstacean's feature-notifier (resolves the
       // dev channel); fall back so the event is never dropped for lacking it.
@@ -339,6 +352,10 @@ export class FeatureLifecycleBusPublisher {
     } else if (isEscalated) {
       // feature.failed keeps the historical `error` field for existing consumers.
       data.error = (feature?.statusChangeReason ?? payload?.reason ?? 'failed').slice(0, 400);
+    }
+    if (isCancelled) {
+      // Why it was cancelled (e.g. "closed as not planned"), for consumer logging.
+      data.reason = (feature?.statusChangeReason ?? payload?.reason ?? 'cancelled').slice(0, 400);
     }
 
     try {

--- a/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
+++ b/apps/server/tests/unit/services/feature-lifecycle-bus-publisher.test.ts
@@ -51,6 +51,33 @@ describe('FeatureLifecycleBusPublisher', () => {
     expect(arg.data.sourceMeta.sourceChannel).toBe('github');
   });
 
+  it('publishes feature.cancelled (not completed) when a terminal feature is archived', async () => {
+    // A not_planned issue close terminalizes to done AND archives the feature (#4103):
+    // it must read as a cancellation, never as shipped work.
+    const feature = {
+      id: 'f9',
+      title: 'Abandoned',
+      projectSlug: 'proj',
+      archived: true,
+      statusChangeReason: 'GitHub issue #5 closed as not planned — archived (not shipped)',
+    };
+    const { pub, publishFn } = makePublisher({ feature });
+
+    await pub.handleStatusChange({
+      featureId: 'f9',
+      projectPath: '/p',
+      oldStatus: 'backlog',
+      newStatus: 'done',
+    });
+
+    expect(publishFn).toHaveBeenCalledTimes(1);
+    const arg = publishFn.mock.calls[0][0];
+    expect(arg.event).toBe('feature.cancelled');
+    expect(arg.data.cancelledAt).toBeDefined();
+    expect(arg.data.completedAt).toBeUndefined();
+    expect(arg.data.reason).toContain('not planned');
+  });
+
   it('echoes feature.sourceMeta when present (manage_feature meta)', async () => {
     const feature = {
       id: 'f1',


### PR DESCRIPTION
## Problem (#4103)
A GitHub issue closed as **not planned** (wontfix/duplicate/abandoned) terminalized its linked feature to `done`, so `FeatureLifecycleBusPublisher` emitted **`feature.completed`** → workstacean recorded it as shipped and it inflated done/throughput counts. The board's only terminal status is `done`, so #4102 had to map both completion and abandonment to it.

## Fix (minimal — no new board status)
The full `cancelled` board status is deferred; this solves the stated harm with the existing model:

- **Webhook handler**: a `not_planned` close sets `done` **+ `archived: true`** — the feature clears the active board (archived is filtered out everywhere) without counting as shipped. A genuine `completed` close stays a plain `done`.
- **Lifecycle bus**: a terminal feature that is `archived` publishes **`feature.cancelled`** (with `cancelledAt` + reason) instead of `feature.completed`. `archiveFeature` writes its stub *without* a status-changed event, so this only fires for the in-band not-planned close that archives via `update()`; persist-before-emit guarantees the bus's fresh load sees `archived=true`.
- **Reopened path**: un-archives (`archived: false`) so a reopened issue restores its feature to the active backlog.

Also refactored the bus topic/timestamp resolution from **nested ternaries** to a single `LifecycleSignal` discriminant + `LIFECYCLE_SIGNALS` lookup table.

## Why minimal
A dedicated `cancelled` terminal status would touch ~20 UI files (board columns/colors), DORA/metrics, and normalization — a board-UX product decision. This achieves #4103's acceptance (no false `feature.completed`, not counted as shipped, reopen recovers) without that surface. Leaving #4103 open to track the fuller status if wanted.

## Tests
- New: terminal + archived publishes `feature.cancelled` (not `feature.completed`), with `cancelledAt` + reason.
- Existing bus (27), feature-loader (60), webhook-wiring (3) suites stay green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)