### PR TITLE
bug: review features with merged PRs not auto-transitioned to done

### DIFF
--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -993,7 +993,7 @@ export class FeatureScheduler {
 
       const doneWithPrGuard = allFeatures.filter(
         (f) =>
-          (f.status === 'backlog' || f.status === 'blocked') &&
+          (f.status === 'backlog' || f.status === 'blocked' || f.status === 'review') &&
           !alreadyReconciled.has(f.id) &&
           (f.statusHistory ?? []).some(
             (t) =>


### PR DESCRIPTION
## Summary

## Bug

After a PR merges, features in `review` status stay stuck there. The merged-PR reconciliation sweep does not pick them up.

## Observed (2026-04-08, protoWorkstacean)

- PR #21 (M2 Discord Autocomplete) merged — feature stayed `review`
- PR #22 (M3 Plane Backfill) — same
- PR #23 (Google Workspace) — same

All 3 required direct `feature.json` edits each time to unblock the dependency chain.

## Root cause hypothesis

`loadPendingFeatures()` in `apps/server/src/services/feature-scheduler....

Closes #4108

---
*Created automatically by Automaker*

<!-- automaker:owner instance=ef15d09b-b02a-4f05-bb57-fcc898070dd7 team= created=2026-06-06T20:35:47.449Z -->