### PR TITLE
bug: .automaker-lock tracked by git causes rebase conflict on every agent branch

### DIFF
--- a/apps/server/src/lib/git-staging-utils.ts
+++ b/apps/server/src/lib/git-staging-utils.ts
@@ -94,3 +94,46 @@ export function buildGitAddArgs(workDir: string): string[] {
 
   return [...args, '--', ...pathspecs];
 }
+
+/**
+ * Files that should be gitignored but may have been committed before the
+ * .gitignore entry was added, causing them to remain tracked.
+ *
+ * When a new worktree branch is created, these files are removed from the
+ * index via `git rm --cached` so that subsequent commits don't include them.
+ */
+const TRACKED_BUT_GITIGNORED = ['.automaker-lock'];
+
+/**
+ * Unstage files that are tracked by git but should be gitignored.
+ *
+ * `.automaker-lock` was committed before `.gitignore` was updated. Every
+ * agent modifies it, causing `force-with-lease` rejections and rebase
+ * conflicts. This function removes such files from the index on worktree
+ * init so they no longer participate in git operations.
+ *
+ * Safe to call repeatedly — if the file is not tracked, `git rm --cached`
+ * will fail silently and we swallow the error.
+ */
+export async function unstageGitignoredFiles(workDir: string): Promise<void> {
+  const { execFile } = await import('child_process');
+  const { promisify } = await import('util');
+  const execFileAsync = promisify(execFile);
+
+  for (const file of TRACKED_BUT_GITIGNORED) {
+    try {
+      // Only unstage if the file is actually tracked in this worktree.
+      // `git ls-files --error-unmatch` exits 0 if tracked, 1 if not.
+      await execFileAsync('git', ['ls-files', '--error-unmatch', file], {
+        cwd: workDir,
+      });
+
+      // File is tracked — remove it from the index.
+      await execFileAsync('git', ['rm', '--cached', file], {
+        cwd: workDir,
+      });
+    } catch {
+      // File not tracked or already unstaged — no-op.
+    }
+  }
+}

--- a/apps/server/src/routes/worktree/routes/create.ts
+++ b/apps/server/src/routes/worktree/routes/create.ts
@@ -26,6 +26,7 @@ import { trackBranch } from './branch-tracking.js';
 import { createLogger } from '@protolabsai/utils';
 import { runInitScript } from '../../../services/init-script-service.js';
 import { installWorktreeDependencies } from '../../../services/worktree-lifecycle-service.js';
+import { unstageGitignoredFiles } from '../../../lib/git-staging-utils.js';
 const logger = createLogger('Worktree');
 
 const execAsync = promisify(exec);
@@ -197,6 +198,16 @@ export function createCreateHandler(events: EventEmitter) {
         logger.debug(`Set local git identity in worktree: ${worktreePath}`);
       } catch (err) {
         logger.warn(`Failed to set local git identity in worktree (non-fatal): ${err}`);
+      }
+
+      // Unstage files that are tracked by git but should be gitignored.
+      // `.automaker-lock` was committed before `.gitignore` was updated, so it
+      // remains tracked. Removing it from the index prevents every agent commit
+      // from including it, which caused force-with-lease rejections and rebase conflicts.
+      try {
+        await unstageGitignoredFiles(worktreePath);
+      } catch (err) {
+        logger.warn(`Failed to unstage gitignored files (non-fatal): ${err}`);
       }
 
       // Note: We intentionally do NOT symlink .automaker to worktrees

--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -16,7 +16,7 @@ import { simpleQuery } from '../providers/simple-query-service.js';
 import { StreamObserver } from './stream-observer-service.js';
 import { getWorkflowSettings, getEffectivePrBaseBranch } from '../lib/settings-helpers.js';
 import { setFeatureContext } from '@protolabsai/error-tracking';
-import { buildGitAddCommand } from '../lib/git-staging-utils.js';
+import { buildGitAddCommand, unstageGitignoredFiles } from '../lib/git-staging-utils.js';
 
 /**
  * Error thrown when stream observer detects an agent loop.
@@ -3297,6 +3297,16 @@ Format your response as a structured markdown document.`;
         logger.debug(`Set local git identity in worktree: ${resolvedWorktreePath}`);
       } catch (err) {
         logger.warn('Failed to set local git identity in worktree (non-fatal):', err);
+      }
+
+      // Unstage files that are tracked by git but should be gitignored.
+      // `.automaker-lock` was committed before `.gitignore` was updated, so it
+      // remains tracked. Removing it from the index prevents every agent commit
+      // from including it, which caused force-with-lease rejections and rebase conflicts.
+      try {
+        await unstageGitignoredFiles(resolvedWorktreePath);
+      } catch (err) {
+        logger.warn('Failed to unstage gitignored files (non-fatal):', err);
       }
 
       // Exclude .automaker/features/ from worktree git status to prevent


### PR DESCRIPTION
## Summary

## Bug

`.automaker-lock` is in `.gitignore` but still tracked by git (committed before the gitignore entry was added). Every agent modifies it, causing `force-with-lease` rejections and rebase conflicts when dev advances.

## Observed (2026-04-08, protoWorkstacean)

Every PR (M2, M3, Google Workspace) hit this pattern:
1. Agent commits work
2. dev advances (another PR merges)
3. Auto-mode tries `git push --force-with-lease` → rejected (stale info)
4. Rebase fails: `.automaker-lock` has unstaged...

Closes #4109

---
*Created automatically by Automaker*

<!-- automaker:owner instance=ef15d09b-b02a-4f05-bb57-fcc898070dd7 team= created=2026-06-06T20:41:12.039Z -->