### PR TITLE
[github] feat: model selection — antagonistic review + Cindi + Specialist Agents UI tab (Phase 1)

### DIFF
--- a/apps/server/src/services/plan-review-service.ts
+++ b/apps/server/src/services/plan-review-service.ts
@@ -12,8 +12,10 @@
 
 import { createLogger } from '@protolabsai/utils';
 import type { StructuredPlan } from '@protolabsai/types';
-import { resolveModelString } from '@protolabsai/model-resolver';
+import { resolvePhaseModel } from '@protolabsai/model-resolver';
 import { simpleQuery } from '../providers/simple-query-service.js';
+import { getPhaseModelWithOverrides } from '../lib/settings-helpers.js';
+import type { SettingsService } from './settings-service.js';
 
 const logger = createLogger('PlanReview');
 
@@ -37,6 +39,7 @@ export class PlanReviewService {
     planOutput: string;
     projectPath: string;
     structuredPlan?: StructuredPlan;
+    settingsService?: SettingsService | null;
   }): Promise<{
     approved: boolean;
     reason?: string;
@@ -50,7 +53,16 @@ export class PlanReviewService {
       planOutput,
       projectPath,
       structuredPlan,
+      settingsService,
     } = params;
+
+    // Resolve model from phase model config
+    const { phaseModel } = await getPhaseModelWithOverrides(
+      'antagonisticReviewModel',
+      settingsService,
+      projectPath
+    );
+    const model = resolvePhaseModel(phaseModel).model;
 
     logger.info('[verifyPlan] Running plan review', {
       featureTitle,
@@ -67,6 +79,8 @@ export class PlanReviewService {
         planOutput,
         projectPath,
         structuredPlan,
+        model,
+        settingsService,
       });
     }
 

--- a/libs/types/src/agent-settings.ts
+++ b/libs/types/src/agent-settings.ts
@@ -222,6 +222,12 @@ export interface PhaseModelConfig {
    * When a flow runs with a matching flowId, its model entry overrides the default.
    */
   flowModels?: Record<string, PhaseModelEntry>;
+
+  // Specialist agent models — review agents that were previously hardcoded to 'haiku'
+  /** Model for antagonistic plan review (PlanReviewService — standard + goal-backward review) */
+  antagonisticReviewModel: PhaseModelEntry;
+  /** Model for inline fallback review when PlanReviewService is not wired (PlanProcessor) */
+  inlineReviewModel: PhaseModelEntry;
 }
 
 /**
@@ -280,6 +286,10 @@ export const DEFAULT_PHASE_MODELS: PhaseModelConfig = {
   complexityMediumModel: { model: 'protolabs/smart' },
   complexityLargeModel: { model: 'protolabs/smart' },
   complexityArchitecturalModel: { model: 'protolabs/reasoning' },
+
+  // Specialist agent models — review agents (fast tier matches previous 'haiku' default)
+  antagonisticReviewModel: { model: 'protolabs/fast' },
+  inlineReviewModel: { model: 'protolabs/fast' },
 };
 
 /**


### PR DESCRIPTION
## Summary

# SPARC PRD: Model Selection — Specialist Agents UI Tab (Phase 1)

## Situation

The protoMaker platform uses a `PhaseModelConfig` system (`libs/types/src/agent-settings.ts`) allowing operators to configure LLM models per workflow phase (enhancement, spec generation, coding, etc.). The UI exposes these controls via a "Model Defaults" settings tab (`apps/ui/src/components/views/settings-view/model-defaults/`), and the server resolves models through `getPhaseModelWithOverrides()` (`apps/server/src...

Closes #4110

---
*Created automatically by Automaker*

<!-- automaker:owner instance=ef15d09b-b02a-4f05-bb57-fcc898070dd7 team= created=2026-06-06T22:32:58.236Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable specialist agent models for antagonistic and inline review processes
  * Enabled customization of phase model behavior through settings service integration, allowing users to tailor review configurations to their needs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->