### PR TITLE
[github] auto-mode review-remediation: surface the failing-test output to the fixing agent + revisit the 2-cy

### DIFF
--- a/apps/server/src/services/auto-mode-service.ts
+++ b/apps/server/src/services/auto-mode-service.ts
@@ -225,12 +225,6 @@ export class AutoModeService {
   // Track which projects have already been checked for interrupted features this server lifecycle.
   // Prevents the UI from re-triggering resumeInterruptedFeatures on every board mount.
   private resumeCheckedProjects = new Set<string>();
-  /**
-   * Pending CI failure messages to inject into running agent sessions.
-   * Keyed by featureId. Consumed by executeFeature continuation after the
-   * current agent turn completes (when isAgentRunning was true at receipt).
-   */
-  private pendingCIInjections = new Map<string, string>();
   // Memory management thresholds (configurable via env vars)
   private readonly HEAP_USAGE_STOP_NEW_AGENTS_THRESHOLD = parseFloat(
     process.env.HEAP_STOP_THRESHOLD || '0.8'
@@ -1070,7 +1064,6 @@ export class AutoModeService {
       if (running.projectPath === projectPath) {
         running.abortController.abort();
         this.runningFeatures.delete(featureId);
-        this.pendingCIInjections.delete(featureId);
         logger.info(`Aborted running feature ${featureId} during auto-loop stop`);
       }
     }
@@ -1524,7 +1517,6 @@ export class AutoModeService {
     // The abort signal will still propagate to stop any ongoing execution
     this.concurrencyManager.release(featureId);
     this.runningFeatures.delete(featureId);
-    this.pendingCIInjections.delete(featureId);
     this.typedEventBus.clearFeature(featureId);
     activeAgentsCount.set(this.runningFeatures.size);
 
@@ -1587,7 +1579,6 @@ export class AutoModeService {
       logger.info(`[Shutdown] Aborted feature: ${featureId}`);
     }
     this.runningFeatures.clear();
-    this.pendingCIInjections.clear();
 
     // Unsubscribe all event listeners to prevent leaks on restart
     for (const sub of this.eventSubscriptions) {
@@ -1610,42 +1601,6 @@ export class AutoModeService {
   isAgentRunning(featureId: string, projectPath: string): boolean {
     const running = this.runningFeatures.get(featureId);
     return running !== undefined && running.projectPath === projectPath;
-  }
-
-  /**
-   * Inject a CI failure message into the running agent session for a feature.
-   * Stores the message as a pending CI injection; the message will be used as a
-   * continuation prompt after the current agent turn completes, so the agent
-   * can fix the CI failure without a full restart.
-   *
-   * Matches on both featureId and projectPath to prevent cross-project injection.
-   * Returns true if a running session was found and the injection was queued.
-   */
-  async sendCIFailureToAgent(
-    featureId: string,
-    projectPath: string,
-    message: string
-  ): Promise<boolean> {
-    const running = this.runningFeatures.get(featureId);
-    if (!running || running.projectPath !== projectPath) {
-      return false;
-    }
-    this.pendingCIInjections.set(featureId, message);
-    logger.info(`CI failure queued for injection into running agent for feature ${featureId}`);
-    return true;
-  }
-
-  /**
-   * Consume and return a pending CI injection message for a feature (if any).
-   * Called by executeFeature after the current run completes to chain the CI fix.
-   * @internal
-   */
-  consumePendingCIInjection(featureId: string): string | undefined {
-    const message = this.pendingCIInjections.get(featureId);
-    if (message !== undefined) {
-      this.pendingCIInjections.delete(featureId);
-    }
-    return message;
   }
 
   /**

--- a/apps/server/src/services/ci-failure-evidence-collector.ts
+++ b/apps/server/src/services/ci-failure-evidence-collector.ts
@@ -1,0 +1,391 @@
+/**
+ * CI Failure Evidence Collector
+ *
+ * Fetches structured failure evidence from GitHub check runs for a given PR.
+ * Prefers annotations (structured file:line:message data) over raw log parsing.
+ * Falls back to log excerpt extraction when annotations are unavailable.
+ */
+
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import type { CIFailureEvidence } from '@protolabsai/types';
+import { createLogger } from '@protolabsai/utils';
+import type { StateContext } from './lead-engineer-types.js';
+
+const execAsync = promisify(exec);
+const logger = createLogger('CIFailureEvidenceCollector');
+
+/** Hard cap on log excerpt lines to prevent context window blowout. */
+const MAX_LOG_LINES = 500;
+
+/** Patterns that indicate test failure or assertion lines in CI logs. */
+const FAILURE_PATTERNS = [
+  /FAIL\b/i,
+  /\bexpect\s*\(/,
+  /\bError:/,
+  /\bAssertionError/,
+  /\breceived\b/i,
+  /\bexpected\b/i,
+  /\bat\s+/,
+  /\breceived length/i,
+  /\bexpected length/i,
+  /\breceived array/i,
+  /\breceived string/i,
+  /\b-d\b/, // diff removed lines
+  /\b\+d\b/, // diff added lines
+];
+
+/**
+ * Fetch the repo slug (owner/repo) via `gh repo view`.
+ */
+async function getRepoSlug(projectPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execAsync('gh repo view --json nameWithOwner -q .nameWithOwner', {
+      cwd: projectPath,
+      timeout: 10000,
+    });
+    return stdout.trim() || null;
+  } catch (err) {
+    logger.warn('Failed to fetch repo slug:', err);
+    return null;
+  }
+}
+
+/**
+ * Fetch the head commit SHA for a PR via `gh pr view`.
+ */
+async function getPrHeadSha(projectPath: string, prNumber: number): Promise<string | null> {
+  try {
+    const { stdout } = await execAsync(`gh pr view ${prNumber} --json headRefOid -q .headRefOid`, {
+      cwd: projectPath,
+      timeout: 10000,
+    });
+    return stdout.trim() || null;
+  } catch (err) {
+    logger.warn('Failed to fetch PR head SHA:', err);
+    return null;
+  }
+}
+
+/**
+ * Fetch failed check runs for a commit via GitHub API.
+ * Returns array of { id, name, html_url }.
+ */
+async function getFailedCheckRuns(
+  slug: string,
+  sha: string,
+  projectPath: string
+): Promise<Array<{ id: string; name: string; html_url: string }>> {
+  try {
+    const { stdout } = await execAsync(
+      `gh api repos/${slug}/commits/${sha}/check-runs --jq '[.check_runs[] | select(.conclusion == "failure")] | [.[] | {id: (.id | tostring), name, html_url}]'`,
+      { cwd: projectPath, timeout: 15000 }
+    );
+    const output = stdout.trim();
+    if (!output || output === '[]') return [];
+    return JSON.parse(output);
+  } catch (err) {
+    logger.warn('Failed to fetch failed check runs:', err);
+    return [];
+  }
+}
+
+/**
+ * Fetch check run output (title, summary, annotations) for a specific check run.
+ */
+async function getCheckRunOutput(
+  slug: string,
+  checkRunId: string,
+  projectPath: string
+): Promise<{
+  title?: string;
+  summary?: string;
+  annotations?: Array<{
+    path?: string;
+    start_line?: number;
+    end_line?: number;
+    annotation_level?: 'notice' | 'warning' | 'failure';
+    message?: string;
+    title?: string;
+    raw_details?: string;
+  }>;
+} | null> {
+  try {
+    const { stdout } = await execAsync(
+      `gh api repos/${slug}/check-runs/${checkRunId}/output --jq '{title: .title, summary: (.summary // ""), annotations: (.annotations // [])}'`,
+      { cwd: projectPath, timeout: 15000 }
+    );
+    const output = stdout.trim();
+    if (!output || output === '{}' || output === 'null') return null;
+    return JSON.parse(output);
+  } catch (err) {
+    logger.warn(`Failed to fetch check run output for ${checkRunId}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Fetch the full check run log via `gh run view --log-failed`, truncated and filtered.
+ */
+async function getFailedStepLog(projectPath: string, prNumber: number): Promise<string | null> {
+  try {
+    // Get the workflow run ID for the PR
+    const { stdout: runsOut } = await execAsync(
+      `gh pr checks ${prNumber} --json databaseId -q .[].databaseId | head -1`,
+      { cwd: projectPath, timeout: 10000 }
+    );
+    const runId = runsOut.trim();
+    if (!runId) return null;
+
+    const { stdout } = await execAsync(`gh run view ${runId} --log-failed 2>/dev/null || true`, {
+      cwd: projectPath,
+      timeout: 20000,
+    });
+    const lines = stdout.split('\n');
+    // Take last MAX_LOG_LINES lines
+    const truncated = lines.slice(-MAX_LOG_LINES);
+    // Filter for failure-relevant lines
+    const relevant = truncated.filter((line) => FAILURE_PATTERNS.some((pat) => pat.test(line)));
+    // If filtering removed too much, return raw truncated
+    return relevant.length > 0 ? relevant.join('\n') : truncated.join('\n');
+  } catch (err) {
+    logger.warn('Failed to fetch failed step log:', err);
+    return null;
+  }
+}
+
+/**
+ * Extract test name and assertion details from a log excerpt or summary.
+ */
+function parseTestFailureDetails(text: string): {
+  testFile?: string;
+  testName?: string;
+  assertion?: string;
+  expectedValue?: string;
+  receivedValue?: string;
+  location?: string;
+} {
+  const result: {
+    testFile?: string;
+    testName?: string;
+    assertion?: string;
+    expectedValue?: string;
+    receivedValue?: string;
+    location?: string;
+  } = {};
+
+  // Extract test file from paths like "src/foo/bar.test.ts" or "tests/foo.spec.ts"
+  const fileMatch = text.match(/([\w/.-]+(?:\.test|\.spec)\.(?:ts|js|tsx|jsx))/);
+  if (fileMatch) {
+    result.testFile = fileMatch[1];
+  }
+
+  // Extract test name: "describe('...')" or "it('...')" or "✓/✕ ..."
+  const testNameMatch = text.match(/(?:describe|it|test)\s*\(\s*['"]([^'"]+)['"]/);
+  if (testNameMatch) {
+    result.testName = testNameMatch[1];
+  }
+
+  // Extract assertion: expect(...).to...
+  const assertionMatch = text.match(/expect\s*\([^)]+\)\s*\.\w+(\([^)]*\))?/);
+  if (assertionMatch) {
+    result.assertion = assertionMatch[0];
+  }
+
+  // Extract expected value
+  const expectedMatch = text.match(/(?:expected|Expected)[^:]*:\s*(.+)/i);
+  if (expectedMatch) {
+    result.expectedValue = expectedMatch[1].trim();
+  }
+
+  // Extract received value
+  const receivedMatch = text.match(/(?:received|Received)[^:]*:\s*(.+)/i);
+  if (receivedMatch) {
+    result.receivedValue = receivedMatch[1].trim();
+  }
+
+  // Extract file:line location
+  const locationMatch = text.match(/([\w/.-]+\.\w+):(\d+)/);
+  if (locationMatch) {
+    result.location = `${locationMatch[1]}:${locationMatch[2]}`;
+  }
+
+  return result;
+}
+
+/**
+ * Collect structured CI failure evidence for a PR's failed checks.
+ *
+ * Strategy:
+ * 1. Fetch head SHA for the PR
+ * 2. Fetch failed check runs via GitHub API
+ * 3. For each failed check, fetch output + annotations
+ * 4. Parse annotations for structured failure details
+ * 5. Fall back to log parsing when annotations are empty
+ */
+export async function collectCIFailureEvidence(ctx: StateContext): Promise<CIFailureEvidence[]> {
+  const { feature, projectPath } = ctx;
+  const prNumber = feature.prNumber ?? ctx.prNumber;
+
+  if (!prNumber) {
+    logger.warn('No PR number available for CI evidence collection');
+    return [];
+  }
+
+  const slug = await getRepoSlug(projectPath);
+  if (!slug) {
+    logger.warn('Could not resolve repo slug for CI evidence collection');
+    return [];
+  }
+
+  const sha = await getPrHeadSha(projectPath, prNumber);
+  if (!sha) {
+    logger.warn(`Could not resolve head SHA for PR #${prNumber}`);
+    return [];
+  }
+
+  const failedChecks = await getFailedCheckRuns(slug, sha, projectPath);
+  if (failedChecks.length === 0) {
+    return [];
+  }
+
+  const evidences: CIFailureEvidence[] = [];
+
+  for (const check of failedChecks) {
+    const evidence: CIFailureEvidence = {
+      checkName: check.name,
+      checkUrl: check.html_url,
+    };
+
+    // Fetch check run output
+    const output = await getCheckRunOutput(slug, check.id, projectPath);
+
+    if (output) {
+      // Prefer annotations
+      if (output.annotations && output.annotations.length > 0) {
+        evidence.annotations = output.annotations;
+
+        // Extract details from annotations
+        const failureAnnotations = output.annotations.filter(
+          (a) => a.annotation_level === 'failure'
+        );
+
+        if (failureAnnotations.length > 0) {
+          const first = failureAnnotations[0];
+          if (first.path) {
+            evidence.testFile = first.path;
+          }
+          if (first.start_line) {
+            evidence.location = `${first.path || 'unknown'}:${first.start_line}`;
+          }
+          if (first.message) {
+            const parsed = parseTestFailureDetails(first.message);
+            Object.assign(evidence, parsed);
+            if (!evidence.testName && first.title) {
+              evidence.testName = first.title;
+            }
+          }
+          if (first.raw_details) {
+            const parsed = parseTestFailureDetails(first.raw_details);
+            Object.assign(evidence, parsed);
+          }
+        }
+
+        // If annotations exist but no failure-level ones, use summary
+        if (!evidence.testName && output.summary) {
+          const parsed = parseTestFailureDetails(output.summary);
+          Object.assign(evidence, parsed);
+        }
+      } else if (output.summary && output.summary.trim()) {
+        // No annotations, parse summary
+        const parsed = parseTestFailureDetails(output.summary);
+        Object.assign(evidence, parsed);
+        // Use summary as log excerpt if it's substantial
+        if (output.summary.trim().length > 50) {
+          evidence.logExcerpt = output.summary.trim().slice(0, 3000);
+        }
+      }
+    }
+
+    // If we still have no log excerpt, try fetching failed step logs
+    if (!evidence.logExcerpt && !evidence.annotations?.length) {
+      const log = await getFailedStepLog(projectPath, prNumber);
+      if (log && log.trim().length > 10) {
+        evidence.logExcerpt = log.trim().slice(0, 5000);
+        // Try to parse details from the log
+        const parsed = parseTestFailureDetails(log);
+        Object.assign(evidence, parsed);
+      }
+    }
+
+    evidences.push(evidence);
+  }
+
+  logger.info(
+    `Collected CI failure evidence for ${evidences.length} failed check(s) on PR #${prNumber}`
+  );
+
+  return evidences;
+}
+
+/**
+ * Format CI failure evidence as structured markdown for agent prompt injection.
+ */
+export function formatCIFailureEvidence(evidences: CIFailureEvidence[]): string {
+  if (!evidences.length) return '';
+
+  const parts: string[] = ['### CI Failure Evidence\n'];
+
+  for (const ev of evidences) {
+    parts.push(`**Failed check:** \`${ev.checkName}\``);
+    if (ev.checkUrl) {
+      parts.push(`[View on GitHub](${ev.checkUrl})`);
+    }
+
+    if (ev.testFile || ev.testName) {
+      const testDesc = [ev.testFile, ev.testName].filter(Boolean).join(' — ');
+      parts.push(`**Failing test:** \`${testDesc}\``);
+    }
+
+    if (ev.assertion) {
+      parts.push(`**Assertion:** \`${ev.assertion}\``);
+    }
+
+    if (ev.expectedValue || ev.receivedValue) {
+      const vals: string[] = [];
+      if (ev.expectedValue) vals.push(`expected: ${ev.expectedValue}`);
+      if (ev.receivedValue) vals.push(`received: ${ev.receivedValue}`);
+      parts.push(`**Values:** ${vals.join(' → ')}`);
+    }
+
+    if (ev.location) {
+      parts.push(`**Location:** \`${ev.location}\``);
+    }
+
+    if (ev.annotations && ev.annotations.length > 0) {
+      const failureAnns = ev.annotations.filter((a) => a.annotation_level === 'failure');
+      if (failureAnns.length > 0) {
+        parts.push('**Annotations:**');
+        for (const ann of failureAnns.slice(0, 5)) {
+          const loc = ann.path
+            ? `${ann.path}${ann.start_line ? ':' + ann.start_line : ''}`
+            : 'unknown';
+          parts.push(`- \`${loc}\`: ${ann.message || ann.title || '(no message)'}`);
+        }
+      }
+    }
+
+    if (ev.logExcerpt) {
+      parts.push('**Log excerpt:**');
+      parts.push('```');
+      // Cap at MAX_LOG_LINES to prevent context blowout
+      const lines = ev.logExcerpt.split('\n').slice(0, MAX_LOG_LINES);
+      parts.push(...lines);
+      parts.push('```');
+    }
+
+    parts.push('');
+  }
+
+  return parts.join('\n');
+}

--- a/apps/server/src/services/lead-engineer-execute-processor.ts
+++ b/apps/server/src/services/lead-engineer-execute-processor.ts
@@ -18,6 +18,7 @@ import type {
   PipelinePhase,
   StructuredPlan,
   VerifiedTrajectory,
+  CIFailureEvidence,
 } from '@protolabsai/types';
 import { deriveVerificationTier } from '@protolabsai/types';
 import type {
@@ -27,6 +28,7 @@ import type {
   StateTransitionResult,
 } from './lead-engineer-types.js';
 import { EXECUTE_TIMEOUT_MS, MAX_AGENT_RETRIES, MAX_INFRA_RETRIES } from './lead-engineer-types.js';
+import { formatCIFailureEvidence } from './ci-failure-evidence-collector.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -1945,6 +1947,14 @@ export class ExecuteProcessor implements StateProcessor {
         contextParts.push(this.formatStructuredPlan(ctx.structuredPlan));
       } else if (ctx.planOutput) {
         contextParts.push(`## Implementation Plan\n\n${ctx.planOutput}`);
+      }
+      // Inject structured CI failure evidence (test names, assertions, log excerpts)
+      // when available — takes priority over plain review feedback for CI failures.
+      if (ctx.ciFailureEvidence && ctx.ciFailureEvidence.length > 0) {
+        const formatted = formatCIFailureEvidence(ctx.ciFailureEvidence);
+        if (formatted) {
+          contextParts.push(formatted);
+        }
       }
       if (ctx.reviewFeedback) {
         contextParts.push(

--- a/apps/server/src/services/lead-engineer-review-merge-processors.ts
+++ b/apps/server/src/services/lead-engineer-review-merge-processors.ts
@@ -9,7 +9,7 @@ import { exec } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { promisify } from 'node:util';
 import { createLogger } from '@protolabsai/utils';
-import type { EventType, PRMergeStrategy } from '@protolabsai/types';
+import type { EventType, PRMergeStrategy, CIFailureEvidence } from '@protolabsai/types';
 import {
   buildFreshEyesReviewPrompt,
   parseFreshEyesVerdict,
@@ -43,6 +43,10 @@ import {
   RemediationBudgetEnforcer,
   DEFAULT_CI_REACTION_SETTINGS,
 } from './remediation-budget-enforcer.js';
+import {
+  collectCIFailureEvidence,
+  formatCIFailureEvidence,
+} from './ci-failure-evidence-collector.js';
 
 const execAsync = promisify(exec);
 const logger = createLogger('LeadEngineerService');
@@ -433,7 +437,7 @@ export class ReviewProcessor implements StateProcessor {
     }
 
     if (reviewState === 'ci_failed') {
-      // Check CI remediation budget
+      // Resolve settings (env var overrides applied at DEFAULT_CI_REACTION_SETTINGS init time)
       const ciWorkflowSettings = await getWorkflowSettings(
         ctx.projectPath,
         this.serviceContext.settingsService,
@@ -442,6 +446,62 @@ export class ReviewProcessor implements StateProcessor {
       const ciReactionSettings =
         ciWorkflowSettings.ciReactionSettings ?? DEFAULT_CI_REACTION_SETTINGS;
 
+      // Fetch failing CI check names first (needed for evidence count + progress tracking)
+      let ciFailureNames: string[] = [];
+      try {
+        const { stdout } = await execAsync(
+          `gh pr view ${ctx.prNumber} --json statusCheckRollup --jq '[(.statusCheckRollup // [])[] | select(.conclusion == "FAILURE") | .context] | join(", ")'`,
+          { cwd: ctx.projectPath, timeout: 15000 }
+        );
+        const names = stdout.trim();
+        if (names) {
+          ciFailureNames = names.split(', ').filter(Boolean);
+        }
+      } catch (err) {
+        logger.warn('[REVIEW] Failed to fetch CI check failure names:', err);
+      }
+
+      // Collect structured CI failure evidence (annotations, log excerpts)
+      let evidences: CIFailureEvidence[] = [];
+      try {
+        evidences = await collectCIFailureEvidence(ctx);
+        if (evidences.length > 0) {
+          ctx.ciFailureEvidence = evidences;
+          const evidenceNames = evidences.map((e) => e.checkName).join(', ');
+          ctx.reviewFeedback = `CI checks failed: ${evidenceNames || ciFailureNames.join(', ')}`;
+          logger.info(
+            `[REVIEW] Collected CI failure evidence for ${evidences.length} check(s): ${evidenceNames}`
+          );
+        } else if (ciFailureNames.length > 0) {
+          ctx.reviewFeedback = `CI checks failed: ${ciFailureNames.join(', ')}`;
+          logger.info(
+            `[REVIEW] CI check failures (no structured evidence): ${ciFailureNames.join(', ')}`
+          );
+        }
+      } catch (err) {
+        logger.warn('[REVIEW] Failed to collect CI failure evidence:', err);
+        if (ciFailureNames.length > 0) {
+          ctx.reviewFeedback = `CI checks failed: ${ciFailureNames.join(', ')}`;
+        }
+      }
+
+      // Record remediation history for progress-aware budget extension
+      try {
+        const history = ctx.feature._remediationHistory ?? [];
+        history.push({
+          timestamp: new Date().toISOString(),
+          ciFailureCount: ciFailureNames.length,
+          failingCheckNames: ciFailureNames,
+        });
+        await this.serviceContext.featureLoader.update(ctx.projectPath, ctx.feature.id, {
+          _remediationHistory: history,
+        });
+        ctx.feature._remediationHistory = history;
+      } catch (err) {
+        logger.warn('[REVIEW] Failed to persist remediation history:', err);
+      }
+
+      // Check CI remediation budget
       const persistedCiCount = (ctx.feature.ciRemediationCount as number | undefined) ?? 0;
       const persistedReviewCount =
         (ctx.feature.reviewRemediationCount as number | undefined) ?? ctx.remediationAttempts;
@@ -457,6 +517,19 @@ export class ReviewProcessor implements StateProcessor {
       });
 
       if (!ciBudgetResult.allowed) {
+        // Check if progress was made before escalating
+        const progressCheck = ciEnforcer.checkProgressAndExtend(ctx.feature, evidences);
+        if (progressCheck.extended) {
+          logger.info(`[REVIEW] Budget extended due to progress: ${progressCheck.reason}`);
+          // Allow one more cycle despite budget exhaustion
+          ctx.remediationAttempts++;
+          return {
+            nextState: 'EXECUTE',
+            shouldContinue: true,
+            reason: `Budget extended (progress: ${progressCheck.reason}), remediating`,
+            context: { remediation: true, ciFailures: ciFailureNames },
+          };
+        }
         ctx.escalationReason = ciBudgetResult.message;
         return {
           nextState: 'ESCALATE',
@@ -474,23 +547,6 @@ export class ReviewProcessor implements StateProcessor {
           shouldContinue: true,
           reason: ctx.escalationReason,
         };
-      }
-
-      // Fetch failing CI check names for remediation context
-      let ciFailureNames: string[] = [];
-      try {
-        const { stdout } = await execAsync(
-          `gh pr view ${ctx.prNumber} --json statusCheckRollup --jq '[(.statusCheckRollup // [])[] | select(.conclusion == "FAILURE") | .context] | join(", ")'`,
-          { cwd: ctx.projectPath, timeout: 15000 }
-        );
-        const names = stdout.trim();
-        if (names) {
-          ciFailureNames = names.split(', ').filter(Boolean);
-          ctx.reviewFeedback = `CI checks failed: ${names}`;
-          logger.info(`[REVIEW] CI check failures: ${names}`);
-        }
-      } catch (err) {
-        logger.warn('[REVIEW] Failed to fetch CI check failure names:', err);
       }
 
       ctx.remediationAttempts++;

--- a/apps/server/src/services/lead-engineer-types.ts
+++ b/apps/server/src/services/lead-engineer-types.ts
@@ -4,7 +4,13 @@
  * All types shared across the lead-engineer subsystem files.
  */
 
-import type { ContextMetrics, Feature, AgentRole, StructuredPlan } from '@protolabsai/types';
+import type {
+  ContextMetrics,
+  Feature,
+  AgentRole,
+  StructuredPlan,
+  CIFailureEvidence,
+} from '@protolabsai/types';
 import type { EventEmitter } from '../lib/events.js';
 import type { FeatureLoader } from './feature-loader.js';
 import type { AutoModeService } from './auto-mode-service.js';
@@ -149,6 +155,8 @@ export interface StateContext {
   planRetryCount: number;
   escalationReason?: string;
   reviewFeedback?: string;
+  /** Structured CI failure evidence collected by the evidence collector */
+  ciFailureEvidence?: CIFailureEvidence[];
   /** Learnings from sibling features: structured facts (markdown, grouped by category) from facts.json, or raw reflection.md content as fallback */
   siblingReflections?: string[];
   /** Aggregated facts from completed milestones in this project, formatted as "Project Knowledge" markdown section */

--- a/apps/server/src/services/remediation-budget-enforcer.ts
+++ b/apps/server/src/services/remediation-budget-enforcer.ts
@@ -3,14 +3,17 @@
  *
  * Enforces per-class (CI / review) retry limits and a hard total cap
  * across both classes. Provides backward compatibility with the legacy
- * single remediationCycleCount field.
+ * single remediationCycleCount field. Supports progress-aware budget
+ * extension when the agent reduces the number of failing checks.
  */
 
 import type {
   CIReactionSettings,
   RemediationBudgetCheckResult,
   RemediationBudgetInput,
+  CIFailureEvidence,
 } from '@protolabsai/types';
+import type { Feature } from '@protolabsai/types';
 
 /**
  * Extended result that includes the next counter values after incrementing.
@@ -21,13 +24,35 @@ export interface RemediationBudgetEnforcerResult extends RemediationBudgetCheckR
 }
 
 /**
- * Default settings that match the legacy MAX_TOTAL_REMEDIATION_CYCLES of 4.
+ * Resolve the effective CI reaction settings by merging environment variable
+ * overrides with the base defaults.
  */
-export const DEFAULT_CI_REACTION_SETTINGS: CIReactionSettings = {
+function resolveEffectiveSettings(base: CIReactionSettings): CIReactionSettings {
+  const envOverride = parseInt(process.env.REVIEW_REMEDIATION_MAX_CYCLES ?? '', 10);
+  if (!isNaN(envOverride) && envOverride > 0) {
+    return {
+      ...base,
+      maxReviewRemediationCycles: envOverride,
+      // Adjust total cap to accommodate the increased review cycles
+      maxTotalRemediationCycles: Math.max(
+        base.maxTotalRemediationCycles,
+        base.maxCiRemediationCycles + envOverride
+      ),
+    };
+  }
+  return base;
+}
+
+/**
+ * Default settings with increased review remediation cycles (2 -> 3)
+ * and a higher total cap to accommodate multi-test fixes.
+ * Can be overridden via REVIEW_REMEDIATION_MAX_CYCLES environment variable.
+ */
+export const DEFAULT_CI_REACTION_SETTINGS: CIReactionSettings = resolveEffectiveSettings({
   maxCiRemediationCycles: 2,
-  maxReviewRemediationCycles: 2,
-  maxTotalRemediationCycles: 4,
-};
+  maxReviewRemediationCycles: 3,
+  maxTotalRemediationCycles: 5,
+});
 
 /**
  * Legacy count migration result.
@@ -36,6 +61,16 @@ export interface LegacyCountMigration {
   ciRemediationCount: number;
   reviewRemediationCount: number;
   remediationCycleCount: number;
+}
+
+/**
+ * Result of a progress-aware budget extension check.
+ */
+export interface ProgressCheckResult {
+  /** Whether the budget was extended due to measurable progress */
+  extended: boolean;
+  /** Reason for the extension (or empty string if not extended) */
+  reason: string;
 }
 
 export class RemediationBudgetEnforcer {
@@ -111,6 +146,34 @@ export class RemediationBudgetEnforcer {
       nextCiRemediationCount: ciRemediationCount,
       nextReviewRemediationCount: reviewRemediationCount + 1,
     };
+  }
+
+  /**
+   * Check whether the agent is making measurable progress by comparing
+   * the current number of CI failures with the previous cycle.
+   * If fewer checks are failing, extend the budget by 1 cycle.
+   */
+  checkProgressAndExtend(
+    feature: Feature,
+    currentEvidences: CIFailureEvidence[]
+  ): ProgressCheckResult {
+    const history = feature._remediationHistory;
+    if (!history || history.length === 0) {
+      return { extended: false, reason: '' };
+    }
+
+    const previousEntry = history[history.length - 1];
+    const previousCount = previousEntry.ciFailureCount;
+    const currentCount = currentEvidences.length;
+
+    if (currentCount < previousCount) {
+      return {
+        extended: true,
+        reason: `${previousCount} -> ${currentCount} failing checks`,
+      };
+    }
+
+    return { extended: false, reason: '' };
   }
 
   /**

--- a/libs/types/src/ci-reaction.ts
+++ b/libs/types/src/ci-reaction.ts
@@ -74,3 +74,57 @@ export interface RemediationBudgetInput {
   /** Settings that define the budget limits */
   settings: CIReactionSettings;
 }
+
+// ============================================================================
+// CI Failure Evidence — structured test failure details for agent prompts
+// ============================================================================
+
+/**
+ * Structured evidence extracted from a failed CI check run.
+ * Populated by ci-failure-evidence-collector using GitHub check run annotations
+ * and log output parsing.
+ */
+export interface CIFailureEvidence {
+  /** Check name as reported by GitHub (e.g. "CI / test") */
+  checkName: string;
+  /** URL to the check run on GitHub */
+  checkUrl?: string;
+  /** File where the failure occurred (e.g. "src/services/foo.test.ts") */
+  testFile?: string;
+  /** Human-readable test name or description */
+  testName?: string;
+  /** Assertion that failed (e.g. "expect(escalations).toHaveLength(1)") */
+  assertion?: string;
+  /** Expected value from the assertion */
+  expectedValue?: string;
+  /** Received/actual value from the assertion */
+  receivedValue?: string;
+  /** File:line location of the failure */
+  location?: string;
+  /** Relevant log excerpt (truncated, filtered for failure patterns) */
+  logExcerpt?: string;
+  /** Raw annotation objects from the GitHub check run */
+  annotations?: Array<{
+    path?: string;
+    start_line?: number;
+    end_line?: number;
+    annotation_level?: 'notice' | 'warning' | 'failure';
+    message?: string;
+    title?: string;
+    raw_details?: string;
+  }>;
+}
+
+/**
+ * Per-cycle remediation history entry for progress-aware budget extension.
+ * Tracks the number of CI failures at each cycle so the budget enforcer can
+ * detect when the agent is making measurable progress (fewer failures).
+ */
+export interface RemediationCycleSnapshot {
+  /** ISO 8601 timestamp */
+  timestamp: string;
+  /** Number of failing checks at this cycle */
+  ciFailureCount: number;
+  /** Names of the failing checks */
+  failingCheckNames?: string[];
+}

--- a/libs/types/src/feature.ts
+++ b/libs/types/src/feature.ts
@@ -461,6 +461,16 @@ export interface Feature {
    */
   reviewRemediationCount?: number;
   /**
+   * Per-cycle remediation history for progress-aware budget extension.
+   * Each entry records the number of CI failures at that cycle so the budget
+   * enforcer can detect when the agent is making measurable progress.
+   */
+  _remediationHistory?: Array<{
+    timestamp: string;
+    ciFailureCount: number;
+    failingCheckNames?: string[];
+  }>;
+  /**
    * Head commit SHA at which the review feedback audit last auto-dismissed a
    * bot CHANGES_REQUESTED review. Paired with reviewAuditDismissCount as a loop
    * guard: if a bot re-requests changes on the same head we already cleared,

--- a/libs/types/src/index.ts
+++ b/libs/types/src/index.ts
@@ -107,6 +107,8 @@ export type {
   CIReactionSettings,
   RemediationBudgetCheckResult,
   RemediationBudgetInput,
+  CIFailureEvidence,
+  RemediationCycleSnapshot,
 } from './ci-reaction.js';
 
 // Quarantine types


### PR DESCRIPTION
## Summary

# SPARC PRD: Auto-Mode Review-Remediation — Failing-Test Evidence + Cycle Budget Revisit

## Situation

Auto-mode's PR review-remediation loop operates as follows:

1. A PR is opened by a fixing agent, triggering CI checks and review
2. `ReviewProcessor` (`lead-engineer-review-merge-processors.ts`) polls the PR via `gh pr view` for check results and review feedback
3. On CI failure, the processor collects **only the check names** (e.g., `CI / test, CI / lint`) and sets `ctx.reviewFeedback = 'CI ...

Closes #4124

---
*Created automatically by Automaker*

<!-- automaker:owner instance=ef15d09b-b02a-4f05-bb57-fcc898070dd7 team= created=2026-06-07T03:28:28.805Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured CI failure evidence collection capturing test details, assertions, and file locations from failed checks
  * Implemented progress-aware remediation budget extension that extends when measurable improvement is detected

* **Improvements**
  * Enhanced CI failure context integration in execution and review workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->