### PR TITLE
ci: route Linux runner through NSC_RUNNER variable

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -35,7 +35,7 @@ permissions: read-all
 
 jobs:
   release:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     if: github.repository == 'protoLabsAI/protoMaker'
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   checks:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
 
     steps:

--- a/.github/workflows/close-external-prs.yml
+++ b/.github/workflows/close-external-prs.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   close-external-pr:
     name: Close external code contributions
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     # Only run for PRs from forks (external contributors)
     if: github.event.pull_request.head.repo.fork == true
     permissions:

--- a/.github/workflows/create-protolab-test.yml
+++ b/.github/workflows/create-protolab-test.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   test:
     name: Test with Node ${{ matrix.node }} and ${{ matrix.package-manager }}
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
 
     strategy:
       fail-fast: false
@@ -199,7 +199,7 @@ jobs:
 
   summary:
     name: Test Summary
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     needs: test
     if: always()
     steps:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,7 +27,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     if: github.repository == 'protoLabsAI/protoMaker'
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     if: github.repository == 'protoLabsAI/protoMaker'
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   e2e:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     timeout-minutes: 20
 

--- a/.github/workflows/harness-eval.yml
+++ b/.github/workflows/harness-eval.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   harness-eval:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
 
     steps:

--- a/.github/workflows/idea-accepted.yml
+++ b/.github/workflows/idea-accepted.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   notify-acceptance:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     if: "github.event.label.name == 'status: accepted'"
     steps:
       - name: Post acceptance comment

--- a/.github/workflows/langfuse-prompt-sync.yml
+++ b/.github/workflows/langfuse-prompt-sync.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   validate:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     outputs:
       docs_only: ${{ steps.changes.outputs.docs_only }}
@@ -69,7 +69,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=4096'
 
   ci-complete:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     needs: [build]
     if: always() && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request')
     steps:

--- a/.github/workflows/regenerate-site.yml
+++ b/.github/workflows/regenerate-site.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   regenerate:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   stale:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     steps:
       - name: Mark stale issues and close inactive ones
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
 
     steps:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   triage:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     steps:
       - name: Add needs-triage label
         run: |

--- a/.github/workflows/workflow-security-lint.yml
+++ b/.github/workflows/workflow-security-lint.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   workflow-security-lint:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Route Linux runner through `NSC_RUNNER`

Part of the org-wide migration off Namespace toward self-hosted runners.

Converts hardcoded `runs-on: namespace-profile-protolabs-linux` to the override pattern already standard in the plugin repos:

```yaml
runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
```

**No behavior change today** — with `NSC_RUNNER` unset, every job still runs on Namespace. Once self-hosted runners are live, setting the org-level `NSC_RUNNER` variable moves the entire fleet at once, with no further workflow edits.

Converted **18** workflow line(s) in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
